### PR TITLE
skip testing when [ci skip] in the commit message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,13 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       
+      - uses: mstachniuk/ci-skip@v1
+      
       # Runs a set of commands using the runners shell
       - name: Build and test
+        if: ${{ env.CI_SKIP == 'false' }}
         run: |
+          echo "This step should not be executed when commit message contains [ci skip]"        
           sudo apt-get update 
           sudo apt-get install -y apt-utils \
           build-essential \


### PR DESCRIPTION
Add commit message checking to skip trivial commits (such as README change). Add "[ci skip]" into commit message will skip CI