### PR TITLE
fix bug in DeformationGradientBySummation

### DIFF
--- a/src/shared/particle_dynamics/solid_dynamics/elastic_dynamics.h
+++ b/src/shared/particle_dynamics/solid_dynamics/elastic_dynamics.h
@@ -114,7 +114,7 @@ class DeformationGradientBySummation : public LocalDynamics, public ElasticSolid
     {
         Vecd &pos_n_i = pos_[index_i];
 
-        Matd deformation = Matd::Identity();
+        Matd deformation = Matd::Zero();
         Neighborhood &inner_neighborhood = inner_configuration_[index_i];
         for (size_t n = 0; n != inner_neighborhood.current_size_; ++n)
         {


### PR DESCRIPTION
deformation must be initialized with a Zero matrix for correct computation of the deformation gradient