### PR TITLE
Fix/cutoff radius

### DIFF
--- a/SPHINXsys/src/shared/adaptations/adaptation.cpp
+++ b/SPHINXsys/src/shared/adaptations/adaptation.cpp
@@ -16,15 +16,19 @@ namespace SPH
 		  local_refinement_level_(0), spacing_ref_(resolution_ref / system_refinement_ratio_),
 		  h_ref_(h_spacing_ratio_ * spacing_ref_), kernel_ptr_(makeUnique<KernelWendlandC2>(h_ref_)),
 		  sigma0_ref_(computeReferenceNumberDensity(Vecd())),
-		  spacing_min_(this->MostRefinedSpacing(spacing_ref_, local_refinement_level_)),
-		  h_ratio_max_(pow(2.0, local_refinement_level_)){};
+		  spacing_min_(this->MostRefinedSpacingRegular(spacing_ref_, local_refinement_level_)),
+		  Vol_min_(pow(spacing_min_, Dimensions)), h_ratio_max_(spacing_ref_ / spacing_min_){};
 	//=================================================================================================//
 	SPHAdaptation::SPHAdaptation(SPHBody &sph_body, Real h_spacing_ratio, Real system_refinement_ratio)
 		: SPHAdaptation(sph_body.getSPHSystem().resolution_ref_, h_spacing_ratio, system_refinement_ratio){};
 	//=================================================================================================//
-	Real SPHAdaptation::MostRefinedSpacing(Real coarse_particle_spacing, int refinement_level)
+	Real SPHAdaptation::MostRefinedSpacing(Real coarse_particle_spacing, int local_refinement_level)
 	{
-		return coarse_particle_spacing / pow(2.0, refinement_level);
+		return MostRefinedSpacingRegular(coarse_particle_spacing, local_refinement_level);
+	}
+	Real SPHAdaptation::MostRefinedSpacingRegular(Real coarse_particle_spacing, int local_refinement_level)
+	{
+		return coarse_particle_spacing / pow(2.0, local_refinement_level);
 	}
 	//=================================================================================================//
 	Real SPHAdaptation::computeReferenceNumberDensity(Vec2d zero)
@@ -77,7 +81,8 @@ namespace SPH
 		kernel_ptr_.reset(new KernelWendlandC2(h_ref_));
 		sigma0_ref_ = computeReferenceNumberDensity(Vecd());
 		spacing_min_ = MostRefinedSpacing(spacing_ref_, local_refinement_level_);
-		h_ratio_max_ = h_ref_ * spacing_ref_ / spacing_min_;
+		Vol_min_ = pow(spacing_min_, Dimensions);
+		h_ratio_max_ = spacing_ref_ / spacing_min_;
 	}
 	//=================================================================================================//
 	UniquePtr<BaseCellLinkedList> SPHAdaptation::
@@ -103,8 +108,9 @@ namespace SPH
 		: SPHAdaptation(sph_body, h_spacing_ratio, system_refinement_ratio)
 	{
 		local_refinement_level_ = local_refinement_level;
-		spacing_min_ = MostRefinedSpacing(spacing_ref_, local_refinement_level_);
-		h_ratio_max_ = pow(2.0, local_refinement_level_);
+		spacing_min_ = MostRefinedSpacingRegular(spacing_ref_, local_refinement_level_);
+		Vol_min_ = pow(spacing_min_, Dimensions);
+		h_ratio_max_ = spacing_ref_ / spacing_min_;
 		// To ensure that the adaptation strictly within all level set and mesh cell linked list levels
 		finest_spacing_bound_ = spacing_min_ + Eps;
 		coarsest_spacing_bound_ = spacing_ref_ - Eps;
@@ -171,15 +177,14 @@ namespace SPH
 		: ParticleWithLocalRefinement(sph_body, h_spacing_ratio,
 									  system_resolution_ratio, local_refinement_level)
 	{
-		spacing_min_ = MostRefinedSpacing(spacing_ref_, local_refinement_level_);
+		spacing_min_ = MostRefinedSpacingSplitting(spacing_ref_, local_refinement_level_);
+		Vol_min_ = pow(spacing_min_, Dimensions);
 		h_ratio_max_ = spacing_ref_ / spacing_min_;
-		minimum_volume_ = pow(spacing_min_, Dimensions);
-		maximum_volume_ = pow(spacing_ref_, Dimensions);
 	};
 	//=================================================================================================//
 	bool ParticleSplitAndMerge::isSplitAllowed(Real current_volume)
 	{
-		return current_volume - 2.0 * minimum_volume_ > -Eps ? true : false;
+		return current_volume - 2.0 * Vol_min_ > -Eps ? true : false;
 	}
 	//=================================================================================================//
 	bool ParticleSplitAndMerge::mergeResolutionCheck(Real volume)
@@ -187,15 +192,11 @@ namespace SPH
 		return volume - 1.2 * pow(spacing_min_, Dimensions) < Eps ? true : false;
 	}
 	//=================================================================================================//
-	void ParticleSplitAndMerge::
-		resetAdaptationRatios(Real h_spacing_ratio, Real new_system_refinement_ratio)
-	{
-		ParticleWithLocalRefinement::resetAdaptationRatios(h_spacing_ratio, new_system_refinement_ratio);
-		minimum_volume_ = pow(spacing_min_, Dimensions);
-		maximum_volume_ = pow(spacing_ref_, Dimensions);
-	}
-	//=================================================================================================//
 	Real ParticleSplitAndMerge::MostRefinedSpacing(Real coarse_particle_spacing, int local_refinement_level)
+	{
+		return MostRefinedSpacingSplitting(coarse_particle_spacing, local_refinement_level);
+	}
+	Real ParticleSplitAndMerge::MostRefinedSpacingSplitting(Real coarse_particle_spacing, int local_refinement_level)
 	{
 		Real minimum_spacing_particles = pow(2.0, local_refinement_level);
 		Real spacing_ratio = pow(minimum_spacing_particles, 1.0 / (Real)Dimensions);

--- a/SPHINXsys/src/shared/adaptations/adaptation.cpp
+++ b/SPHINXsys/src/shared/adaptations/adaptation.cpp
@@ -78,7 +78,7 @@ namespace SPH
 		spacing_ref_ = spacing_ref_ * system_refinement_ratio_ / new_system_refinement_ratio;
 		system_refinement_ratio_ = new_system_refinement_ratio;
 		h_ref_ = h_spacing_ratio_ * spacing_ref_;
-		kernel_ptr_.reset(new KernelWendlandC2(h_ref_));
+		getKernel()->resetSmoothingLength(h_ref_);
 		sigma0_ref_ = computeReferenceNumberDensity(Vecd());
 		spacing_min_ = MostRefinedSpacing(spacing_ref_, local_refinement_level_);
 		Vol_min_ = pow(spacing_min_, Dimensions);

--- a/SPHINXsys/src/shared/adaptations/adaptation.h
+++ b/SPHINXsys/src/shared/adaptations/adaptation.h
@@ -63,6 +63,7 @@ namespace SPH
 		UniquePtr<Kernel> kernel_ptr_; /**< unique pointer of kernel function owned this class */
 		Real sigma0_ref_;			   /**< Reference number density dependent on h_spacing_ratio_ and kernel function */
 		Real spacing_min_;			   /**< minimum particle spacing determined by local refinement level */
+		Real Vol_min_;				   /**< minimum particle volume measure determined by local refinement level */
 		Real h_ratio_max_;			   /**< the ratio between the reference smoothing length to the minimum smoothing length */
 
 	public:
@@ -78,8 +79,8 @@ namespace SPH
 		Kernel *getKernel() { return kernel_ptr_.get(); };
 		Real ReferenceNumberDensity(Real smoothing_length_ratio = 1.0);
 		virtual Real SmoothingLengthRatio(size_t particle_index_i) { return 1.0; };
-		virtual void resetAdaptationRatios(Real h_spacing_ratio, Real new_system_refinement_ratio = 1.0);
-		virtual void registerAdaptationVariables(BaseParticles &base_particles) {};
+		void resetAdaptationRatios(Real h_spacing_ratio, Real new_system_refinement_ratio = 1.0);
+		virtual void registerAdaptationVariables(BaseParticles &base_particles){};
 
 		virtual UniquePtr<BaseCellLinkedList> createCellLinkedList(const BoundingBox &domain_bounds, RealBody &real_body);
 		virtual UniquePtr<BaseLevelSet> createLevelSet(Shape &shape, Real refinement_ratio);
@@ -94,7 +95,8 @@ namespace SPH
 	protected:
 		Real computeReferenceNumberDensity(Vec2d zero);
 		Real computeReferenceNumberDensity(Vec3d zero);
-		virtual Real MostRefinedSpacing(Real coarse_particle_spacing, int refinement_level);
+		virtual Real MostRefinedSpacing(Real coarse_particle_spacing, int local_refinement_level);
+		Real MostRefinedSpacingRegular(Real coarse_particle_spacing, int local_refinement_level);
 	};
 
 	/**
@@ -188,7 +190,6 @@ namespace SPH
 		ParticleSplitAndMerge(SPHBody &sph_body, Real h_spacing_ratio_,
 							  Real system_resolution_ratio, int local_refinement_level);
 		virtual ~ParticleSplitAndMerge(){};
-		void resetAdaptationRatios(Real h_spacing_ratio, Real new_system_refinement_ratio = 1.0) override;
 
 		virtual bool isSplitAllowed(Real current_volume);
 		virtual bool mergeResolutionCheck(Real volume);
@@ -197,10 +198,10 @@ namespace SPH
 
 	protected:
 		Real minimum_volume_;
-		Real maximum_volume_;
 
 		virtual Real MostRefinedSpacing(Real coarse_particle_spacing, int local_refinement_level) override;
 		virtual size_t getCellLinkedListTotalLevel() override;
+		Real MostRefinedSpacingSplitting(Real coarse_particle_spacing, int local_refinement_level);
 	};
 }
 #endif // ADAPTATION_H

--- a/SPHINXsys/src/shared/kernels/all_kernels.h
+++ b/SPHINXsys/src/shared/kernels/all_kernels.h
@@ -31,7 +31,7 @@
 
 #include "kernel_wenland_c2.h"
 #include "kernel_hyperbolic.h"
-#include "kernel_tabulated.hpp"
+#include "kernel_tabulated.h"
 #include "kernel_cubic_B_spline.h"
 #include "kernel_laguerre_gauss.h"
 

--- a/SPHINXsys/src/shared/kernels/base_kernel.cpp
+++ b/SPHINXsys/src/shared/kernels/base_kernel.cpp
@@ -3,9 +3,9 @@
 namespace SPH
 {
 	//=================================================================================================//
-	Kernel::Kernel(Real h, Real kernel_size, Real rc_ref, const std::string &name)
+	Kernel::Kernel(Real h, Real kernel_size, Real truncation, const std::string &name)
 		: kernel_name_(name), h_(h), inv_h_(1.0 / h), kernel_size_(kernel_size),
-		  rc_ref_(rc_ref), rc_ref_sqr_(rc_ref * rc_ref),
+		  truncation_(truncation), rc_ref_(truncation * h), rc_ref_sqr_(rc_ref_ * rc_ref_),
 		  h_factor_W_1D_(std::bind(&Kernel::factorW1D, this, _1)),
 		  h_factor_W_2D_(std::bind(&Kernel::factorW2D, this, _1)),
 		  h_factor_W_3D_(std::bind(&Kernel::factorW3D, this, _1)),
@@ -24,6 +24,21 @@ namespace SPH
 		factor_d2W_1D_ = inv_h_ * factor_dW_1D_;
 		factor_d2W_2D_ = inv_h_ * factor_dW_2D_;
 		factor_d2W_3D_ = inv_h_ * factor_dW_3D_;
+	}
+	//=================================================================================================//
+	void Kernel::resetSmoothingLength(Real h)
+	{
+		Real ratio = h_ / h;
+		h_ /= ratio;
+		inv_h_ *= ratio;
+		rc_ref_ /= ratio;
+		rc_ref_sqr_ /= ratio * ratio;
+
+		factor_W_1D_ *= ratio;
+		factor_W_2D_ *= ratio * ratio;
+		factor_W_3D_ *= ratio * ratio * ratio;
+
+		setDerivativeParameters();
 	}
 	//=================================================================================================//
 	Real Kernel::W(const Real &r_ij, const Real &displacement) const

--- a/SPHINXsys/src/shared/kernels/base_kernel.cpp
+++ b/SPHINXsys/src/shared/kernels/base_kernel.cpp
@@ -3,8 +3,9 @@
 namespace SPH
 {
 	//=================================================================================================//
-	Kernel::Kernel(Real h, const std::string &kernel_name)
-		: kernel_name_(kernel_name), h_(h), inv_h_(1.0 / h),
+	Kernel::Kernel(Real h, Real kernel_size, Real rc_ref, const std::string &name)
+		: kernel_name_(name), h_(h), inv_h_(1.0 / h), kernel_size_(kernel_size),
+		  rc_ref_(rc_ref), rc_ref_sqr_(rc_ref * rc_ref),
 		  h_factor_W_1D_(std::bind(&Kernel::factorW1D, this, _1)),
 		  h_factor_W_2D_(std::bind(&Kernel::factorW2D, this, _1)),
 		  h_factor_W_3D_(std::bind(&Kernel::factorW3D, this, _1)),
@@ -17,8 +18,6 @@ namespace SPH
 	//=================================================================================================//
 	void Kernel::setDerivativeParameters()
 	{
-		cutoff_radius_ref_ = KernelSize() * h_;
-		cutoff_radius_sqr_ = cutoff_radius_ref_ * cutoff_radius_ref_;
 		factor_dW_1D_ = inv_h_ * factor_W_1D_;
 		factor_dW_2D_ = inv_h_ * factor_W_2D_;
 		factor_dW_3D_ = inv_h_ * factor_W_3D_;

--- a/SPHINXsys/src/shared/kernels/base_kernel.h
+++ b/SPHINXsys/src/shared/kernels/base_kernel.h
@@ -21,14 +21,13 @@
  *                                                                          *
  * ------------------------------------------------------------------------*/
 /**
-* @file 	base_kernel.h
-* @brief 	This is the base classes of kernel functions.  Implementation will be
-*			implemented in derived classes. The kernal function define the relevance
-* 			between two neighboring particles. Basically, the further the two
-*			particles, the less relevance they have.     
-* @author	Chi ZHang and Xiangyu Hu
-*/
-
+ * @file 	base_kernel.h
+ * @brief 	This is the base classes of kernel functions.  Implementation will be
+ *			implemented in derived classes. The kernal function define the relevance
+ * 			between two neighboring particles. Basically, the further the two
+ *			particles, the less relevance they have.
+ * @author	Chi ZHang and Xiangyu Hu
+ */
 
 #ifndef BASE_KERNELS_H
 #define BASE_KERNELS_H
@@ -57,10 +56,11 @@ namespace SPH
 	class Kernel
 	{
 	protected:
-		const std::string kernel_name_;
-		Real h_, inv_h_;		 /**< reference smoothing length and its inverse **/
-		Real cutoff_radius_ref_; /** reference cut off radius **/
-		Real cutoff_radius_sqr_; /** reference cut off radius square **/
+		std::string kernel_name_;
+		const Real h_, inv_h_;	 /**< reference smoothing length and its inverse **/
+		Real kernel_size_; /**<kernel_size_ *  h_ gives the zero kernel value */
+		Real rc_ref_;		 /** reference cut off radius, beyond this kernel value is neglected. **/
+		Real rc_ref_sqr_;	 /** reference cut off radius square **/
 		/** Normalization factors for the kernel function  **/
 		Real factor_W_1D_, factor_W_2D_, factor_W_3D_;
 		/** Auxiliary factors for the derivative of kernel function  **/
@@ -72,20 +72,20 @@ namespace SPH
 
 	public:
 		/** empty initialization in constructor, initialization will be carried out later. */
-		explicit Kernel(Real h, const std::string &kernel_name = "Kernel");
+		explicit Kernel(Real h, Real kernel_size, Real rc_ref, const std::string &name);
 		virtual ~Kernel(){};
 
 		std::string Name() const { return kernel_name_; };
 		Real SmoothingLength() const { return h_; };
 		/**< non-dimensional size of the kernel, generally 2.0 **/
-		virtual Real KernelSize() const { return 2.0; };
-		Real CutOffRadius() const { return cutoff_radius_ref_; };
-		Real CutOffRadiusSqr() const { return cutoff_radius_sqr_; };
+		virtual Real KernelSize() const { return kernel_size_; };
+		Real CutOffRadius() const { return rc_ref_; };
+		Real CutOffRadiusSqr() const { return rc_ref_sqr_; };
 		Real FactorW1D() const { return factor_W_1D_; };
 		Real FactorW2D() const { return factor_W_2D_; };
 		Real FactorW3D() const { return factor_W_3D_; };
 
-		/** 
+		/**
 		 * Calculates the kernel value for the given displacement of two particles
 		 * r_ij pointing from particle j to particle i
 		 */
@@ -156,8 +156,8 @@ namespace SPH
 		Real factord2W3D(const Real &h_ratio) const { return factordW3D(h_ratio) * h_ratio; };
 
 	public:
-		Real CutOffRadius(Real h_ratio) const { return cutoff_radius_ref_ / h_ratio; };
-		Real CutOffRadiusSqr(Real h_ratio) const { return cutoff_radius_sqr_ / (h_ratio * h_ratio); };
+		Real CutOffRadius(Real h_ratio) const { return rc_ref_ / h_ratio; };
+		Real CutOffRadiusSqr(Real h_ratio) const { return rc_ref_sqr_ / (h_ratio * h_ratio); };
 
 		Real W(const Real &h_ratio, const Real &r_ij, const Real &displacement) const;
 		Real W(const Real &h_ratio, const Real &r_ij, const Vec2d &displacement) const;

--- a/SPHINXsys/src/shared/kernels/base_kernel.h
+++ b/SPHINXsys/src/shared/kernels/base_kernel.h
@@ -57,10 +57,11 @@ namespace SPH
 	{
 	protected:
 		std::string kernel_name_;
-		const Real h_, inv_h_;	 /**< reference smoothing length and its inverse **/
+		Real h_, inv_h_;   /**< reference smoothing length and its inverse **/
 		Real kernel_size_; /**<kernel_size_ *  h_ gives the zero kernel value */
-		Real rc_ref_;		 /** reference cut off radius, beyond this kernel value is neglected. **/
-		Real rc_ref_sqr_;	 /** reference cut off radius square **/
+		Real truncation_;  /**< to obtain cut off radius */
+		Real rc_ref_;	   /** reference cut off radius, beyond this kernel value is neglected. **/
+		Real rc_ref_sqr_;  /** reference cut off radius square **/
 		/** Normalization factors for the kernel function  **/
 		Real factor_W_1D_, factor_W_2D_, factor_W_3D_;
 		/** Auxiliary factors for the derivative of kernel function  **/
@@ -76,9 +77,11 @@ namespace SPH
 		virtual ~Kernel(){};
 
 		std::string Name() const { return kernel_name_; };
+		void resetSmoothingLength(Real h);
 		Real SmoothingLength() const { return h_; };
 		/**< non-dimensional size of the kernel, generally 2.0 **/
-		virtual Real KernelSize() const { return kernel_size_; };
+		Real KernelSize() const { return kernel_size_; };
+		Real Truncation() const { return truncation_; };
 		Real CutOffRadius() const { return rc_ref_; };
 		Real CutOffRadiusSqr() const { return rc_ref_sqr_; };
 		Real FactorW1D() const { return factor_W_1D_; };

--- a/SPHINXsys/src/shared/kernels/kernel_cubic_B_spline.cpp
+++ b/SPHINXsys/src/shared/kernels/kernel_cubic_B_spline.cpp
@@ -6,7 +6,7 @@ namespace SPH
 {
 	//=================================================================================================//
 	KernelCubicBSpline::KernelCubicBSpline(Real h)
-		: Kernel(h, 2.0, 2.0 * h, "CubicBSpline")
+		: Kernel(h, 2.0, 2.0, "CubicBSpline")
 	{
 		factor_W_1D_ = inv_h_ * 2.0 / 3.0;
 		factor_W_2D_ = inv_h_ * inv_h_ * 10.0 / (7.0 * Pi);

--- a/SPHINXsys/src/shared/kernels/kernel_cubic_B_spline.cpp
+++ b/SPHINXsys/src/shared/kernels/kernel_cubic_B_spline.cpp
@@ -6,7 +6,7 @@ namespace SPH
 {
 	//=================================================================================================//
 	KernelCubicBSpline::KernelCubicBSpline(Real h)
-		: Kernel(h, "CubicBSpline")
+		: Kernel(h, 2.0, 2.0 * h, "CubicBSpline")
 	{
 		factor_W_1D_ = inv_h_ * 2.0 / 3.0;
 		factor_W_2D_ = inv_h_ * inv_h_ * 10.0 / (7.0 * Pi);

--- a/SPHINXsys/src/shared/kernels/kernel_hyperbolic.cpp
+++ b/SPHINXsys/src/shared/kernels/kernel_hyperbolic.cpp
@@ -6,7 +6,7 @@ namespace SPH
 {
 	//=================================================================================================//
 	KernelHyperbolic::KernelHyperbolic(Real h)
-		: Kernel(h, "HyperbolicKernel")
+		: Kernel(h, 2.0, 2.0 * h, "HyperbolicKernel")
 	{
 		factor_W_1D_ = inv_h_ / 7.0;
 		factor_W_2D_ = inv_h_ * inv_h_ / (3.0 * Pi);

--- a/SPHINXsys/src/shared/kernels/kernel_hyperbolic.cpp
+++ b/SPHINXsys/src/shared/kernels/kernel_hyperbolic.cpp
@@ -6,7 +6,7 @@ namespace SPH
 {
 	//=================================================================================================//
 	KernelHyperbolic::KernelHyperbolic(Real h)
-		: Kernel(h, 2.0, 2.0 * h, "HyperbolicKernel")
+		: Kernel(h, 2.0, 2.0, "HyperbolicKernel")
 	{
 		factor_W_1D_ = inv_h_ / 7.0;
 		factor_W_2D_ = inv_h_ * inv_h_ / (3.0 * Pi);

--- a/SPHINXsys/src/shared/kernels/kernel_laguerre_gauss.cpp
+++ b/SPHINXsys/src/shared/kernels/kernel_laguerre_gauss.cpp
@@ -6,7 +6,7 @@ namespace SPH
 {
 	//=================================================================================================//
 	KernelLaguerreGauss::KernelLaguerreGauss(Real h)
-		: Kernel(h, "LaguerreGauss")
+		: Kernel(h, 2.0, 2.0 * h, "LaguerreGauss")
 	{
 		factor_W_1D_ = inv_h_ * 8.0 / (5.0 * pow(Pi, 0.5));
 		factor_W_2D_ = inv_h_ * inv_h_ * 3.0 / Pi;

--- a/SPHINXsys/src/shared/kernels/kernel_laguerre_gauss.cpp
+++ b/SPHINXsys/src/shared/kernels/kernel_laguerre_gauss.cpp
@@ -6,7 +6,7 @@ namespace SPH
 {
 	//=================================================================================================//
 	KernelLaguerreGauss::KernelLaguerreGauss(Real h)
-		: Kernel(h, 2.0, 2.0 * h, "LaguerreGauss")
+		: Kernel(h, 2.0, 2.0, "LaguerreGauss")
 	{
 		factor_W_1D_ = inv_h_ * 8.0 / (5.0 * pow(Pi, 0.5));
 		factor_W_2D_ = inv_h_ * inv_h_ * 3.0 / Pi;

--- a/SPHINXsys/src/shared/kernels/kernel_quadratic.cpp
+++ b/SPHINXsys/src/shared/kernels/kernel_quadratic.cpp
@@ -6,7 +6,7 @@ namespace SPH
 {
 	//=================================================================================================//
 	KernelQuadratic::KernelQuadratic(Real h)
-		: Kernel(h, "QuadraticKernel")
+		: Kernel(h, 2.0, 2.0 * h, "QuadraticKernel")
 	{
 		factor_W_1D_ = inv_h_ / 7.0;
 		factor_W_2D_ = inv_h_ * inv_h_ / (3.0 * Pi);

--- a/SPHINXsys/src/shared/kernels/kernel_quadratic.cpp
+++ b/SPHINXsys/src/shared/kernels/kernel_quadratic.cpp
@@ -6,7 +6,7 @@ namespace SPH
 {
 	//=================================================================================================//
 	KernelQuadratic::KernelQuadratic(Real h)
-		: Kernel(h, 2.0, 2.0 * h, "QuadraticKernel")
+		: Kernel(h, 2.0, 2.0, "QuadraticKernel")
 	{
 		factor_W_1D_ = inv_h_ / 7.0;
 		factor_W_2D_ = inv_h_ * inv_h_ / (3.0 * Pi);

--- a/SPHINXsys/src/shared/kernels/kernel_tabulated.h
+++ b/SPHINXsys/src/shared/kernels/kernel_tabulated.h
@@ -64,8 +64,6 @@ namespace SPH
 	public:
 		explicit KernelTabulated(Real h, int kernel_resolution);
 
-		virtual Real KernelSize() const override { return original_kernel_.KernelSize(); };
-
 		virtual Real W_1D(const Real q) const override;
 		virtual Real W_2D(const Real q) const override;
 		virtual Real W_3D(const Real q) const override;

--- a/SPHINXsys/src/shared/kernels/kernel_tabulated.h
+++ b/SPHINXsys/src/shared/kernels/kernel_tabulated.h
@@ -81,17 +81,20 @@ namespace SPH
 	//=================================================================================================//
 	template <class KernelType>
 	KernelTabulated<KernelType>::KernelTabulated(Real h, int kernel_resolution)
-		: Kernel(h, 2.0, 2.0 * h, "Tabulated"), original_kernel_(h),
+		: Kernel(h, 2.0, 2.0, "Tabulated"), original_kernel_(h),
 		  kernel_resolution_(kernel_resolution)
 	{
 		kernel_name_ += original_kernel_.Name();
 		kernel_size_ = original_kernel_.KernelSize();
+		truncation_ = original_kernel_.Truncation();
 		rc_ref_ = original_kernel_.CutOffRadius();
 		rc_ref_sqr_ = original_kernel_.CutOffRadiusSqr();
 
 		factor_W_1D_ = original_kernel_.FactorW1D();
 		factor_W_2D_ = original_kernel_.FactorW2D();
 		factor_W_3D_ = original_kernel_.FactorW3D();
+
+		setDerivativeParameters();
 
 		dq_ = KernelSize() / Real(kernel_resolution_);
 		for (int i = 0; i < kernel_resolution_ + 4; i++)
@@ -111,8 +114,6 @@ namespace SPH
 		delta_q_1_ = dq_ * (-1.0 * dq_) * (-2.0 * dq_);
 		delta_q_2_ = (2.0 * dq_) * dq_ * (-1.0 * dq_);
 		delta_q_3_ = (3.0 * dq_) * (2.0 * dq_) * dq_;
-
-		setDerivativeParameters();
 	}
 	//=================================================================================================//
 	template <class KernelType>

--- a/SPHINXsys/src/shared/kernels/kernel_tabulated.h
+++ b/SPHINXsys/src/shared/kernels/kernel_tabulated.h
@@ -21,13 +21,13 @@
  *                                                                          *
  * ------------------------------------------------------------------------*/
 /**
- * @file 	kernel_tabulated.hpp
+ * @file 	kernel_tabulated.h
  * @brief 	This is the class for tabulated kernels using template.
  * @author	Yongchuan Yu, Massoud Rezevand, Chi ZHang and Xiangyu Hu
  */
 
-#ifndef KERNEL_TABULATED_HPP
-#define KERNEL_TABULATED_HPP
+#ifndef KERNEL_TABULATED_H
+#define KERNEL_TABULATED_H
 
 #include "base_kernel.h"
 #include <cmath>
@@ -81,9 +81,14 @@ namespace SPH
 	//=================================================================================================//
 	template <class KernelType>
 	KernelTabulated<KernelType>::KernelTabulated(Real h, int kernel_resolution)
-		: Kernel(h, "KernelTabulated"), original_kernel_(h),
+		: Kernel(h, 2.0, 2.0 * h, "Tabulated"), original_kernel_(h),
 		  kernel_resolution_(kernel_resolution)
 	{
+		kernel_name_ += original_kernel_.Name();
+		kernel_size_ = original_kernel_.KernelSize();
+		rc_ref_ = original_kernel_.CutOffRadius();
+		rc_ref_sqr_ = original_kernel_.CutOffRadiusSqr();
+
 		factor_W_1D_ = original_kernel_.FactorW1D();
 		factor_W_2D_ = original_kernel_.FactorW2D();
 		factor_W_3D_ = original_kernel_.FactorW3D();
@@ -165,4 +170,4 @@ namespace SPH
 	}
 	//=================================================================================================//
 }
-#endif // KERNEL_TABULATED_HPP
+#endif // KERNEL_TABULATED_H

--- a/SPHINXsys/src/shared/kernels/kernel_wenland_c2.cpp
+++ b/SPHINXsys/src/shared/kernels/kernel_wenland_c2.cpp
@@ -6,7 +6,7 @@ namespace SPH
 {
 	//=================================================================================================//
 	KernelWendlandC2::KernelWendlandC2(Real h)
-		: Kernel(h, "Wendland2CKernel")
+		: Kernel(h, 2.0, 2.0 * h, "Wendland2CKernel")
 	{
 		factor_W_1D_ = inv_h_ * 3.0 / 4.0;
 		factor_W_2D_ = inv_h_ * inv_h_ * 7.0 / (4.0 * Pi);

--- a/SPHINXsys/src/shared/kernels/kernel_wenland_c2.cpp
+++ b/SPHINXsys/src/shared/kernels/kernel_wenland_c2.cpp
@@ -6,7 +6,7 @@ namespace SPH
 {
 	//=================================================================================================//
 	KernelWendlandC2::KernelWendlandC2(Real h)
-		: Kernel(h, 2.0, 2.0 * h, "Wendland2CKernel")
+		: Kernel(h, 2.0, 2.0, "Wendland2CKernel")
 	{
 		factor_W_1D_ = inv_h_ * 3.0 / 4.0;
 		factor_W_2D_ = inv_h_ * inv_h_ * 7.0 / (4.0 * Pi);


### PR DESCRIPTION
1. introduce truncation to kernel function.
2. revise the resetAdaptionRatios() so that one do not need to recreate the kernel and it is not virtual anymore.