### PR TITLE
Fix shared variable segfault risk and share contact density

### DIFF
--- a/SPHINXsys/src/shared/particle_dynamics/solid_dynamics/contact_dynamics.cpp
+++ b/SPHINXsys/src/shared/particle_dynamics/solid_dynamics/contact_dynamics.cpp
@@ -12,21 +12,22 @@ namespace SPH
 		//=================================================================================================//
 		SelfContactDensitySummation::
 			SelfContactDensitySummation(SelfSurfaceContactRelation &self_contact_relation)
-			: LocalDynamics(self_contact_relation.getSPHBody()), SolidDataInner(self_contact_relation),
+			: ContactDensityAccessor(self_contact_relation.base_particles_,"SelfContactDensity"),
+			  LocalDynamics(self_contact_relation.getSPHBody()),
+			  SolidDataInner(self_contact_relation),
 			  mass_(particles_->mass_)
 		{
-			particles_->registerVariable(self_contact_density_, "SelfContactDensity");
 			Real dp_1 = self_contact_relation.getSPHBody().sph_adaptation_->ReferenceSpacing();
 			offset_W_ij_ = self_contact_relation.getSPHBody().sph_adaptation_->getKernel()->W(dp_1, ZeroVecd);
 		}
 		//=================================================================================================//
 		ContactDensitySummation::
 			ContactDensitySummation(SurfaceContactRelation &solid_body_contact_relation)
-			: LocalDynamics(solid_body_contact_relation.getSPHBody()),
+			: ContactDensityAccessor(solid_body_contact_relation.base_particles_,"ContactDensity"), 
+			  LocalDynamics(solid_body_contact_relation.getSPHBody()),
 			  ContactDynamicsData(solid_body_contact_relation), mass_(particles_->mass_),
 			  offset_W_ij_(StdVec<Real>(contact_configuration_.size(), 0.0))
 		{
-			particles_->registerVariable(contact_density_, "ContactDensity");
 			for (size_t k = 0; k != contact_particles_.size(); ++k)
 			{
 				contact_mass_.push_back(&(contact_particles_[k]->mass_));
@@ -47,13 +48,12 @@ namespace SPH
 		}
 		//=================================================================================================//
 		ShellContactDensity::ShellContactDensity(SurfaceContactRelation &solid_body_contact_relation)
-			: LocalDynamics(solid_body_contact_relation.getSPHBody()),
+			: ContactDensityAccessor(solid_body_contact_relation.base_particles_,"ContactDensity"), 
+			  LocalDynamics(solid_body_contact_relation.getSPHBody()),
 			  ContactDynamicsData(solid_body_contact_relation), solid_(particles_->solid_),
 			  kernel_(solid_body_contact_relation.getSPHBody().sph_adaptation_->getKernel()),
 			  particle_spacing_(solid_body_contact_relation.getSPHBody().sph_adaptation_->ReferenceSpacing())
 		{
-			particles_->registerVariable(contact_density_, "ContactDensity");
-
 			for (size_t k = 0; k != contact_particles_.size(); ++k)
 			{
 				Real dp_k = solid_body_contact_relation.contact_bodies_[k]->sph_adaptation_->ReferenceSpacing();

--- a/SPHINXsys/src/shared/particles/base_particles.hpp
+++ b/SPHINXsys/src/shared/particles/base_particles.hpp
@@ -74,10 +74,10 @@ namespace SPH
         constexpr int type_index = DataTypeIndex<VariableType>::value;
         if (all_variable_maps_[type_index].find(variable_name) == all_variable_maps_[type_index].end())
         {
-            StdVec<StdLargeVec<VariableType>> &container = std::get<type_index>(shared_variable_data_);
-            container.push_back(StdLargeVec<VariableType>());
-            registerVariable(container.back(), variable_name);
-            return &container.back();
+            auto &container = std::get<type_index>(shared_variable_data_);
+            container.emplace_back(new StdLargeVec<VariableType>());
+            registerVariable(*container.back(), variable_name);
+            return container.back();
         }
         else
         {


### PR DESCRIPTION
1. Fix memory segfault risks for shared variable subsystem. See base_particles.*
   * Using `DataContainerAssemble` can lead to memory corruption for components storing a reference or pointer to the given variable. Indeed, `StdVec` invalidates memory location on resize, unless sufficiently reserved upfront. 
   * Current solution is to replace it by `DataContainerAddressAssemble`. Alternative is replacing the outer container by another (e.g. std::deque, external fixed vector options, etc) or reserving a MAX_SIZE constant before first entry is inserted.
2. Attempt to reconciliate diverged history between our internal repo and this one. Make the contact density variable a shared variable for enabling time varying contact network. This is done through a base class `ContactDensityAccessor` enabling access to the shared variable, although reworking ContactDynamicsData might be an option. See contact_dynamics.*

The PR can be split into two if you wish, but point 2 rely on point 1 being merged first and it also provides a direct test of the fix.