### PR TITLE
[SYCL] Register device variables using data assemble

### DIFF
--- a/src/shared/bodies/base_body.h
+++ b/src/shared/bodies/base_body.h
@@ -153,8 +153,7 @@ class SPHBody
         base_material_->initializeLocalParameters(base_particles_);
             
         // copy allocated particles to device memory
-        base_particles_->allocateDeviceMemory();
-        base_particles_->copyToDeviceMemory();
+        base_particles_->registerDeviceMemory();
     };
 
     template <typename DataType>

--- a/src/shared/body_relations/base_body_relation.h
+++ b/src/shared/body_relations/base_body_relation.h
@@ -154,6 +154,7 @@ class BaseContactRelation : public SPHRelation
   public:
     RealBodyVector contact_bodies_;
     StdVec<ParticleConfiguration> contact_configuration_; /**< Configurations for particle interaction between bodies. */
+    StdVec<StdSharedVec<NeighborhoodDevice>> contact_configuration_device_;
 
     BaseContactRelation(SPHBody &sph_body, RealBodyVector contact_bodies);
     BaseContactRelation(SPHBody &sph_body, BodyPartVector contact_body_parts)

--- a/src/shared/common/base_data_package.h
+++ b/src/shared/common/base_data_package.h
@@ -90,7 +90,10 @@ using DataContainerAssemble =
                StdVec<DataContainerType<Vec3d>>,
                StdVec<DataContainerType<Mat2d>>,
                StdVec<DataContainerType<Mat3d>>,
-               StdVec<DataContainerType<int>>>;
+               StdVec<DataContainerType<int>>,
+               StdVec<DataContainerType<DeviceReal>>,
+               StdVec<DataContainerType<DeviceVec2d>>,
+               StdVec<DataContainerType<DeviceVec3d>>>;
 /** Generalized data container address assemble type */
 template <template <typename DataType> typename DataContainerType>
 using DataContainerAddressAssemble =
@@ -99,7 +102,10 @@ using DataContainerAddressAssemble =
                StdVec<DataContainerType<Vec3d> *>,
                StdVec<DataContainerType<Mat2d> *>,
                StdVec<DataContainerType<Mat3d> *>,
-               StdVec<DataContainerType<int> *>>;
+               StdVec<DataContainerType<int> *>,
+               StdVec<DataContainerType<DeviceReal> *>,
+               StdVec<DataContainerType<DeviceVec2d> *>,
+               StdVec<DataContainerType<DeviceVec3d> *>>;
 /** Generalized data container unique pointer assemble type */
 template <template <typename DataType> typename DataContainerType>
 using DataContainerUniquePtrAssemble =
@@ -108,7 +114,10 @@ using DataContainerUniquePtrAssemble =
                UniquePtrsKeeper<DataContainerType<Vec3d>>,
                UniquePtrsKeeper<DataContainerType<Mat2d>>,
                UniquePtrsKeeper<DataContainerType<Mat3d>>,
-               UniquePtrsKeeper<DataContainerType<int>>>;
+               UniquePtrsKeeper<DataContainerType<int>>,
+               UniquePtrsKeeper<DataContainerType<DeviceReal>>,
+               UniquePtrsKeeper<DataContainerType<DeviceVec2d>>,
+               UniquePtrsKeeper<DataContainerType<DeviceVec3d>>>;
 
 /** a type irrelevant operation on the data assembles  */
 template <template <typename VariableType> typename OperationType>

--- a/src/shared/common/base_data_type.h
+++ b/src/shared/common/base_data_type.h
@@ -119,7 +119,7 @@ struct ZeroData<int>
     static inline int value = 0;
 };
 /** Type trait for data type index. */
-template <typename T>
+template <typename T, typename Enable = void>
 struct DataTypeIndex
 {
     static constexpr int value = std::numeric_limits<int>::max();
@@ -153,6 +153,21 @@ template <>
 struct DataTypeIndex<int>
 {
     static constexpr int value = 5;
+};
+template <>
+struct DataTypeIndex<DeviceReal, std::enable_if_t<std::negation_v<std::is_same<Real, DeviceReal>>>>
+{
+    static constexpr int value = 6;
+};
+template <>
+struct DataTypeIndex<DeviceVec2d, std::enable_if_t<std::negation_v<std::is_same<Vec2d, DeviceVec2d>>>>
+{
+    static constexpr int value = 7;
+};
+template <>
+struct DataTypeIndex<DeviceVec3d, std::enable_if_t<std::negation_v<std::is_same<Vec3d, DeviceVec3d>>>>
+{
+    static constexpr int value = 8;
 };
 /** Useful float point constants. */
 constexpr size_t MaxSize_t = std::numeric_limits<size_t>::max();

--- a/src/shared/common/sph_data_containers.h
+++ b/src/shared/common/sph_data_containers.h
@@ -70,6 +70,8 @@ typedef DataContainerAddressAssemble<StdLargeVec> ParticleData;
 typedef DataContainerAddressAssemble<DiscreteVariable> ParticleVariables;
 /** Generalized particle variable type*/
 typedef DataContainerAddressAssemble<GlobalVariable> GlobalVariables;
+/** Generalized particle device variable type*/
+typedef DataContainerAddressAssemble<DeviceVariable> DeviceVariables;
 
 /** Generalized mesh data type */
 template <typename DataType>

--- a/src/shared/materials/riemann_solver.cpp
+++ b/src/shared/materials/riemann_solver.cpp
@@ -4,16 +4,6 @@
 namespace SPH
 {
 //=================================================================================================//
-Real NoRiemannSolver::DissipativePJump(const Real &u_jump)
-{
-    return 0.0;
-}
-//=================================================================================================//
-Real NoRiemannSolver::DissipativeUJump(const Real &p_jump)
-{
-    return 0.0;
-}
-//=================================================================================================//
 Real NoRiemannSolver::AverageP(const Real &p_i, const Real &p_j)
 {
     return (p_i * rho0c0_j_ + p_j * rho0c0_i_) * inv_rho0c0_sum_;
@@ -22,16 +12,6 @@ Real NoRiemannSolver::AverageP(const Real &p_i, const Real &p_j)
 Vecd NoRiemannSolver::AverageV(const Vecd &vel_i, const Vecd &vel_j)
 {
     return (vel_i * rho0c0_i_ + vel_j * rho0c0_j_) * inv_rho0c0_sum_;
-}
-//=================================================================================================//
-Real AcousticRiemannSolver::DissipativePJump(const Real &u_jump)
-{
-    return rho0c0_geo_ave_ * u_jump * SMIN(Real(3) * SMAX(u_jump * inv_c_ave_, Real(0)), Real(1));
-}
-//=================================================================================================//
-Real DissipativeRiemannSolver::DissipativePJump(const Real &u_jump)
-{
-    return rho0c0_geo_ave_ * u_jump;
 }
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/materials/riemann_solver.h
+++ b/src/shared/materials/riemann_solver.h
@@ -68,8 +68,8 @@ class NoRiemannSolver
           c0_i_(fluid_i.ReferenceSoundSpeed()), c0_j_(fluid_j.ReferenceSoundSpeed()),
           rho0c0_i_(rho0_i_ * c0_i_), rho0c0_j_(rho0_j_ * c0_j_),
           inv_rho0c0_sum_(1.0 / (rho0c0_i_ + rho0c0_j_)){};
-    Real DissipativePJump(const Real &u_jump);
-    Real DissipativeUJump(const Real &p_jump);
+    Real DissipativePJump(const Real &u_jump) const { return 0.0; }
+    Real DissipativeUJump(const Real &p_jump) const { return 0.0; }
     Real AverageP(const Real &p_i, const Real &p_j);
     Vecd AverageV(const Vecd &vel_i, const Vecd &vel_j);
 
@@ -88,12 +88,11 @@ class AcousticRiemannSolver : public NoRiemannSolver
           inv_rho0c0_ave_(2.0 * inv_rho0c0_sum_),
           rho0c0_geo_ave_(2.0 * rho0c0_i_ * rho0c0_j_ * inv_rho0c0_sum_),
           inv_c_ave_(0.5 * (rho0_i_ + rho0_j_) * inv_rho0c0_ave_){};
-    Real DissipativePJump(const Real &u_jump);
-    Real DissipativeUJump(const Real &p_jump) {
-        return p_jump * inv_rho0c0_ave_;
+    Real DissipativePJump(const Real &u_jump) const {
+        return rho0c0_geo_ave_ * u_jump * SMIN(Real(3) * SMAX(u_jump * inv_c_ave_, Real(0)), Real(1));
     }
-    DeviceReal DissipativeUJump_Device(const DeviceReal &p_jump) const {
-        return p_jump * static_cast<DeviceReal>(inv_rho0c0_ave_);
+    Real DissipativeUJump(const Real &p_jump) const  {
+        return p_jump * inv_rho0c0_ave_;
     }
 
   protected:
@@ -107,7 +106,9 @@ class DissipativeRiemannSolver : public AcousticRiemannSolver
     template <class FluidI, class FluidJ>
     DissipativeRiemannSolver(FluidI &fluid_i, FluidJ &fluid_j)
         : AcousticRiemannSolver(fluid_i, fluid_j){};
-    Real DissipativePJump(const Real &u_jump);
+    Real DissipativePJump(const Real &u_jump) const {
+        return rho0c0_geo_ave_ * u_jump;
+    }
 };
 } // namespace SPH
 

--- a/src/shared/particle_dynamics/base_particle_dynamics.h
+++ b/src/shared/particle_dynamics/base_particle_dynamics.h
@@ -130,7 +130,7 @@ class DataDelegateInner : public BaseDataDelegateType
   public:
     explicit DataDelegateInner(BaseInnerRelation &inner_relation)
         : BaseDataDelegateType(inner_relation.getSPHBody()),
-          inner_configuration_(inner_relation.inner_configuration_)
+          inner_configuration_(inner_relation.inner_configuration_),
           inner_configuration_device_(inner_relation.inner_configuration_device_) {};
     virtual ~DataDelegateInner(){};
 

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.h
@@ -328,7 +328,8 @@ public DeviceExecutable<BaseIntegration1stHalfWithWall<BaseIntegration1stHalfTyp
         : InteractionWithWall<BaseIntegration1stHalfType>(std::forward<Args>(args)...),
           DeviceExecutable<BaseIntegration1stHalfWithWall<BaseIntegration1stHalfType>,
                            BaseIntegration1stHalfWithWallKernel<typename BaseIntegration1stHalfType::DeviceKernel>>(this,
-                           *this->contact_configuration_device_, this->contact_particles_[0]->acc_device_,
+                           *this->contact_configuration_device_,
+                           this->contact_particles_[0]->template getDeviceVariableByName<DeviceVecd>("Acceleration"),
                            BaseIntegration1stHalfType::particles_,
                            BaseIntegration1stHalfType::inner_configuration_device_->data(),
                            this->riemann_solver_) {};

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.h
@@ -291,7 +291,7 @@ class BaseIntegration1stHalfWithWallKernel : public BaseIntegration1stHalfType {
                 RealT face_wall_external_acceleration = dot(acc_prior_i - acc_ave_k[index_j], -e_ij);
                 auto p_in_wall = p[index_i] + rho[index_i] * r_ij * SMAX(min_external_acc, face_wall_external_acceleration);
                 acceleration -= (p[index_i] + p_in_wall) * dW_ijV_j * e_ij;
-                rho_dissipation += riemann_solver.DissipativeUJump_Device(p[index_i] - p_in_wall) * dW_ijV_j;
+                rho_dissipation += riemann_solver.DissipativeUJump(p[index_i] - p_in_wall) * dW_ijV_j;
             }
         }
         acc[index_i] += acceleration / rho[index_i];

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.h
@@ -280,7 +280,7 @@ class BaseIntegration1stHalfWithWallKernel : public BaseIntegration1stHalfType {
         for (size_t k = 0; k < contact_configuration_size; ++k)
         {
             Vec* acc_ave_k = getWallAccAve(k);
-            auto &wall_neighborhood = getWallNeighborhood(k, index_i);
+            const auto &wall_neighborhood = getWallNeighborhood(k, index_i);
             for (size_t n = 0; n < wall_neighborhood.current_size(); ++n)
             {
                 const auto& index_j = wall_neighborhood.j_[n];
@@ -304,7 +304,7 @@ class BaseIntegration1stHalfWithWallKernel : public BaseIntegration1stHalfType {
         interaction(index_i, dt, this->p_, this->rho_, this->drho_dt_, this->acc_, this->riemann_solver_,
                     contact_configuration_.size(), [&](auto index_i){ return this->acc_prior_[index_i]; },
                     [&](auto k){ return this->wall_acc_ave_[k]; },
-                    [&](auto k, auto index_i) -> NeighborhoodDevice&
+                    [&](auto k, auto index_i) -> const NeighborhoodDevice&
                         { return this->contact_configuration_[k][index_i]; },
                     [](const DeviceVecd& v1, const DeviceVecd& v2) { return sycl::dot(v1, v2); });
     }

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.hpp
@@ -162,10 +162,10 @@ InteractionWithWall<BaseIntegrationType>::
         
         // Device variables
         wall_inv_rho0_device_.at(k) = 1.0f / static_cast<DeviceReal>(rho0_k);
-        wall_mass_device_.at(k) = this->contact_particles_[k]->mass_device_;
-        wall_vel_ave_device_.at(k) = this->contact_particles_[k]->vel_device_;
-        wall_acc_ave_device_.at(k) = this->contact_particles_[k]->acc_device_;
-        wall_n_device_.at(k) = this->contact_particles_[k]->n_device_;
+        wall_mass_device_.at(k) = this->contact_particles_[k]->template getDeviceVariableByName<DeviceReal>("Mass");;
+        wall_vel_ave_device_.at(k) = this->contact_particles_[k]->template getDeviceVariableByName<DeviceVecd>("Velocity");
+        wall_acc_ave_device_.at(k) = this->contact_particles_[k]->template getDeviceVariableByName<DeviceVecd>("Acceleration");;
+        wall_n_device_.at(k) = this->contact_particles_[k]->template getDeviceVariableByName<DeviceVecd>("Normal");;
     }
 }
 //=================================================================================================//
@@ -189,7 +189,7 @@ BaseDensitySummationComplex<DensitySummationInnerType>::
 
 	// Device variables
 	contact_inv_rho0_device_.at(k) = 1.0f / static_cast<DeviceReal>(rho0_k);
-        contact_mass_device_.at(k) = this->contact_particles_[k]->mass_device_;
+        contact_mass_device_.at(k) = this->contact_particles_[k]->template getDeviceVariableByName<DeviceReal>("Mass");
     }
 }
 //=================================================================================================//

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.h
@@ -67,7 +67,7 @@ class BaseDensitySummationInnerKernel {
     BaseDensitySummationInnerKernel(NeighborhoodDevice* inner_configuration, BaseParticles* particles,
                                     DeviceReal rho0, DeviceReal invSigma0) :
         inner_configuration_(inner_configuration), rho_(particles->getDeviceVariableByName<DeviceReal>("Density")),
-        rho_sum_(particles->getDeviceVariableByName<DeviceReal>("DensitySummation")),
+        rho_sum_(particles->registerDeviceVariable<DeviceReal>("DensitySummation", particles->total_real_particles_)),
         mass_(particles->getDeviceVariableByName<DeviceReal>("Mass")), rho0_(rho0), inv_sigma0_(invSigma0) {}
   protected:
     NeighborhoodDevice* inner_configuration_;
@@ -244,7 +244,7 @@ class AcousticTimeStepSizeKernel {
   public:
     explicit AcousticTimeStepSizeKernel(BaseParticles* particles) :
         rho_(particles->getDeviceVariableByName<DeviceReal>("Density")),
-        p_(particles->getDeviceVariableByName<DeviceReal>("Pressure")),
+        p_(particles->registerDeviceVariable<DeviceReal>("Pressure", particles->total_real_particles_)),
         vel_(particles->getDeviceVariableByName<DeviceVecd>("Velocity")),
         fluid_(DynamicCast<FluidT>(this, particles->getBaseMaterial())) {}
 
@@ -386,8 +386,8 @@ class BaseIntegrationKernel {
     BaseIntegrationKernel(BaseParticles *particles) :
         fluid_(DynamicCast<FluidT>(this, particles->getBaseMaterial())),
         rho_(particles->getDeviceVariableByName<DeviceReal>("Density")),
-        p_(particles->getDeviceVariableByName<DeviceReal>("Pressure")),
-        drho_dt_(particles->getDeviceVariableByName<DeviceReal>("DensityChangeRate")),
+        p_(particles->registerDeviceVariable<DeviceReal>("Pressure", particles->total_real_particles_)),
+        drho_dt_(particles->registerDeviceVariable<DeviceReal>("DensityChangeRate", particles->total_real_particles_)),
         pos_(particles->getDeviceVariableByName<DeviceVecd>("Position")),
         vel_(particles->getDeviceVariableByName<DeviceVecd>("Velocity")),
         acc_(particles->getDeviceVariableByName<DeviceVecd>("Acceleration")),

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_surface_inner.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_surface_inner.h
@@ -90,8 +90,8 @@ class DensitySummationFreeSurfaceKernel : public DensitySummationKernel {
     DensitySummationFreeSurfaceKernel(const DensitySummationKernel& densitySummation) :
         DensitySummationKernel(densitySummation) {}
 
-    template<class RealT, class ReinitializedDensityFunc>
-    static void update(size_t index_i, Real dt, RealT* rho, RealT* rho_sum, RealT rho0,
+    template<class RealType, class ReinitializedDensityFunc>
+    static void update(size_t index_i, Real dt, RealType* rho, RealType* rho_sum, RealType rho0,
                        ReinitializedDensityFunc&& ReinitializedDensity)
     {
         rho[index_i] = ReinitializedDensity(rho_sum[index_i], rho0);

--- a/src/shared/particle_dynamics/general_dynamics/general_dynamics.h
+++ b/src/shared/particle_dynamics/general_dynamics/general_dynamics.h
@@ -66,7 +66,8 @@ class BaseTimeStepInitialization : public LocalDynamics
 class TimeStepInitializationKernel {
   public:
     TimeStepInitializationKernel(BaseParticles* particles, Gravity* gravity) :
-        pos_(particles->pos_device_), acc_prior_(particles->acc_prior_device_), gravity_(gravity) {}
+        pos_(particles->getDeviceVariableByName<DeviceVecd>("Position")),
+        acc_prior_(particles->getDeviceVariableByName<DeviceVecd>("AccelerationPrior")), gravity_(gravity) {}
 
     void update(size_t index_i, Real dt)
     {

--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -369,58 +369,58 @@ void BaseParticles::readFromXmlForReloadParticle(std::string &filefullpath)
 }
 
     void BaseParticles::registerDeviceMemory() {
-        registerDeviceVariable<DeviceVecd>("Position", pos_.size(), pos_.data());
-        registerDeviceVariable<DeviceVecd>("Velocity", vel_.size(), vel_.data());
-        registerDeviceVariable<DeviceVecd>("Acceleration", acc_.size(), acc_.data());
-        registerDeviceVariable<DeviceVecd>("AccelerationPrior", acc_prior_.size(), acc_prior_.data());
-        registerDeviceVariable<DeviceReal>("Density", rho_.size(), rho_.data());
-        registerDeviceVariable<DeviceReal>("Mass", mass_.size(), mass_.data());
+        registerDeviceVariable<DeviceVecd>("Position", total_real_particles_, pos_.data());
+        registerDeviceVariable<DeviceVecd>("Velocity", total_real_particles_, vel_.data());
+        registerDeviceVariable<DeviceVecd>("Acceleration", total_real_particles_, acc_.data());
+        registerDeviceVariable<DeviceVecd>("AccelerationPrior", total_real_particles_, acc_prior_.data());
+        registerDeviceVariable<DeviceReal>("Density", total_real_particles_, rho_.data());
+        registerDeviceVariable<DeviceReal>("Mass", total_real_particles_, mass_.data());
     }
 
     void BaseParticles::copyToDeviceMemory() {
-        copyDataToDevice(pos_.data(), getDeviceVariableByName<DeviceVecd>("Position"), pos_.size());
-        copyDataToDevice(vel_.data(), getDeviceVariableByName<DeviceVecd>("Velocity"), vel_.size());
-        copyDataToDevice(acc_.data(), getDeviceVariableByName<DeviceVecd>("Acceleration"), acc_.size());
-        copyDataToDevice(acc_prior_.data(), getDeviceVariableByName<DeviceVecd>("AccelerationPrior"), acc_prior_.size());
-        copyDataToDevice(rho_.data(), getDeviceVariableByName<DeviceReal>("Density"), rho_.size());
-        copyDataToDevice(mass_.data(), getDeviceVariableByName<DeviceReal>("Mass"), mass_.size());
+        copyDataToDevice(pos_.data(), getDeviceVariableByName<DeviceVecd>("Position"), total_real_particles_);
+        copyDataToDevice(vel_.data(), getDeviceVariableByName<DeviceVecd>("Velocity"), total_real_particles_);
+        copyDataToDevice(acc_.data(), getDeviceVariableByName<DeviceVecd>("Acceleration"), total_real_particles_);
+        copyDataToDevice(acc_prior_.data(), getDeviceVariableByName<DeviceVecd>("AccelerationPrior"), total_real_particles_);
+        copyDataToDevice(rho_.data(), getDeviceVariableByName<DeviceReal>("Density"), total_real_particles_);
+        copyDataToDevice(mass_.data(), getDeviceVariableByName<DeviceReal>("Mass"), total_real_particles_);
     }
 
     void BaseParticles::copyFromDeviceMemory() {
-        copyDataFromDevice(pos_.data(), getDeviceVariableByName<DeviceVecd>("Position"), pos_.size());
-        copyDataFromDevice(vel_.data(), getDeviceVariableByName<DeviceVecd>("Velocity"), vel_.size());
-        copyDataFromDevice(acc_.data(), getDeviceVariableByName<DeviceVecd>("Acceleration"), acc_.size());
-        copyDataFromDevice(acc_prior_.data(), getDeviceVariableByName<DeviceVecd>("AccelerationPrior"), acc_prior_.size());
-        copyDataFromDevice(rho_.data(), getDeviceVariableByName<DeviceReal>("Density"), rho_.size());
-        copyDataFromDevice(mass_.data(), getDeviceVariableByName<DeviceReal>("Mass"), mass_.size());
+        copyDataFromDevice(pos_.data(), getDeviceVariableByName<DeviceVecd>("Position"), total_real_particles_);
+        copyDataFromDevice(vel_.data(), getDeviceVariableByName<DeviceVecd>("Velocity"), total_real_particles_);
+        copyDataFromDevice(acc_.data(), getDeviceVariableByName<DeviceVecd>("Acceleration"), total_real_particles_);
+        copyDataFromDevice(acc_prior_.data(), getDeviceVariableByName<DeviceVecd>("AccelerationPrior"), total_real_particles_);
+        copyDataFromDevice(rho_.data(), getDeviceVariableByName<DeviceReal>("Density"), total_real_particles_);
+        copyDataFromDevice(mass_.data(), getDeviceVariableByName<DeviceReal>("Mass"), total_real_particles_);
     }
 
     void BaseParticles::registerExtraDeviceMemory() {
-        registerDeviceVariable<DeviceReal>("Pressure", pos_.size());
-        registerDeviceVariable<DeviceReal>("DensityChangeRate", pos_.size());
-        registerDeviceVariable<DeviceReal>("DensitySummation", pos_.size());
+        registerDeviceVariable<DeviceReal>("Pressure", total_real_particles_);
+        registerDeviceVariable<DeviceReal>("DensityChangeRate", total_real_particles_);
+        registerDeviceVariable<DeviceReal>("DensitySummation", total_real_particles_);
     }
 
     void BaseParticles::copyToExtraDeviceMemory() {
         auto *p = getVariableByName<Real>("Pressure");
-        copyDataToDevice(p->data(), getDeviceVariableByName<DeviceReal>("Pressure"), p->size());
+        copyDataToDevice(p->data(), getDeviceVariableByName<DeviceReal>("Pressure"), total_real_particles_);
 
         auto *drho_dt = getVariableByName<Real>("DensityChangeRate");
-        copyDataToDevice(drho_dt->data(), getDeviceVariableByName<DeviceReal>("DensityChangeRate"), drho_dt->size());
+        copyDataToDevice(drho_dt->data(), getDeviceVariableByName<DeviceReal>("DensityChangeRate"), total_real_particles_);
 
         auto *rho_sum = getVariableByName<Real>("DensitySummation");
-        copyDataToDevice(rho_sum->data(), getDeviceVariableByName<DeviceReal>("DensitySummation"), rho_sum->size());
+        copyDataToDevice(rho_sum->data(), getDeviceVariableByName<DeviceReal>("DensitySummation"), total_real_particles_);
     }
 
     void BaseParticles::copyFromExtraDeviceMemory() {
         auto *p = getVariableByName<Real>("Pressure");
-        copyDataFromDevice(p->data(), getDeviceVariableByName<DeviceReal>("Pressure"), p->size());
+        copyDataFromDevice(p->data(), getDeviceVariableByName<DeviceReal>("Pressure"), total_real_particles_);
 
         auto *drho_dt = getVariableByName<Real>("DensityChangeRate");
-        copyDataFromDevice(drho_dt->data(), getDeviceVariableByName<DeviceReal>("DensityChangeRate"), drho_dt->size());
+        copyDataFromDevice(drho_dt->data(), getDeviceVariableByName<DeviceReal>("DensityChangeRate"), total_real_particles_);
 
         auto *rho_sum = getVariableByName<Real>("DensitySummation");
-        copyDataFromDevice(rho_sum->data(), getDeviceVariableByName<DeviceReal>("DensitySummation"), rho_sum->size());
+        copyDataFromDevice(rho_sum->data(), getDeviceVariableByName<DeviceReal>("DensitySummation"), total_real_particles_);
     }
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -394,34 +394,6 @@ void BaseParticles::readFromXmlForReloadParticle(std::string &filefullpath)
         copyDataFromDevice(rho_.data(), getDeviceVariableByName<DeviceReal>("Density"), total_real_particles_);
         copyDataFromDevice(mass_.data(), getDeviceVariableByName<DeviceReal>("Mass"), total_real_particles_);
     }
-
-    void BaseParticles::registerExtraDeviceMemory() {
-        registerDeviceVariable<DeviceReal>("Pressure", total_real_particles_);
-        registerDeviceVariable<DeviceReal>("DensityChangeRate", total_real_particles_);
-        registerDeviceVariable<DeviceReal>("DensitySummation", total_real_particles_);
-    }
-
-    void BaseParticles::copyToExtraDeviceMemory() {
-        auto *p = getVariableByName<Real>("Pressure");
-        copyDataToDevice(p->data(), getDeviceVariableByName<DeviceReal>("Pressure"), total_real_particles_);
-
-        auto *drho_dt = getVariableByName<Real>("DensityChangeRate");
-        copyDataToDevice(drho_dt->data(), getDeviceVariableByName<DeviceReal>("DensityChangeRate"), total_real_particles_);
-
-        auto *rho_sum = getVariableByName<Real>("DensitySummation");
-        copyDataToDevice(rho_sum->data(), getDeviceVariableByName<DeviceReal>("DensitySummation"), total_real_particles_);
-    }
-
-    void BaseParticles::copyFromExtraDeviceMemory() {
-        auto *p = getVariableByName<Real>("Pressure");
-        copyDataFromDevice(p->data(), getDeviceVariableByName<DeviceReal>("Pressure"), total_real_particles_);
-
-        auto *drho_dt = getVariableByName<Real>("DensityChangeRate");
-        copyDataFromDevice(drho_dt->data(), getDeviceVariableByName<DeviceReal>("DensityChangeRate"), total_real_particles_);
-
-        auto *rho_sum = getVariableByName<Real>("DensitySummation");
-        copyDataFromDevice(rho_sum->data(), getDeviceVariableByName<DeviceReal>("DensitySummation"), total_real_particles_);
-    }
 //=================================================================================================//
 } // namespace SPH
   //=====================================================================================================//

--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -377,15 +377,6 @@ void BaseParticles::readFromXmlForReloadParticle(std::string &filefullpath)
         registerDeviceVariable<DeviceReal>("Mass", mass_.size(), mass_.data());
     }
 
-    void BaseParticles::freeDeviceMemory() {
-        freeDeviceData(getDeviceVariableByName<DeviceVecd>("Position"));
-        freeDeviceData(getDeviceVariableByName<DeviceVecd>("Velocity"));
-        freeDeviceData(getDeviceVariableByName<DeviceVecd>("Acceleration"));
-        freeDeviceData(getDeviceVariableByName<DeviceVecd>("AccelerationPrior"));
-        freeDeviceData(getDeviceVariableByName<DeviceReal>("Density"));
-        freeDeviceData(getDeviceVariableByName<DeviceReal>("Mass"));
-    }
-
     void BaseParticles::copyToDeviceMemory() {
         copyDataToDevice(pos_.data(), getDeviceVariableByName<DeviceVecd>("Position"), pos_.size());
         copyDataToDevice(vel_.data(), getDeviceVariableByName<DeviceVecd>("Velocity"), vel_.size());
@@ -408,12 +399,6 @@ void BaseParticles::readFromXmlForReloadParticle(std::string &filefullpath)
         registerDeviceVariable<DeviceReal>("Pressure", pos_.size());
         registerDeviceVariable<DeviceReal>("DensityChangeRate", pos_.size());
         registerDeviceVariable<DeviceReal>("DensitySummation", pos_.size());
-    }
-
-    void BaseParticles::freeExtraDeviceMemory() {
-        freeDeviceData(getDeviceVariableByName<DeviceReal>("Pressure"));
-        freeDeviceData(getDeviceVariableByName<DeviceReal>("DensityChangeRate"));
-        freeDeviceData(getDeviceVariableByName<DeviceReal>("DensitySummation"));
     }
 
     void BaseParticles::copyToExtraDeviceMemory() {

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -87,20 +87,21 @@ class BaseParticles
     DataContainerUniquePtrAssemble<DiscreteVariable> all_discrete_variable_ptrs_;
     DataContainerUniquePtrAssemble<StdLargeVec> shared_particle_data_ptrs_;
     DataContainerUniquePtrAssemble<GlobalVariable> all_global_variable_ptrs_;
+    DataContainerUniquePtrAssemble<DeviceVariable> all_device_variable_ptrs_;
     UniquePtrsKeeper<BaseDynamics<void>> derived_particle_data_;
 
   public:
     explicit BaseParticles(SPHBody &sph_body, BaseMaterial *base_material);
     virtual ~BaseParticles(){};
 
-    StdLargeVec<Vecd> pos_; DeviceVecd* pos_device_;       /**< Position */
-    StdLargeVec<Vecd> vel_; DeviceVecd* vel_device_;       /**< Velocity */
-    StdLargeVec<Vecd> acc_; DeviceVecd* acc_device_;       /**< Acceleration induced by pressure- or stress */
-    StdLargeVec<Vecd> acc_prior_; DeviceVecd* acc_prior_device_; /**< Other, such as gravity and viscous, accelerations computed before acc_ */
+    StdLargeVec<Vecd> pos_;       /**< Position */
+    StdLargeVec<Vecd> vel_;       /**< Velocity */
+    StdLargeVec<Vecd> acc_;       /**< Acceleration induced by pressure- or stress */
+    StdLargeVec<Vecd> acc_prior_; /**< Other, such as gravity and viscous, accelerations computed before acc_ */
 
     StdLargeVec<Real> Vol_;              /**< Volumetric measure, also area and length of surface and linear particle */
-    StdLargeVec<Real> rho_; DeviceReal* rho_device_;              /**< Density */
-    StdLargeVec<Real> mass_; DeviceReal* mass_device_;             /**< Massive measure, also mass per-unit thickness and per-unit cross-section of surface and linear particle */
+    StdLargeVec<Real> rho_;              /**< Density */
+    StdLargeVec<Real> mass_;             /**< Massive measure, also mass per-unit thickness and per-unit cross-section of surface and linear particle */
     StdLargeVec<int> surface_indicator_; /**< free surface indicator */
     //----------------------------------------------------------------------
     // Global information for defining particle groups
@@ -143,6 +144,12 @@ class BaseParticles
                                      DataType initial_value = ZeroData<DataType>::value);
     template <typename DataType>
     DataType *getGlobalVariableByName(const std::string &variable_name);
+
+    template <typename DeviceDataType, typename HostDataType = void>
+    DeviceDataType *registerDeviceVariable(const std::string &variable_name, std::size_t size,
+                                           const HostDataType* host_value = nullptr);
+    template <typename DeviceDataType>
+    DeviceDataType *getDeviceVariableByName(const std::string &variable_name);
     //----------------------------------------------------------------------
     //		Manage subsets of particle variables
     //----------------------------------------------------------------------
@@ -193,41 +200,15 @@ class BaseParticles
     virtual Real ParticleVolume(size_t index) { return Vol_[index]; }
     virtual Real ParticleMass(size_t index) { return mass_[index]; }
 
-    virtual void allocateDeviceMemory() {
-        pos_device_ = allocateSharedData<DeviceVecd>(pos_.size());
-        vel_device_ = allocateSharedData<DeviceVecd>(vel_.size());
-        acc_device_ = allocateSharedData<DeviceVecd>(acc_.size());
-        acc_prior_device_ = allocateSharedData<DeviceVecd>(acc_prior_.size());
-        rho_device_ = allocateDeviceData<DeviceReal>(rho_.size());
-        mass_device_ = allocateDeviceData<DeviceReal>(mass_.size());
-    }
+    virtual void registerDeviceMemory();
+    virtual void freeDeviceMemory();
+    virtual void copyToDeviceMemory();
+    virtual void copyFromDeviceMemory();
 
-    virtual void freeDeviceMemory() {
-        freeDeviceData(pos_device_);
-        freeDeviceData(vel_device_);
-        freeDeviceData(acc_device_);
-        freeDeviceData(acc_prior_device_);
-        freeDeviceData(rho_device_);
-        freeDeviceData(mass_device_);
-    }
-
-    virtual void copyToDeviceMemory() {
-        copyDataToDevice(pos_.data(), pos_device_, pos_.size());
-        copyDataToDevice(vel_.data(), vel_device_, vel_.size());
-        copyDataToDevice(acc_.data(), acc_device_, acc_.size());
-        copyDataToDevice(acc_prior_.data(), acc_prior_device_, acc_prior_.size());
-        copyDataToDevice(rho_.data(), rho_device_, rho_.size());
-        copyDataToDevice(mass_.data(), mass_device_, mass_.size());
-    }
-
-    virtual void copyFromDeviceMemory() {
-        copyDataFromDevice(pos_.data(), pos_device_, pos_.size());
-        copyDataFromDevice(vel_.data(), vel_device_, vel_.size());
-        copyDataFromDevice(acc_.data(), acc_device_, acc_.size());
-        copyDataFromDevice(acc_prior_.data(), acc_prior_device_, acc_prior_.size());
-        copyDataFromDevice(rho_.data(), rho_device_, rho_.size());
-        copyDataFromDevice(mass_.data(), mass_device_, mass_.size());
-    }
+    virtual void registerExtraDeviceMemory();
+    virtual void freeExtraDeviceMemory();
+    virtual void copyToExtraDeviceMemory();
+    virtual void copyFromExtraDeviceMemory();
 
   protected:
     SPHBody &sph_body_;
@@ -238,6 +219,7 @@ class BaseParticles
     ParticleData all_particle_data_;
     ParticleVariables all_discrete_variables_;
     GlobalVariables all_global_variables_;
+    DeviceVariables all_device_variables_;
     ParticleVariables variables_to_write_;
     ParticleVariables variables_to_restart_;
     ParticleVariables variables_to_reload_;

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -201,12 +201,10 @@ class BaseParticles
     virtual Real ParticleMass(size_t index) { return mass_[index]; }
 
     virtual void registerDeviceMemory();
-    virtual void freeDeviceMemory();
     virtual void copyToDeviceMemory();
     virtual void copyFromDeviceMemory();
 
     virtual void registerExtraDeviceMemory();
-    virtual void freeExtraDeviceMemory();
     virtual void copyToExtraDeviceMemory();
     virtual void copyFromExtraDeviceMemory();
 

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -204,10 +204,6 @@ class BaseParticles
     virtual void copyToDeviceMemory();
     virtual void copyFromDeviceMemory();
 
-    virtual void registerExtraDeviceMemory();
-    virtual void copyToExtraDeviceMemory();
-    virtual void copyFromExtraDeviceMemory();
-
   protected:
     SPHBody &sph_body_;
     std::string body_name_;

--- a/src/shared/particles/base_particles.hpp
+++ b/src/shared/particles/base_particles.hpp
@@ -79,6 +79,33 @@ DataType *BaseParticles::getGlobalVariableByName(const std::string &variable_nam
     return nullptr;
 }
 //=================================================================================================//
+template <typename DeviceDataType, typename HostDataType>
+DeviceDataType *BaseParticles::registerDeviceVariable(const std::string &variable_name, std::size_t size,
+                                                      const HostDataType* host_value)
+{
+    DeviceVariable<DeviceDataType> *variable = findVariableByName<DeviceDataType>(all_device_variables_, variable_name);
+
+    return variable != nullptr
+           ? variable->VariableAddress()
+           : addVariableToAssemble<DeviceDataType>(all_device_variables_, all_device_variable_ptrs_, variable_name,
+                                                   size, host_value)->VariableAddress();
+}
+//=================================================================================================//
+template <typename DeviceDataType>
+DeviceDataType *BaseParticles::getDeviceVariableByName(const std::string &variable_name)
+{
+    DeviceVariable<DeviceDataType> *variable = findVariableByName<DeviceDataType>(all_device_variables_, variable_name);
+
+    if (variable != nullptr)
+    {
+        return variable->VariableAddress();
+    }
+
+    std::cout << "\nError: the device variable '" << variable_name << "' is not registered!\n";
+    std::cout << __FILE__ << ':' << __LINE__ << std::endl;
+    return nullptr;
+}
+//=================================================================================================//
 template <typename DataType>
 StdLargeVec<DataType> *BaseParticles::
     registerSharedVariable(const std::string &variable_name, const DataType &default_value)

--- a/src/shared/particles/solid_particles.cpp
+++ b/src/shared/particles/solid_particles.cpp
@@ -29,11 +29,6 @@ void SolidParticles::registerDeviceMemory() {
         registerDeviceVariable<DeviceVecd>("Normal", n_.size(), n_.data());
 }
 
-void SolidParticles::freeDeviceMemory() {
-        BaseParticles::freeDeviceMemory();
-        freeDeviceData(getDeviceVariableByName<DeviceVecd>("Normal"));
-}
-
 void SolidParticles::copyToDeviceMemory() {
     BaseParticles::copyToDeviceMemory();
     copyDataToDevice(n_.data(), getDeviceVariableByName<DeviceVecd>("Normal"), n_.size());

--- a/src/shared/particles/solid_particles.cpp
+++ b/src/shared/particles/solid_particles.cpp
@@ -24,25 +24,24 @@ void SolidParticles::initializeOtherVariables()
                      { return Matd::Identity(); });
 }
 //=================================================================================================//
-void SolidParticles::allocateDeviceMemory() {
-        BaseParticles::allocateDeviceMemory();
-        n_device_ = allocateSharedData<DeviceVecd>(n_.size());
+void SolidParticles::registerDeviceMemory() {
+        BaseParticles::registerDeviceMemory();
+        registerDeviceVariable<DeviceVecd>("Normal", n_.size(), n_.data());
 }
 
 void SolidParticles::freeDeviceMemory() {
         BaseParticles::freeDeviceMemory();
-        freeDeviceData(n_device_);
+        freeDeviceData(getDeviceVariableByName<DeviceVecd>("Normal"));
 }
 
 void SolidParticles::copyToDeviceMemory() {
     BaseParticles::copyToDeviceMemory();
-    copyDataToDevice(n_.data(), n_device_, n_.size());
-//    executionQueue.getQueue().wait();
+    copyDataToDevice(n_.data(), getDeviceVariableByName<DeviceVecd>("Normal"), n_.size());
 }
 
 void SolidParticles::copyFromDeviceMemory() {
     BaseParticles::copyFromDeviceMemory();
-    copyDataFromDevice(n_.data(), n_device_, n_.size());
+    copyDataFromDevice(n_.data(), getDeviceVariableByName<DeviceVecd>("Normal"), n_.size());
 }
 
 //=============================================================================================//

--- a/src/shared/particles/solid_particles.cpp
+++ b/src/shared/particles/solid_particles.cpp
@@ -26,17 +26,17 @@ void SolidParticles::initializeOtherVariables()
 //=================================================================================================//
 void SolidParticles::registerDeviceMemory() {
         BaseParticles::registerDeviceMemory();
-        registerDeviceVariable<DeviceVecd>("Normal", n_.size(), n_.data());
+        registerDeviceVariable<DeviceVecd>("Normal", total_real_particles_, n_.data());
 }
 
 void SolidParticles::copyToDeviceMemory() {
     BaseParticles::copyToDeviceMemory();
-    copyDataToDevice(n_.data(), getDeviceVariableByName<DeviceVecd>("Normal"), n_.size());
+    copyDataToDevice(n_.data(), getDeviceVariableByName<DeviceVecd>("Normal"), total_real_particles_);
 }
 
 void SolidParticles::copyFromDeviceMemory() {
     BaseParticles::copyFromDeviceMemory();
-    copyDataFromDevice(n_.data(), getDeviceVariableByName<DeviceVecd>("Normal"), n_.size());
+    copyDataFromDevice(n_.data(), getDeviceVariableByName<DeviceVecd>("Normal"), total_real_particles_);
 }
 
 //=============================================================================================//

--- a/src/shared/particles/solid_particles.h
+++ b/src/shared/particles/solid_particles.h
@@ -68,7 +68,6 @@ class SolidParticles : public BaseParticles
     virtual SolidParticles *ThisObjectPtr() override { return this; };
 
     void registerDeviceMemory() override;
-    void freeDeviceMemory() override;
     void copyToDeviceMemory() override;
     void copyFromDeviceMemory() override;
 };

--- a/src/shared/particles/solid_particles.h
+++ b/src/shared/particles/solid_particles.h
@@ -53,7 +53,7 @@ class SolidParticles : public BaseParticles
     virtual ~SolidParticles(){};
 
     StdLargeVec<Vecd> pos0_; /**< initial position */
-    StdLargeVec<Vecd> n_; DeviceVecd* n_device_;    /**< normal direction */
+    StdLargeVec<Vecd> n_;    /**< normal direction */
     StdLargeVec<Vecd> n0_;   /**< initial normal direction */
     StdLargeVec<Matd> B_;    /**< configuration correction for linear reproducing */
     Solid &solid_;
@@ -67,7 +67,7 @@ class SolidParticles : public BaseParticles
     /** Return this pointer. */
     virtual SolidParticles *ThisObjectPtr() override { return this; };
 
-    void allocateDeviceMemory() override;
+    void registerDeviceMemory() override;
     void freeDeviceMemory() override;
     void copyToDeviceMemory() override;
     void copyFromDeviceMemory() override;

--- a/src/shared/variables/base_variable.h
+++ b/src/shared/variables/base_variable.h
@@ -59,6 +59,28 @@ class GlobalVariable : public BaseVariable
     DataType value_;
 };
 
+template <typename DeviceDataType>
+class DeviceVariable : public BaseVariable
+{
+public:
+    template<class HostDataType = void>
+    DeviceVariable(const std::string &name, std::size_t size, const HostDataType *host_value = nullptr)
+            : BaseVariable(name), device_addr_(allocateSharedData<DeviceDataType>(size))
+    {
+        if constexpr(std::negation_v<std::is_same<HostDataType, void>>)
+            copyDataToDevice(host_value, device_addr_, size);
+    }
+    virtual ~DeviceVariable()
+    {
+        freeDeviceData(device_addr_);
+    }
+
+    DeviceDataType *VariableAddress() { return device_addr_; };
+
+private:
+    DeviceDataType *device_addr_;
+};
+
 template <typename DataType>
 class DiscreteVariable : public BaseVariable
 {

--- a/tests/2d_examples/test_2d_dambreak/Dambreak.cpp
+++ b/tests/2d_examples/test_2d_dambreak/Dambreak.cpp
@@ -85,7 +85,6 @@ int main(int ac, char *av[])
     //	Define the numerical methods used in the simulation.
     //	Note that there may be data dependence on the sequence of constructions.
     //----------------------------------------------------------------------
-    water_block.getBaseParticles().registerExtraDeviceMemory();
     fluid_observer_contact.allocateContactConfiguration();
     fluid_observer_contact.copyContactConfigurationToDevice();    
 
@@ -159,7 +158,6 @@ int main(int ac, char *av[])
         {
             /** outer loop for dual-time criteria time-stepping. */
             water_block.getBaseParticles().copyToDeviceMemory();
-            water_block.getBaseParticles().copyToExtraDeviceMemory();
             water_block_complex.getInnerRelation().copyInnerConfigurationToDevice();
             water_block_complex.getContactRelation().copyContactConfigurationToDevice();
 
@@ -169,7 +167,6 @@ int main(int ac, char *av[])
             fluid_density_by_summation.exec();
 
             water_block.getBaseParticles().copyFromDeviceMemory();
-            water_block.getBaseParticles().copyFromExtraDeviceMemory();
             water_block_complex.getInnerRelation().copyInnerConfigurationFromDevice();
             water_block_complex.getContactRelation().copyContactConfigurationFromDevice();
 
@@ -183,13 +180,11 @@ int main(int ac, char *av[])
                 /** inner loop for dual-time criteria time-stepping.  */
 
                 water_block.getBaseParticles().copyToDeviceMemory();
-                water_block.getBaseParticles().copyToExtraDeviceMemory();
 
                 acoustic_dt = fluid_acoustic_time_step.exec();
                 fluid_pressure_relaxation.exec(acoustic_dt);
 
                 water_block.getBaseParticles().copyFromDeviceMemory();
-                water_block.getBaseParticles().copyFromExtraDeviceMemory();
 
                 fluid_density_relaxation.exec(acoustic_dt);
                 relaxation_time += acoustic_dt;
@@ -230,7 +225,6 @@ int main(int ac, char *av[])
     }
 
     water_block.getBaseParticles().copyFromDeviceMemory();
-    water_block.getBaseParticles().copyFromExtraDeviceMemory();
 
     TickCount t4 = TickCount::now();
 

--- a/tests/2d_examples/test_2d_sycl_performance/Performance.cpp
+++ b/tests/2d_examples/test_2d_sycl_performance/Performance.cpp
@@ -140,7 +140,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Main loop benchmarks
     //----------------------------------------------------------------------
-    std::cout << "Number of particles: " << water_block.getBaseParticles().pos_.size() << std::endl;
+    std::cout << "Number of particles: " << water_block_sycl.getBaseParticles().total_real_particles_ << std::endl;
 
     std::size_t iterations = 2000;
     std::cout << "Number of iterations per test: " << iterations << std::endl;

--- a/tests/2d_examples/test_2d_sycl_performance/Performance.cpp
+++ b/tests/2d_examples/test_2d_sycl_performance/Performance.cpp
@@ -50,11 +50,11 @@ Vec2d inner_wall_translation = inner_wall_halfsize;
 class WallBoundary : public ComplexShape
 {
 public:
-	explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
-	{
-		add<TransformShape<GeometricShapeBox>>(Transform2d(outer_wall_translation), outer_wall_halfsize);
-		subtract<TransformShape<GeometricShapeBox>>(Transform2d(inner_wall_translation), inner_wall_halfsize);
-	}
+    explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
+    {
+        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+    }
 };
 //----------------------------------------------------------------------
 //	Main program starts here.
@@ -70,16 +70,16 @@ int main(int ac, char *av[])
 	//----------------------------------------------------------------------
 	//	Creating bodies with corresponding materials and particles.
 	//----------------------------------------------------------------------
-	FluidBody water_block(
-		sph_system, makeShared<TransformShape<GeometricShapeBox>>(
-						Transform2d(water_block_translation), water_block_halfsize, "WaterBody"));
-	water_block.defineParticlesAndMaterial<FluidParticles, WeaklyCompressibleFluid>(rho0_f, c_f);
-	water_block.generateParticles<ParticleGeneratorLattice>();
+    FluidBody water_block(
+            sph_system, makeShared<TransformShape<GeometricShapeBox>>(
+                    Transform(water_block_translation), water_block_halfsize, "WaterBody"));
+    water_block.defineParticlesAndMaterial<BaseParticles, WeaklyCompressibleFluid>(rho0_f, c_f);
+    water_block.generateParticles<ParticleGeneratorLattice>();
 
     FluidBody water_block_sycl(
             sph_system, makeShared<TransformShape<GeometricShapeBox>>(
-                    Transform2d(water_block_translation), water_block_halfsize, "WaterBody"));
-    water_block_sycl.defineParticlesAndMaterial<FluidParticles, WeaklyCompressibleFluid>(rho0_f, c_f);
+                    Transform(water_block_translation), water_block_halfsize, "WaterBody"));
+    water_block_sycl.defineParticlesAndMaterial<BaseParticles, WeaklyCompressibleFluid>(rho0_f, c_f);
     water_block_sycl.generateParticles<ParticleGeneratorLattice>();
 
 	SolidBody wall_boundary(sph_system, makeShared<WallBoundary>("WallBoundary"));

--- a/tests/2d_examples/test_2d_sycl_performance/Performance.cpp
+++ b/tests/2d_examples/test_2d_sycl_performance/Performance.cpp
@@ -99,12 +99,6 @@ int main(int ac, char *av[])
 	ComplexRelation water_block_complex(water_block, {&wall_boundary});
 	ComplexRelation water_block_complex_sycl(water_block_sycl, {&wall_boundary_sycl});
 
-    TickCount timer_mem = TickCount::now();
-    water_block_sycl.getBaseParticles().registerExtraDeviceMemory();
-    TimeInterval tt_mem = TickCount::now() - timer_mem;
-
-    water_block.getBaseParticles().registerExtraDeviceMemory();
-
     SharedPtr<Gravity> gravity_ptr = makeSharedDevice<Gravity>(Vecd(0.0, -gravity_g));
 
     Dynamics1Level<fluid_dynamics::Integration1stHalfRiemannWithWall, ParallelSYCLDevicePolicy> fluid_pressure_relaxation_sycl(water_block_complex_sycl);
@@ -128,12 +122,11 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Copy data to device
     //----------------------------------------------------------------------
-    timer_mem = TickCount::now();
+    TickCount timer_mem = TickCount::now();
     water_block_sycl.getBaseParticles().copyToDeviceMemory();
-    water_block_sycl.getBaseParticles().copyToExtraDeviceMemory();
     water_block_complex_sycl.getInnerRelation().copyInnerConfigurationToDevice();
     water_block_complex_sycl.getContactRelation().copyContactConfigurationToDevice();
-    tt_mem += TickCount::now() - timer_mem;
+    TimeInterval tt_mem = TickCount::now() - timer_mem;
 
     executionQueue.setWorkGroupSize(32);
 


### PR DESCRIPTION
- Device memory is now allocated inside a data container assemble, as for other particle variables.
- Usage to `FluidParticles` has been changed to `BaseParticles`, and `getDeviceVariableByName` is used to pass address pointers to kernel classes.
- `DataTypeIndex` has been updated to include device types, which are only enabled if they are different from normal host types (using a new template parameter `Enable` for SFINAE instructions)
- `DeviceVariable` is a new data container type that manages device memory
- ~Variables that are only relevant to fluids (like Pressure, DensityChangeRate, and DensitySummation) are allocated with `BaseParticles::registerExtraDeviceMemory()`. This is a temporary solution; this task should be delegated to those classes that register their host counterparts, which should also be responsible to register the corresponding device variables.~ ([See comment below](https://github.com/Xiangyu-Hu/SPHinXsys/pull/366#issuecomment-1632950737))

Dambreak and Performance (benchmark) have been updated and can be run to test convergence and speedup, respectively.