### PR TITLE
Xiangyu/shared variable

### DIFF
--- a/SPHINXsys/src/shared/bodies/base_body.cpp
+++ b/SPHINXsys/src/shared/bodies/base_body.cpp
@@ -33,7 +33,7 @@ namespace SPH
 	{
 		for (size_t i = 0; i < body_relations_.size(); i++)
 		{
-			body_relations_[i]->updateConfigurationMemories();
+			body_relations_[i]->resizeConfiguration();
 		}
 	}
 	//=================================================================================================//

--- a/SPHINXsys/src/shared/bodies/complex_bodies/complex_body.h
+++ b/SPHINXsys/src/shared/bodies/complex_bodies/complex_body.h
@@ -64,7 +64,7 @@ namespace SPH
 		class Branch;
 
 	private:
-		UniquePtrKeepers<Branch> branches_ptr_keeper_;
+		UniquePtrsKeeper<Branch> branches_ptr_keeper_;
 
 	public:
 		StdVec<Branch *> branches_;	   /**< Container of all branches */

--- a/SPHINXsys/src/shared/body_relations/base_body_relation.cpp
+++ b/SPHINXsys/src/shared/body_relations/base_body_relation.cpp
@@ -22,10 +22,10 @@ namespace SPH
 		: SPHRelation(real_body), real_body_(&real_body)
 	{
 		subscribeToBody();
-		updateConfigurationMemories();
+		resizeConfiguration();
 	}
 	//=================================================================================================//
-	void BaseInnerRelation::updateConfigurationMemories()
+	void BaseInnerRelation::resizeConfiguration()
 	{
 		size_t updated_size = base_particles_.real_particles_bound_;
 		inner_configuration_.resize(updated_size, Neighborhood());
@@ -51,7 +51,7 @@ namespace SPH
 		subscribeToBody();
 	}
 	//=================================================================================================//
-	void BaseContactRelation::updateConfigurationMemories()
+	void BaseContactRelation::resizeConfiguration()
 	{
 		size_t updated_size = base_particles_.real_particles_bound_;
 		for (size_t k = 0; k != contact_bodies_.size(); ++k)

--- a/SPHINXsys/src/shared/body_relations/base_body_relation.cpp
+++ b/SPHINXsys/src/shared/body_relations/base_body_relation.cpp
@@ -49,16 +49,14 @@ namespace SPH
 		: SPHRelation(sph_body), contact_bodies_(contact_sph_bodies)
 	{
 		subscribeToBody();
-		updateConfigurationMemories();
 	}
 	//=================================================================================================//
 	void BaseContactRelation::updateConfigurationMemories()
 	{
 		size_t updated_size = base_particles_.real_particles_bound_;
-		contact_configuration_.resize(contact_bodies_.size());
 		for (size_t k = 0; k != contact_bodies_.size(); ++k)
 		{
-			contact_configuration_[k].resize(updated_size, Neighborhood());
+			contact_configuration_[k]->resize(updated_size, Neighborhood());
 		}
 	}
 	//=================================================================================================//
@@ -72,7 +70,7 @@ namespace SPH
 				{
 					for (size_t num = r.begin(); num != r.end(); ++num)
 					{
-						contact_configuration_[k][num].current_size_ = 0;
+						(*contact_configuration_[k])[num].current_size_ = 0;
 					}
 				},
 				ap);

--- a/SPHINXsys/src/shared/body_relations/base_body_relation.cpp
+++ b/SPHINXsys/src/shared/body_relations/base_body_relation.cpp
@@ -49,6 +49,7 @@ namespace SPH
 		: SPHRelation(sph_body), contact_bodies_(contact_sph_bodies)
 	{
 		subscribeToBody();
+		contact_configuration_.resize(contact_bodies_.size());
 	}
 	//=================================================================================================//
 	void BaseContactRelation::resizeConfiguration()
@@ -56,7 +57,7 @@ namespace SPH
 		size_t updated_size = base_particles_.real_particles_bound_;
 		for (size_t k = 0; k != contact_bodies_.size(); ++k)
 		{
-			contact_configuration_[k]->resize(updated_size, Neighborhood());
+			contact_configuration_[k].resize(updated_size, Neighborhood());
 		}
 	}
 	//=================================================================================================//
@@ -70,7 +71,7 @@ namespace SPH
 				{
 					for (size_t num = r.begin(); num != r.end(); ++num)
 					{
-						(*contact_configuration_[k])[num].current_size_ = 0;
+						contact_configuration_[k][num].current_size_ = 0;
 					}
 				},
 				ap);

--- a/SPHINXsys/src/shared/body_relations/base_body_relation.h
+++ b/SPHINXsys/src/shared/body_relations/base_body_relation.h
@@ -114,7 +114,7 @@ namespace SPH
 		virtual ~SPHRelation(){};
 
 		void subscribeToBody() { sph_body_.body_relations_.push_back(this); };
-		virtual void updateConfigurationMemories() = 0;
+		virtual void resizeConfiguration() = 0;
 		virtual void updateConfiguration() = 0;
 	};
 
@@ -133,7 +133,7 @@ namespace SPH
 		explicit BaseInnerRelation(RealBody &real_body);
 		virtual ~BaseInnerRelation(){};
 
-		virtual void updateConfigurationMemories() override;
+		virtual void resizeConfiguration() override;
 	};
 
 	/**
@@ -155,7 +155,7 @@ namespace SPH
 			: BaseContactRelation(sph_body, BodyPartsToRealBodies(contact_body_parts)){};
 		virtual ~BaseContactRelation(){};
 
-		virtual void updateConfigurationMemories() override;
+		virtual void resizeConfiguration() override;
 	};
 }
 #endif // BASE_BODY_RELATION_H

--- a/SPHINXsys/src/shared/body_relations/base_body_relation.h
+++ b/SPHINXsys/src/shared/body_relations/base_body_relation.h
@@ -143,12 +143,11 @@ namespace SPH
 	class BaseContactRelation : public SPHRelation
 	{
 	protected:
-		UniquePtrsKeeper<ParticleConfiguration> configuration_ptrs_keeper_;
 		virtual void resetNeighborhoodCurrentSize();
 
 	public:
 		RealBodyVector contact_bodies_;
-		ContactParticleConfiguration contact_configuration_; /**< Configurations for particle interaction between bodies. */
+		StdVec<ParticleConfiguration> contact_configuration_; /**< Configurations for particle interaction between bodies. */
 
 		BaseContactRelation(SPHBody &sph_body, RealBodyVector contact_bodies);
 		BaseContactRelation(SPHBody &sph_body, BodyPartVector contact_body_parts)

--- a/SPHINXsys/src/shared/body_relations/base_body_relation.h
+++ b/SPHINXsys/src/shared/body_relations/base_body_relation.h
@@ -143,11 +143,12 @@ namespace SPH
 	class BaseContactRelation : public SPHRelation
 	{
 	protected:
+		UniquePtrKeepers<ParticleConfiguration> configuration_ptrs_keeper_;
 		virtual void resetNeighborhoodCurrentSize();
 
 	public:
 		RealBodyVector contact_bodies_;
-		ContactParticleConfiguration contact_configuration_; /**< Configurations for particle interaction between bodies. */
+		StdVec<ParticleConfiguration *> contact_configuration_; /**< Configurations for particle interaction between bodies. */
 
 		BaseContactRelation(SPHBody &sph_body, RealBodyVector contact_bodies);
 		BaseContactRelation(SPHBody &sph_body, BodyPartVector contact_body_parts)

--- a/SPHINXsys/src/shared/body_relations/base_body_relation.h
+++ b/SPHINXsys/src/shared/body_relations/base_body_relation.h
@@ -143,7 +143,7 @@ namespace SPH
 	class BaseContactRelation : public SPHRelation
 	{
 	protected:
-		UniquePtrKeepers<ParticleConfiguration> configuration_ptrs_keeper_;
+		UniquePtrsKeeper<ParticleConfiguration> configuration_ptrs_keeper_;
 		virtual void resetNeighborhoodCurrentSize();
 
 	public:

--- a/SPHINXsys/src/shared/body_relations/base_body_relation.h
+++ b/SPHINXsys/src/shared/body_relations/base_body_relation.h
@@ -148,7 +148,7 @@ namespace SPH
 
 	public:
 		RealBodyVector contact_bodies_;
-		StdVec<ParticleConfiguration *> contact_configuration_; /**< Configurations for particle interaction between bodies. */
+		ContactParticleConfiguration contact_configuration_; /**< Configurations for particle interaction between bodies. */
 
 		BaseContactRelation(SPHBody &sph_body, RealBodyVector contact_bodies);
 		BaseContactRelation(SPHBody &sph_body, BodyPartVector contact_body_parts)

--- a/SPHINXsys/src/shared/body_relations/complex_body_relation.cpp
+++ b/SPHINXsys/src/shared/body_relations/complex_body_relation.cpp
@@ -15,7 +15,7 @@ namespace SPH
 		  inner_configuration_(inner_relation_.inner_configuration_),
 		  contact_configuration_(contact_relation_.contact_configuration_)
 	{
-		updateConfigurationMemories();
+		resizeConfiguration();
 	}
 	//=================================================================================================//
 	ComplexRelation::ComplexRelation(RealBody &real_body, RealBodyVector contact_bodies)
@@ -27,7 +27,7 @@ namespace SPH
 		  inner_configuration_(inner_relation_.inner_configuration_),
 		  contact_configuration_(contact_relation_.contact_configuration_)
 	{
-		updateConfigurationMemories();
+		resizeConfiguration();
 	}
 	//=================================================================================================//
 	ComplexRelation::
@@ -40,7 +40,7 @@ namespace SPH
 		  inner_configuration_(inner_relation_.inner_configuration_),
 		  contact_configuration_(contact_relation_.contact_configuration_)
 	{
-		updateConfigurationMemories();
+		resizeConfiguration();
 	}
 	//=================================================================================================//
 	ComplexRelation::ComplexRelation(RealBody &real_body, BodyPartVector contact_body_parts)
@@ -52,13 +52,13 @@ namespace SPH
 		  inner_configuration_(inner_relation_.inner_configuration_),
 		  contact_configuration_(contact_relation_.contact_configuration_)
 	{
-		updateConfigurationMemories();
+		resizeConfiguration();
 	}
 	//=================================================================================================//
-	void ComplexRelation::updateConfigurationMemories()
+	void ComplexRelation::resizeConfiguration()
 	{
-		inner_relation_.updateConfigurationMemories();
-		contact_relation_.updateConfigurationMemories();
+		inner_relation_.resizeConfiguration();
+		contact_relation_.resizeConfiguration();
 	}
 	//=================================================================================================//
 	void ComplexRelation::updateConfiguration()

--- a/SPHINXsys/src/shared/body_relations/complex_body_relation.h
+++ b/SPHINXsys/src/shared/body_relations/complex_body_relation.h
@@ -62,7 +62,7 @@ namespace SPH
 		ComplexRelation(RealBody &real_body, BodyPartVector contact_body_parts);
 		virtual ~ComplexRelation(){};
 
-		virtual void updateConfigurationMemories() override;
+		virtual void resizeConfiguration() override;
 		virtual void updateConfiguration() override;
 	};
 }

--- a/SPHINXsys/src/shared/body_relations/complex_body_relation.h
+++ b/SPHINXsys/src/shared/body_relations/complex_body_relation.h
@@ -54,7 +54,7 @@ namespace SPH
 		BaseContactRelation &getContactRelation() { return contact_relation_; };
 		RealBodyVector contact_bodies_;
 		ParticleConfiguration &inner_configuration_;
-		ContactParticleConfiguration contact_configuration_;
+		StdVec<ParticleConfiguration> &contact_configuration_;
 
 		ComplexRelation(BaseInnerRelation &inner_relation, BaseContactRelation &contact_relation);
 		ComplexRelation(RealBody &real_body, RealBodyVector contact_bodies);

--- a/SPHINXsys/src/shared/body_relations/complex_body_relation.h
+++ b/SPHINXsys/src/shared/body_relations/complex_body_relation.h
@@ -54,7 +54,7 @@ namespace SPH
 		BaseContactRelation &getContactRelation() { return contact_relation_; };
 		RealBodyVector contact_bodies_;
 		ParticleConfiguration &inner_configuration_;
-		ContactParticleConfiguration &contact_configuration_;
+		StdVec<ParticleConfiguration *> contact_configuration_;
 
 		ComplexRelation(BaseInnerRelation &inner_relation, BaseContactRelation &contact_relation);
 		ComplexRelation(RealBody &real_body, RealBodyVector contact_bodies);

--- a/SPHINXsys/src/shared/body_relations/complex_body_relation.h
+++ b/SPHINXsys/src/shared/body_relations/complex_body_relation.h
@@ -54,7 +54,7 @@ namespace SPH
 		BaseContactRelation &getContactRelation() { return contact_relation_; };
 		RealBodyVector contact_bodies_;
 		ParticleConfiguration &inner_configuration_;
-		StdVec<ParticleConfiguration *> contact_configuration_;
+		ContactParticleConfiguration contact_configuration_;
 
 		ComplexRelation(BaseInnerRelation &inner_relation, BaseContactRelation &contact_relation);
 		ComplexRelation(RealBody &real_body, RealBodyVector contact_bodies);

--- a/SPHINXsys/src/shared/body_relations/contact_body_relation.cpp
+++ b/SPHINXsys/src/shared/body_relations/contact_body_relation.cpp
@@ -22,7 +22,7 @@ namespace SPH
 		for (size_t k = 0; k != contact_bodies_.size(); ++k)
 		{
 			target_cell_linked_lists_[k]->searchNeighborsByParticles(
-				sph_body_, *contact_configuration_[k],
+				sph_body_, contact_configuration_[k],
 				*get_search_depths_[k], *get_contact_neighbors_[k]);
 		}
 	}
@@ -47,7 +47,7 @@ namespace SPH
 			particle_for(execution::ParallelPolicy(), body_part_particles_,
 						 [&](size_t index_i)
 						 {
-							 (*contact_configuration_[k])[index_i].current_size_ = 0;
+							 contact_configuration_[k][index_i].current_size_ = 0;
 						 });
 		}
 	}
@@ -58,7 +58,7 @@ namespace SPH
 		for (size_t k = 0; k != contact_bodies_.size(); ++k)
 		{
 			target_cell_linked_lists_[k]->searchNeighborsByParticles(
-				*body_surface_layer_, *contact_configuration_[k],
+				*body_surface_layer_, contact_configuration_[k],
 				*get_search_depths_[k], *get_contact_neighbors_[k]);
 		}
 	}
@@ -81,7 +81,7 @@ namespace SPH
 		for (size_t k = 0; k != contact_bodies_.size(); ++k)
 		{
 			target_cell_linked_lists_[k]->searchNeighborsByParticles(
-				sph_body_, *contact_configuration_[k],
+				sph_body_, contact_configuration_[k],
 				*get_search_depths_[k], *get_part_contact_neighbors_[k]);
 		}
 	}
@@ -95,9 +95,6 @@ namespace SPH
 
 		for (size_t k = 0; k != contact_bodies_.size(); ++k)
 		{
-			contact_configuration_.push_back(
-				configuration_ptrs_keeper_.createPtr<ParticleConfiguration>());
-
 			cell_linked_list_levels_[k] = contact_bodies_[k]->getCellLinkedList().CellLinkedListLevels();
 
 			for (size_t l = 0; l != cell_linked_list_levels_[k].size(); ++l)
@@ -124,7 +121,7 @@ namespace SPH
 			for (size_t l = 0; l != cell_linked_list_levels_[k].size(); ++l)
 			{
 				cell_linked_list_levels_[k][l]->searchNeighborsByParticles(
-					sph_body_, *contact_configuration_[k],
+					sph_body_, contact_configuration_[k],
 					*get_multi_level_search_range_[k][l], *get_contact_neighbors_adaptive_[k][l]);
 			}
 		}

--- a/SPHINXsys/src/shared/body_relations/contact_body_relation.cpp
+++ b/SPHINXsys/src/shared/body_relations/contact_body_relation.cpp
@@ -22,7 +22,7 @@ namespace SPH
 		for (size_t k = 0; k != contact_bodies_.size(); ++k)
 		{
 			target_cell_linked_lists_[k]->searchNeighborsByParticles(
-				sph_body_, contact_configuration_[k],
+				sph_body_, *contact_configuration_[k],
 				*get_search_depths_[k], *get_contact_neighbors_[k]);
 		}
 	}
@@ -47,7 +47,7 @@ namespace SPH
 			particle_for(execution::ParallelPolicy(), body_part_particles_,
 						 [&](size_t index_i)
 						 {
-							 contact_configuration_[k][index_i].current_size_ = 0;
+							 (*contact_configuration_[k])[index_i].current_size_ = 0;
 						 });
 		}
 	}
@@ -58,7 +58,7 @@ namespace SPH
 		for (size_t k = 0; k != contact_bodies_.size(); ++k)
 		{
 			target_cell_linked_lists_[k]->searchNeighborsByParticles(
-				*body_surface_layer_, contact_configuration_[k],
+				*body_surface_layer_, *contact_configuration_[k],
 				*get_search_depths_[k], *get_contact_neighbors_[k]);
 		}
 	}
@@ -81,7 +81,7 @@ namespace SPH
 		for (size_t k = 0; k != contact_bodies_.size(); ++k)
 		{
 			target_cell_linked_lists_[k]->searchNeighborsByParticles(
-				sph_body_, contact_configuration_[k],
+				sph_body_, *contact_configuration_[k],
 				*get_search_depths_[k], *get_part_contact_neighbors_[k]);
 		}
 	}
@@ -95,6 +95,9 @@ namespace SPH
 
 		for (size_t k = 0; k != contact_bodies_.size(); ++k)
 		{
+			contact_configuration_.push_back(
+				configuration_ptrs_keeper_.createPtr<ParticleConfiguration>());
+
 			cell_linked_list_levels_[k] = contact_bodies_[k]->getCellLinkedList().CellLinkedListLevels();
 
 			for (size_t l = 0; l != cell_linked_list_levels_[k].size(); ++l)
@@ -110,6 +113,7 @@ namespace SPH
 							sph_body, *contact_sph_bodies[k]));
 			}
 		}
+		updateConfigurationMemories();
 	}
 	//=================================================================================================//
 	void AdaptiveContactRelation::updateConfiguration()
@@ -120,7 +124,7 @@ namespace SPH
 			for (size_t l = 0; l != cell_linked_list_levels_[k].size(); ++l)
 			{
 				cell_linked_list_levels_[k][l]->searchNeighborsByParticles(
-					sph_body_, contact_configuration_[k],
+					sph_body_, *contact_configuration_[k],
 					*get_multi_level_search_range_[k][l], *get_contact_neighbors_adaptive_[k][l]);
 			}
 		}

--- a/SPHINXsys/src/shared/body_relations/contact_body_relation.cpp
+++ b/SPHINXsys/src/shared/body_relations/contact_body_relation.cpp
@@ -113,7 +113,7 @@ namespace SPH
 							sph_body, *contact_sph_bodies[k]));
 			}
 		}
-		updateConfigurationMemories();
+		resizeConfiguration();
 	}
 	//=================================================================================================//
 	void AdaptiveContactRelation::updateConfiguration()

--- a/SPHINXsys/src/shared/body_relations/contact_body_relation.h
+++ b/SPHINXsys/src/shared/body_relations/contact_body_relation.h
@@ -52,8 +52,6 @@ namespace SPH
 		{
 			for (size_t k = 0; k != contact_bodies_.size(); ++k)
 			{
-				contact_configuration_.push_back(
-					configuration_ptrs_keeper_.createPtr<ParticleConfiguration>());
 				CellLinkedList *target_cell_linked_list =
 					DynamicCast<CellLinkedList>(this, &contact_bodies_[k]->getCellLinkedList());
 				target_cell_linked_lists_.push_back(target_cell_linked_list);

--- a/SPHINXsys/src/shared/body_relations/contact_body_relation.h
+++ b/SPHINXsys/src/shared/body_relations/contact_body_relation.h
@@ -61,7 +61,7 @@ namespace SPH
 					search_depth_ptrs_keeper_.createPtr<SearchDepthContact>(
 						sph_body_, target_cell_linked_list));
 			}
-			updateConfigurationMemories();
+			resizeConfiguration();
 		};
 		virtual ~ContactRelationCrossResolution(){};
 

--- a/SPHINXsys/src/shared/body_relations/contact_body_relation.h
+++ b/SPHINXsys/src/shared/body_relations/contact_body_relation.h
@@ -52,6 +52,8 @@ namespace SPH
 		{
 			for (size_t k = 0; k != contact_bodies_.size(); ++k)
 			{
+				contact_configuration_.push_back(
+					configuration_ptrs_keeper_.createPtr<ParticleConfiguration>());
 				CellLinkedList *target_cell_linked_list =
 					DynamicCast<CellLinkedList>(this, &contact_bodies_[k]->getCellLinkedList());
 				target_cell_linked_lists_.push_back(target_cell_linked_list);
@@ -59,6 +61,7 @@ namespace SPH
 					search_depth_ptrs_keeper_.createPtr<SearchDepthContact>(
 						sph_body_, target_cell_linked_list));
 			}
+			updateConfigurationMemories();
 		};
 		virtual ~ContactRelationCrossResolution(){};
 

--- a/SPHINXsys/src/shared/body_relations/contact_body_relation.h
+++ b/SPHINXsys/src/shared/body_relations/contact_body_relation.h
@@ -43,7 +43,7 @@ namespace SPH
 	class ContactRelationCrossResolution : public BaseContactRelation
 	{
 	protected:
-		UniquePtrKeepers<SearchDepthContact> search_depth_ptrs_keeper_;
+		UniquePtrsKeeper<SearchDepthContact> search_depth_ptrs_keeper_;
 
 	public:
 		template <typename... Args>
@@ -77,7 +77,7 @@ namespace SPH
 	class ContactRelation : public ContactRelationCrossResolution
 	{
 	protected:
-		UniquePtrKeepers<NeighborBuilderContact> neighbor_builder_contact_ptrs_keeper_;
+		UniquePtrsKeeper<NeighborBuilderContact> neighbor_builder_contact_ptrs_keeper_;
 
 	public:
 		ContactRelation(SPHBody &sph_body, RealBodyVector contact_bodies);
@@ -95,7 +95,7 @@ namespace SPH
 	class SurfaceContactRelation : public ContactRelationCrossResolution
 	{
 	protected:
-		UniquePtrKeepers<NeighborBuilderSurfaceContact> neighbor_builder_contact_ptrs_keeper_;
+		UniquePtrsKeeper<NeighborBuilderSurfaceContact> neighbor_builder_contact_ptrs_keeper_;
 		UniquePtrKeeper<BodySurfaceLayer> shape_surface_ptr_keeper_;
 
 	public:
@@ -122,7 +122,7 @@ namespace SPH
 	class ContactRelationToBodyPart : public ContactRelationCrossResolution
 	{
 	protected:
-		UniquePtrKeepers<NeighborBuilderContactBodyPart> neighbor_builder_contact_ptrs_keeper_;
+		UniquePtrsKeeper<NeighborBuilderContactBodyPart> neighbor_builder_contact_ptrs_keeper_;
 
 	public:
 		StdVec<NeighborBuilderContactBodyPart *> get_part_contact_neighbors_;
@@ -140,8 +140,8 @@ namespace SPH
 	class AdaptiveContactRelation : public BaseContactRelation
 	{
 	private:
-		UniquePtrKeepers<SearchDepthAdaptiveContact> adaptive_search_depth_ptr_vector_keeper_;
-		UniquePtrKeepers<NeighborBuilderContactAdaptive> neighbor_builder_contact_adaptive_ptr_vector_keeper_;
+		UniquePtrsKeeper<SearchDepthAdaptiveContact> adaptive_search_depth_ptr_vector_keeper_;
+		UniquePtrsKeeper<NeighborBuilderContactAdaptive> neighbor_builder_contact_adaptive_ptr_vector_keeper_;
 
 	protected:
 		StdVec<StdVec<SearchDepthAdaptiveContact *>> get_multi_level_search_range_;

--- a/SPHINXsys/src/shared/body_relations/inner_body_relation.h
+++ b/SPHINXsys/src/shared/body_relations/inner_body_relation.h
@@ -58,7 +58,7 @@ namespace SPH
 	class AdaptiveInnerRelation : public BaseInnerRelation
 	{
 	private:
-		UniquePtrKeepers<SearchDepthAdaptive> adaptive_search_depth_ptr_vector_keeper_;
+		UniquePtrsKeeper<SearchDepthAdaptive> adaptive_search_depth_ptr_vector_keeper_;
 
 	protected:
 		size_t total_levels_;

--- a/SPHINXsys/src/shared/common/base_data_package.h
+++ b/SPHINXsys/src/shared/common/base_data_package.h
@@ -57,6 +57,16 @@ namespace SPH
                    StdVec<DataContainerType<Mat2d> *>,
                    StdVec<DataContainerType<Mat3d> *>,
                    StdVec<DataContainerType<int> *>>;
+   /** Generalized data container unique pointer assemble type */
+    template <template <typename DataType> typename DataContainerType>
+    using DataContainerUniquePtrAssemble =
+        std::tuple<UniquePtrsKeeper<DataContainerType<Real>>,
+                   UniquePtrsKeeper<DataContainerType<Vec2d>>,
+                   UniquePtrsKeeper<DataContainerType<Vec3d>>,
+                   UniquePtrsKeeper<DataContainerType<Mat2d>>,
+                   UniquePtrsKeeper<DataContainerType<Mat3d>>,
+                   UniquePtrsKeeper<DataContainerType<int>>>;
+
     /** a type irrelevant operation on the data assembles  */
     template <template <typename VariableType> typename OperationType>
     struct DataAssembleOperation

--- a/SPHINXsys/src/shared/common/ownership.h
+++ b/SPHINXsys/src/shared/common/ownership.h
@@ -118,13 +118,13 @@ namespace SPH
 	};
 
 	/**
-	 * @class UniquePtrKeepers
+	 * @class UniquePtrsKeeper
 	 * @brief A wrapper to provide an ownership for
 	 * a vector of base class pointers which point to derived objects.
 	 * It should be a private member.
 	 */
 	template <class BaseType>
-	class UniquePtrKeepers
+	class UniquePtrsKeeper
 	{
 	public:
 		/** used to create a new derived object in the vector
@@ -144,7 +144,7 @@ namespace SPH
 			{
 				return ptr_keepers_[index];
 			}
-			std::cout << "\n Error in UniquePtrKeepers : UniquePtr index is out of bound! \n";
+			std::cout << "\n Error in UniquePtrsKeeper : UniquePtr index is out of bound! \n";
 			exit(1);
 		}
 

--- a/SPHINXsys/src/shared/geometries/base_geometry.h
+++ b/SPHINXsys/src/shared/geometries/base_geometry.h
@@ -128,7 +128,7 @@ namespace SPH
 		size_t getShapeIndexByName(const std::string &shape_name);
 
 	protected:
-		UniquePtrKeepers<Shape> shapes_ptr_keeper_;
+		UniquePtrsKeeper<Shape> shapes_ptr_keeper_;
 		StdVec<ShapeAndOp> shapes_and_ops_;
 
 		virtual BoundingBox findBounds() override;

--- a/SPHINXsys/src/shared/io_system/io_vtk.h
+++ b/SPHINXsys/src/shared/io_system/io_vtk.h
@@ -88,7 +88,7 @@ namespace SPH
 		: public BodyStatesRecordingToVtp
 	{
 	private:
-	UniquePtrKeepers<ReduceDynamics<VelocityBoundCheck>> check_bodies_ptr_keeper_;	
+	UniquePtrsKeeper<ReduceDynamics<VelocityBoundCheck>> check_bodies_ptr_keeper_;	
 
 	protected:
 		bool out_of_bound_;

--- a/SPHINXsys/src/shared/materials/diffusion_reaction.h
+++ b/SPHINXsys/src/shared/materials/diffusion_reaction.h
@@ -215,7 +215,7 @@ namespace SPH
 	public:
 		static constexpr int NumReactiveSpecies = NUM_REACTIVE_SPECIES;
 	private:
-		UniquePtrKeepers<BaseDiffusion> diffusion_ptr_keeper_;
+		UniquePtrsKeeper<BaseDiffusion> diffusion_ptr_keeper_;
 		SharedPtrKeeper<BaseReactionModel<NUM_REACTIVE_SPECIES>> reaction_ptr_keeper_;
 
 	protected:

--- a/SPHINXsys/src/shared/meshes/base_mesh.h
+++ b/SPHINXsys/src/shared/meshes/base_mesh.h
@@ -193,7 +193,7 @@ namespace SPH
 		virtual ~MultilevelMesh(){};
 
 	private:
-		UniquePtrKeepers<CoarsestMeshType> mesh_level_ptr_vector_keeper_;
+		UniquePtrsKeeper<CoarsestMeshType> mesh_level_ptr_vector_keeper_;
 
 	protected:
 		size_t total_levels_;					 /**< level 0 is the coarsest */

--- a/SPHINXsys/src/shared/particle_dynamics/base_particle_dynamics.h
+++ b/SPHINXsys/src/shared/particle_dynamics/base_particle_dynamics.h
@@ -156,7 +156,7 @@ namespace SPH
 		SPHBodyVector contact_bodies_;
 		StdVec<ContactParticlesType *> contact_particles_;
 		/** Configurations for particle interaction between bodies. */
-		ContactParticleConfiguration contact_configuration_;
+		StdVec<ParticleConfiguration *> contact_configuration_;
 	};
 
 	/**

--- a/SPHINXsys/src/shared/particle_dynamics/base_particle_dynamics.h
+++ b/SPHINXsys/src/shared/particle_dynamics/base_particle_dynamics.h
@@ -156,7 +156,7 @@ namespace SPH
 		SPHBodyVector contact_bodies_;
 		StdVec<ContactParticlesType *> contact_particles_;
 		/** Configurations for particle interaction between bodies. */
-		StdVec<ParticleConfiguration *> contact_configuration_;
+		ContactParticleConfiguration contact_configuration_;
 	};
 
 	/**

--- a/SPHINXsys/src/shared/particle_dynamics/base_particle_dynamics.hpp
+++ b/SPHINXsys/src/shared/particle_dynamics/base_particle_dynamics.hpp
@@ -47,7 +47,7 @@ namespace SPH
 		{
 			contact_bodies_.push_back(contact_sph_bodies[i]);
 			contact_particles_.push_back(DynamicCast<ContactParticlesType>(this, &contact_sph_bodies[i]->getBaseParticles()));
-			contact_configuration_.push_back(body_contact_relation.contact_configuration_[i]);
+			contact_configuration_.push_back(&body_contact_relation.contact_configuration_[i]);
 		}
 	}
 	//=================================================================================================//
@@ -72,7 +72,7 @@ namespace SPH
 
 		for (size_t i = 0; i != extra_contact_relation.contact_bodies_.size(); ++i)
 		{
-			contact_configuration_.push_back(extra_contact_relation.contact_configuration_[i]);
+			contact_configuration_.push_back(&extra_contact_relation.contact_configuration_[i]);
 		}
 	}
 	//=================================================================================================//

--- a/SPHINXsys/src/shared/particle_dynamics/base_particle_dynamics.hpp
+++ b/SPHINXsys/src/shared/particle_dynamics/base_particle_dynamics.hpp
@@ -47,7 +47,7 @@ namespace SPH
 		{
 			contact_bodies_.push_back(contact_sph_bodies[i]);
 			contact_particles_.push_back(DynamicCast<ContactParticlesType>(this, &contact_sph_bodies[i]->getBaseParticles()));
-			contact_configuration_.push_back(&body_contact_relation.contact_configuration_[i]);
+			contact_configuration_.push_back(body_contact_relation.contact_configuration_[i]);
 		}
 	}
 	//=================================================================================================//
@@ -72,7 +72,7 @@ namespace SPH
 
 		for (size_t i = 0; i != extra_contact_relation.contact_bodies_.size(); ++i)
 		{
-			contact_configuration_.push_back(&extra_contact_relation.contact_configuration_[i]);
+			contact_configuration_.push_back(extra_contact_relation.contact_configuration_[i]);
 		}
 	}
 	//=================================================================================================//

--- a/SPHINXsys/src/shared/particle_neighborhood/neighborhood.h
+++ b/SPHINXsys/src/shared/particle_neighborhood/neighborhood.h
@@ -63,11 +63,7 @@ namespace SPH
 
 		void removeANeighbor(size_t neighbor_n);
 	};
-
-	/** Neighborhoods for all particles in a body for a inner body relation. */
 	using ParticleConfiguration = StdLargeVec<Neighborhood>;
-	/** Neighborhoods for all particles in a body for a contact body relation. */
-	using ContactParticleConfiguration = StdVec<ParticleConfiguration>;
 
 	/**
 	 * @class NeighborBuilder

--- a/SPHINXsys/src/shared/particle_neighborhood/neighborhood.h
+++ b/SPHINXsys/src/shared/particle_neighborhood/neighborhood.h
@@ -64,6 +64,7 @@ namespace SPH
 		void removeANeighbor(size_t neighbor_n);
 	};
 	using ParticleConfiguration = StdLargeVec<Neighborhood>;
+	using ContactParticleConfiguration = StdVec<ParticleConfiguration *>;
 
 	/**
 	 * @class NeighborBuilder

--- a/SPHINXsys/src/shared/particle_neighborhood/neighborhood.h
+++ b/SPHINXsys/src/shared/particle_neighborhood/neighborhood.h
@@ -64,7 +64,6 @@ namespace SPH
 		void removeANeighbor(size_t neighbor_n);
 	};
 	using ParticleConfiguration = StdLargeVec<Neighborhood>;
-	using ContactParticleConfiguration = StdVec<ParticleConfiguration *>;
 
 	/**
 	 * @class NeighborBuilder

--- a/SPHINXsys/src/shared/particles/base_particles.h
+++ b/SPHINXsys/src/shared/particles/base_particles.h
@@ -82,7 +82,7 @@ namespace SPH
 	class BaseParticles
 	{
 	private:
-		UniquePtrKeepers<BaseDynamics<void>> derived_particle_data_; /**< Unique ptr for Base dynamics. */
+		UniquePtrsKeeper<BaseDynamics<void>> derived_particle_data_; /**< Unique ptr for Base dynamics. */
 		
 		template <typename VariableType>
 		struct AllVariablesDelete
@@ -96,11 +96,7 @@ namespace SPH
 		};
 	public:
 		explicit BaseParticles(SPHBody &sph_body, BaseMaterial *base_material);
-		virtual ~BaseParticles()
-		{
-			DataAssembleOperation<AllVariablesDelete> delete_all_shared;
-			delete_all_shared(shared_variable_data_);
-		};
+		virtual ~BaseParticles() {};
 
 		StdLargeVec<Vecd> pos_;		  /**< particle position */
 		StdLargeVec<Vecd> vel_;		  /**< particle velocity */
@@ -121,7 +117,7 @@ namespace SPH
 		//		Generalized particle data for parameterized management
 		//----------------------------------------------------------------------
 		ParticleData all_particle_data_;
-		DataContainerAddressAssemble<StdLargeVec> shared_variable_data_; // extra data for shared variables
+		DataContainerUniquePtrAssemble<StdLargeVec> shared_variable_data_; // extra data for shared variables
 		ParticleDataMap all_variable_maps_;
 		StdVec<BaseDynamics<void> *> derived_variables_;
 		ParticleVariableList variables_to_write_;

--- a/SPHINXsys/src/shared/particles/base_particles.h
+++ b/SPHINXsys/src/shared/particles/base_particles.h
@@ -84,16 +84,6 @@ namespace SPH
 	private:
 		UniquePtrsKeeper<BaseDynamics<void>> derived_particle_data_; /**< Unique ptr for Base dynamics. */
 		
-		template <typename VariableType>
-		struct AllVariablesDelete
-		{
-			void operator()(ParticleData &particle_data) const
-			{
-				constexpr int type_index = DataTypeIndex<VariableType>::value;
-				for (size_t i = 0; i != std::get<type_index>(particle_data).size(); ++i)
-					delete std::get<type_index>(particle_data)[i];
-			}
-		};
 	public:
 		explicit BaseParticles(SPHBody &sph_body, BaseMaterial *base_material);
 		virtual ~BaseParticles() {};

--- a/SPHINXsys/src/shared/particles/base_particles.hpp
+++ b/SPHINXsys/src/shared/particles/base_particles.hpp
@@ -74,10 +74,10 @@ namespace SPH
         constexpr int type_index = DataTypeIndex<VariableType>::value;
         if (all_variable_maps_[type_index].find(variable_name) == all_variable_maps_[type_index].end())
         {
-            auto &container = std::get<type_index>(shared_variable_data_);
-            container.emplace_back(new StdLargeVec<VariableType>());
-            registerVariable(*container.back(), variable_name);
-            return container.back();
+            UniquePtrsKeeper<StdLargeVec<VariableType>> &container = std::get<type_index>(shared_variable_data_);
+            StdLargeVec<VariableType> *contained_data = container.template createPtr<StdLargeVec<VariableType>>();
+            registerVariable(*contained_data, variable_name);
+            return contained_data;
         }
         else
         {

--- a/SPHINXsys/src/shared/simbody_sphinxsys/state_engine.h
+++ b/SPHINXsys/src/shared/simbody_sphinxsys/state_engine.h
@@ -162,7 +162,7 @@ namespace SPH {
             SimTK::Stage    invalidatestage_;
         };
  
-        UniquePtrKeepers<AddedStateVariable> added_state_variable_ptr_keeper_;
+        UniquePtrsKeeper<AddedStateVariable> added_state_variable_ptr_keeper_;
         /**
          * @struct StateVariableInfo
          * @brief   To hold related info about discrete variables.

--- a/modules/structural_simulation/structural_simulation_class.h
+++ b/modules/structural_simulation/structural_simulation_class.h
@@ -154,9 +154,9 @@ public:
 class StructuralSimulation
 {
 private:
-	UniquePtrKeepers<SurfaceContactRelation> contact_relation_ptr_keeper_;
-	UniquePtrKeepers<Gravity> gravity_ptr_keeper_;
-	UniquePtrKeepers<BodyPartFromMesh> body_part_tri_mesh_ptr_keeper_;
+	UniquePtrsKeeper<SurfaceContactRelation> contact_relation_ptr_keeper_;
+	UniquePtrsKeeper<Gravity> gravity_ptr_keeper_;
+	UniquePtrsKeeper<BodyPartFromMesh> body_part_tri_mesh_ptr_keeper_;
 
 protected:
 	// mandatory input


### PR DESCRIPTION
1. Using unique pointer for shared particle data.
2. Simplify the type for contact figuration.
3. Renaming resize configuration and unique pointers keeper for better expression. 