### PR TITLE
Log hardware information for Linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
       - uses: friendlyanon/setup-vcpkg@v1 # Setup vcpkg into ${{github.workspace}}
         with: 
           committish: ${{ env.VCPKG_VERSION }}
+          cache-version: ${{ github.run_attempt }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: friendlyanon/setup-vcpkg@v1 # Setup vcpkg into ${{github.workspace}}
         with: 
           committish: ${{ env.VCPKG_VERSION }}
-          cache-version: ${{ github.run_attempt }}
+          # cache-version: ${{ github.run_attempt }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
+      - name: Print hardware information # To help analysis for https://github.com/Xiangyu-Hu/SPHinXsys/issues/182
+        run: lscpu
+      
       - name: Install system dependencies
         run: |
           sudo apt update 
@@ -40,7 +43,7 @@ jobs:
             cmake \
             ninja-build \
             python3
-
+      
       - uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.job }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,8 @@ jobs:
       - name: Install dependencies
         run: |
           ${{github.workspace}}/vcpkg/vcpkg install --clean-after-build \
+            openblas[dynamic-arch] `# simbody depends on blas implementation, which -march=native by default, conflicting with cache restore, hence dynamic-arch feature` \
+            # Above problem might also be resolved by adding the hash of architecture in the cache key, esp. if more package do the same
             eigen3 \
             tbb \
             boost-program-options \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          ${{github.workspace}}/vcpkg/vcpkg install --clean-after-build \
-            openblas[dynamic-arch] `# simbody depends on blas implementation, which -march=native by default, conflicting with cache restore, hence dynamic-arch feature` \
-            # Above problem might also be resolved by adding the hash of architecture in the cache key, esp. if more package do the same
+          ${{github.workspace}}/vcpkg/vcpkg install --clean-after-build openblas[dynamic-arch] 
+          # Simbody depends on (open)blas implementation, which -march=native by default, conflicting with cache restore, hence dynamic-arch feature
+          # Above problem might also be resolved by adding the hash of architecture in the cache key, esp. if more package do the same
+          ${{github.workspace}}/vcpkg/vcpkg install --clean-after-build \  
             eigen3 \
             tbb \
             boost-program-options \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           ${{github.workspace}}/vcpkg/vcpkg install --clean-after-build openblas[dynamic-arch] 
           # Simbody depends on (open)blas implementation, which -march=native by default, conflicting with cache restore, hence dynamic-arch feature
           # Above problem might also be resolved by adding the hash of architecture in the cache key, esp. if more package do the same
-          ${{github.workspace}}/vcpkg/vcpkg install --clean-after-build \  
+          ${{github.workspace}}/vcpkg/vcpkg install --clean-after-build \
             eigen3 \
             tbb \
             boost-program-options \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,6 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
-      - name: Print hardware information # To help analysis for https://github.com/Xiangyu-Hu/SPHinXsys/issues/182
-        run: lscpu
-      
       - name: Install system dependencies
         run: |
           sudo apt update 
@@ -43,7 +40,7 @@ jobs:
             cmake \
             ninja-build \
             python3
-      
+
       - uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ github.job }}
@@ -51,7 +48,6 @@ jobs:
       - uses: friendlyanon/setup-vcpkg@v1 # Setup vcpkg into ${{github.workspace}}
         with: 
           committish: ${{ env.VCPKG_VERSION }}
-          # cache-version: ${{ github.run_attempt }}
 
       - name: Install dependencies
         run: |
@@ -74,6 +70,7 @@ jobs:
             -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -S ${{github.workspace}} \
             -B ${{github.workspace}}/build
+            
       - name: Build
         run: cmake --build build --config Release --verbose
 


### PR DESCRIPTION
SIMD flags: -msse4.2 -mfpmath=sse -msse4.1 -msse3 -mavx2 -mavx -mfma

## Illegal instructions

Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz [logs_465.zip](https://github.com/Xiangyu-Hu/SPHinXsys/files/10226856/logs_465.zip)

Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz [logs_468 (1).zip](https://github.com/Xiangyu-Hu/SPHinXsys/files/10228691/logs_468.1.zip)

fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology cpuid pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch invpcid_single pti fsgsbase bmi1 hle avx2 smep bmi2 erms invpcid rtm rdseed adx smap xsaveopt md_clear

## Passing 

Passing on Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz [logs_467.zip](https://github.com/Xiangyu-Hu/SPHinXsys/files/10227663/logs_467.zip) 2 times

fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology cpuid pni pclmulqdq ssse3 fma cx16 pcid sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch invpcid_single pti fsgsbase bmi1 hle avx2 smep bmi2 erms invpcid rtm avx512f avx512dq rdseed adx smap clflushopt avx512cd avx512bw avx512vl xsaveopt xsavec xsaves md_clear


## Observations

* Problem occurs for same examples, on same category of systems (Xeon E5).
* The difference of flags with the working Xeon Platinum are: clflushopt, avx512f, avx512dq, avx512cd, avx512bw, avx512vl, xsavec, xsaves
* The building step of sphinxsys is done whenever compile flags change
* The vcpkg dependencies do not change

## Thoughts

* __Some dependency built via vcpkg with -march=native on avx512 systems then used on a avx2 system could lead to such failure__ &rarr; see below for details.
* Alignment issue: aligned read when not the case due to some combination of container Vec3d
* Faulty operation leading to wrong codegen
* Possible but completely unverifiable
   * Eigen bug
   * A compiler problem with given hardware
   * A hardware problem

## Solution

> Inspection of OpenBLAS installed as blas implementation has a feature to allow "dynamic-arch" which is NOT a default feature. In summary simbody → blas[core] → openblas[core] → fitting to underlying architecture (e.g. AVX512) → caching → restoring cache on older hardware (e.g. AVX2 only) → illegal instruction

OpenBLAS is implicitly installed by simbody as a dependency.

This PR solves #182. Another fix will be needed if more packages do similarly on vcpkg install.