### PR TITLE
Fix FSI Riemann dissipation

### DIFF
--- a/SPHINXsys/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.hpp
+++ b/SPHINXsys/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.hpp
@@ -351,7 +351,7 @@ namespace SPH
 					Vecd vel_in_wall = 2.0 * vel_ave_k[index_j] - this->vel_[index_i];
 					density_change_rate += (this->vel_[index_i] - vel_in_wall).dot(e_ij) * dW_ijV_j;
 					Real u_jump = 2.0 * (this->vel_[index_i] - vel_ave_k[index_j]).dot(n_k[index_j]);
-					p_dissipation += this->riemann_solver_.DissipativePJump(u_jump) * dW_ijV_j * e_ij;
+					p_dissipation += this->riemann_solver_.DissipativePJump(u_jump) * dW_ijV_j * n_k[index_j];
 				}
 			}
 			this->drho_dt_[index_i] += density_change_rate * this->rho_[index_i];

--- a/SPHINXsys/src/shared/particle_dynamics/solid_dynamics/fluid_structure_interaction.h
+++ b/SPHINXsys/src/shared/particle_dynamics/solid_dynamics/fluid_structure_interaction.h
@@ -140,8 +140,8 @@ namespace SPH
 						Real face_wall_external_acceleration = (acc_prior_k[index_j] - acc_ave_[index_i]).dot(e_ij);
 						Real p_in_wall = p_k[index_j] + rho_n_k[index_j] * r_ij * SMAX(0.0, face_wall_external_acceleration);
 						Real u_jump = 2.0 * (vel_k[index_j] - vel_ave_[index_i]).dot(n_[index_i]);
-						force += (riemann_solvers_k.DissipativePJump(u_jump) - (p_in_wall + p_k[index_j])) *
-								 e_ij * Vol_[index_i] * contact_neighborhood.dW_ijV_j_[n];
+						force += (riemann_solvers_k.DissipativePJump(u_jump) * n_[index_i] - (p_in_wall + p_k[index_j]) * e_ij )
+								 * Vol_[index_i] * contact_neighborhood.dW_ijV_j_[n];
 					}
 				}
 				force_from_fluid_[index_i] = force;


### PR DESCRIPTION
Fix bug introduced in https://github.com/Xiangyu-Hu/SPHinXsys/commit/716ed06961f372b93cfd23da140ac8c1025ca171

Graph reporteing results for the elastic gate 2D example with several variation (no dissipation, dissipation along wall normal and along e_ij were tested)

![image](https://user-images.githubusercontent.com/99172565/233025544-47c934c8-b1e4-4ba9-b4b4-106a7f0980b1.png)

Partially fixes #236
