### PR TITLE
Add getters for base particle member variables

### DIFF
--- a/SPHINXsys/src/shared/common/sph_data_containers.h
+++ b/SPHINXsys/src/shared/common/sph_data_containers.h
@@ -95,7 +95,7 @@ namespace SPH
 	{
 		template <typename VariableOperation>
 		void operator()(ParticleData &particle_data,
-						ParticleVariableList &variable_name_list, VariableOperation &variable_operation) const
+						const ParticleVariableList &variable_name_list, VariableOperation &variable_operation) const
 		{
 			constexpr int type_index = DataTypeIndex<VariableType>::value;
 			for (std::pair<std::string, size_t> &name_index : variable_name_list[type_index])

--- a/SPHINXsys/src/shared/common/sph_data_containers.h
+++ b/SPHINXsys/src/shared/common/sph_data_containers.h
@@ -98,10 +98,9 @@ namespace SPH
 						const ParticleVariableList &variable_name_list, VariableOperation &variable_operation) const
 		{
 			constexpr int type_index = DataTypeIndex<VariableType>::value;
-			for (std::pair<std::string, size_t> &name_index : variable_name_list[type_index])
+			for (const auto& [variable_name,variable_index] : variable_name_list[type_index])
 			{
-				std::string variable_name = name_index.first;
-				StdLargeVec<VariableType> &variable = *(std::get<type_index>(particle_data)[name_index.second]);
+				StdLargeVec<VariableType> &variable = *(std::get<type_index>(particle_data)[variable_index]);
 				variable_operation(variable_name, variable);
 			}
 		};

--- a/SPHINXsys/src/shared/particles/base_particles.h
+++ b/SPHINXsys/src/shared/particles/base_particles.h
@@ -152,9 +152,11 @@ namespace SPH
 		/** add a variable into the list for restart */
 		template <typename VariableType>
 		void addVariableToRestart(const std::string &variable_name);
+		inline const ParticleVariableList& getVariablesToRestart() const {return variables_to_restart_;}
 		/** add a variable into the list for particle reload */
 		template <typename VariableType>
 		void addVariableToReload(const std::string &variable_name);
+		inline const ParticleVariableList& getVariablesToReload() const {return variables_to_reload_;}
 		/**
 		 *		Particle data for sorting
 		 */

--- a/SPHINXsys/src/shared/particles/base_particles.h
+++ b/SPHINXsys/src/shared/particles/base_particles.h
@@ -268,7 +268,7 @@ namespace SPH
 			: xml_engine_(xml_engine), total_real_particles_(total_real_particles){};
 
 		template <typename VariableType>
-		void operator()(std::string &variable_name, StdLargeVec<VariableType> &variable) const;
+		void operator()(const std::string &variable_name, StdLargeVec<VariableType> &variable) const;
 	};
 	/**
 	 * @struct ReadAParticleVariableFromXml
@@ -282,7 +282,7 @@ namespace SPH
 			: xml_engine_(xml_engine), total_real_particles_(total_real_particles){};
 
 		template <typename VariableType>
-		void operator()(std::string &variable_name, StdLargeVec<VariableType> &variable) const;
+		void operator()(const std::string &variable_name, StdLargeVec<VariableType> &variable) const;
 	};
 	/**
 	 * @class BaseDerivedVariable

--- a/SPHINXsys/src/shared/particles/base_particles.hpp
+++ b/SPHINXsys/src/shared/particles/base_particles.hpp
@@ -340,7 +340,7 @@ namespace SPH
     //=================================================================================================//
     template <typename VariableType>
     void WriteAParticleVariableToXml::
-    operator()(std::string &variable_name, StdLargeVec<VariableType> &variable) const
+    operator()(const std::string &variable_name, StdLargeVec<VariableType> &variable) const
     {
         SimTK::Xml::element_iterator ele_ite = xml_engine_.root_element_.element_begin();
         for (size_t i = 0; i != total_real_particles_; ++i)
@@ -352,7 +352,7 @@ namespace SPH
     //=================================================================================================//
     template <typename VariableType>
     void ReadAParticleVariableFromXml::
-    operator()(std::string &variable_name, StdLargeVec<VariableType> &variable) const
+    operator()(const std::string &variable_name, StdLargeVec<VariableType> &variable) const
     {
         SimTK::Xml::element_iterator ele_ite = xml_engine_.root_element_.element_begin();
         for (size_t i = 0; i != total_real_particles_; ++i)


### PR DESCRIPTION
* Add getter for accessing reload and restart variable lists from base particles. This allows to externalize and add extra reload/restart writer/reader
* Change arguments into const