### PR TITLE
Fix ParticleSpacingByBodyShape::getLocalSpacing()

### DIFF
--- a/SPHINXsys/src/shared/particles/particle_adaptation.cpp
+++ b/SPHINXsys/src/shared/particles/particle_adaptation.cpp
@@ -167,7 +167,7 @@ namespace SPH
 	//=================================================================================================//
 	Real ParticleSpacingByBodyShape::getLocalSpacing(ComplexShape &complex_shape, Vecd &position)
 	{
-		Real phi = abs(complex_shape.findSignedDistance(position));
+		Real phi = fabs(complex_shape.findSignedDistance(position));
 		Real ratio_ref = phi / (2.0 * spacing_ref_ * spacing_ratio_max_);
 		Real target_ratio = spacing_ratio_max_;
 		if (ratio_ref < kernel_->KernelSize())


### PR DESCRIPTION
`complex_shape.findSignedDistance(position)` returns type `Real`, but the `abs` called on it  is `int abs(int)`. Shouldn't it be `fabs`? I usually use `std::abs` to avoid this bug, however `fabs` is used elsewhere.