### PR TITLE
[SYCL] Fluid density relaxation

### DIFF
--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.h
@@ -384,18 +384,81 @@ class BaseExtendIntegration1stHalfWithWall : public BaseIntegration1stHalfWithWa
 
 using ExtendIntegration1stHalfRiemannWithWall = BaseExtendIntegration1stHalfWithWall<Integration1stHalfRiemann>;
 
+
+template <class BaseIntegration2ndHalfType>
+class BaseIntegration2ndHalfWithWallKernel : public BaseIntegration2ndHalfType {
+  public:
+    template<class ...BaseArgs>
+    BaseIntegration2ndHalfWithWallKernel(StdSharedVec<NeighborhoodDevice*> &contact_configuration,
+                                         DeviceVecd** wall_vel_ave, DeviceVecd** wall_n, BaseArgs&& ...args) :
+            BaseIntegration2ndHalfType(args...),
+            contact_configuration_(contact_configuration),
+            wall_vel_ave_(wall_vel_ave), wall_n_(wall_n) {}
+
+    template<class RealType, class VecType, class RiemannSolver, class WallNeighborhoodFunc,
+             class WallVelAveFunc, class WallNormalFunc, class DotFunc>
+    static void interaction(size_t index_i, Real dt, RealType *rho, RealType *drho_dt, VecType* vel, VecType *acc,
+                            RiemannSolver& riemann_solver, std::size_t contact_configuration_size,
+                            WallVelAveFunc&& getWallVelAve, WallNormalFunc&& getWallNormal,
+                            WallNeighborhoodFunc&& getWallNeighborhood, DotFunc&& dot) {
+        RealType density_change_rate{0};
+        auto p_dissipation = VecdZero<VecType>();
+        for (size_t k = 0; k < contact_configuration_size; ++k)
+        {
+            VecType *vel_ave_k = getWallVelAve(k);
+            VecType *n_k = getWallNormal(k);
+            const auto &wall_neighborhood = getWallNeighborhood(k, index_i);
+            for (size_t n = 0; n != wall_neighborhood.current_size(); ++n)
+            {
+                const auto &index_j = wall_neighborhood.j_[n];
+                const auto &e_ij = wall_neighborhood.e_ij_[n];
+                const auto &dW_ijV_j = wall_neighborhood.dW_ijV_j_[n];
+
+                const VecType vel_in_wall = static_cast<RealType>(2.0) * vel_ave_k[index_j] - vel[index_i];
+                density_change_rate += dot(vel[index_i] - vel_in_wall, e_ij) * dW_ijV_j;
+                const RealType u_jump = static_cast<RealType>(2.0) * dot(vel[index_i] - vel_ave_k[index_j], n_k[index_j]);
+                p_dissipation += static_cast<RealType>(riemann_solver.DissipativePJump(u_jump)) * dW_ijV_j * n_k[index_j];
+            }
+        }
+        drho_dt[index_i] += density_change_rate * rho[index_i];
+        acc[index_i] += p_dissipation / rho[index_i];
+    }
+
+    void interaction(size_t index_i, Real dt = 0.0) {
+        BaseIntegration2ndHalfType::interaction(index_i, dt);
+
+        interaction(index_i, dt, this->rho_, this->drho_dt_, this->vel_, this->acc_, this->riemann_solver_,
+                    contact_configuration_.size(), [&](auto k){ return this->wall_vel_ave_[k]; },
+                    [&](auto k){ return this->wall_n_[k]; },
+                    [&](auto k, auto index_i) -> const NeighborhoodDevice&
+                        { return this->contact_configuration_[k][index_i]; },
+                    [](const DeviceVecd& v1, const DeviceVecd& v2) { return sycl::dot(v1, v2); });
+    }
+  private:
+    StdSharedVec<NeighborhoodDevice*> &contact_configuration_;
+    DeviceVecd **wall_vel_ave_, **wall_n_;
+};
+
+
 /**
  * @class BaseIntegration2ndHalfWithWall
  * @brief template density relaxation scheme without using different Riemann solvers.
  * The difference from the free surface version is that no Riemann problem is applied
  */
 template <class BaseIntegration2ndHalfType>
-class BaseIntegration2ndHalfWithWall : public InteractionWithWall<BaseIntegration2ndHalfType>
+class BaseIntegration2ndHalfWithWall : public InteractionWithWall<BaseIntegration2ndHalfType>,
+   public DeviceExecutable<BaseIntegration2ndHalfWithWall<BaseIntegration2ndHalfType>,
+                           BaseIntegration2ndHalfWithWallKernel<typename BaseIntegration2ndHalfType::DeviceKernel>>
 {
   public:
     template <typename... Args>
     BaseIntegration2ndHalfWithWall(Args &&...args)
-        : InteractionWithWall<BaseIntegration2ndHalfType>(std::forward<Args>(args)...){};
+        : InteractionWithWall<BaseIntegration2ndHalfType>(std::forward<Args>(args)...),
+          DeviceExecutable<BaseIntegration2ndHalfWithWall<BaseIntegration2ndHalfType>,
+                  BaseIntegration2ndHalfWithWallKernel<typename BaseIntegration2ndHalfType::DeviceKernel>>(this,
+                    *this->contact_configuration_device_, this->wall_vel_ave_device_.data(),
+                    this->wall_n_device_.data(), BaseIntegration2ndHalfType::particles_,
+                    BaseIntegration2ndHalfType::inner_configuration_device_->data(), this->riemann_solver_) {};
     virtual ~BaseIntegration2ndHalfWithWall(){};
 
     inline void interaction(size_t index_i, Real dt = 0.0);

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.hpp
@@ -312,27 +312,14 @@ void BaseIntegration2ndHalfWithWall<BaseIntegration2ndHalfType>::
 {
     BaseIntegration2ndHalfType::interaction(index_i, dt);
 
-    Real density_change_rate = 0.0;
-    Vecd p_dissipation = Vecd::Zero();
-    for (size_t k = 0; k < FluidWallData::contact_configuration_.size(); ++k)
-    {
-        StdLargeVec<Vecd> &vel_ave_k = *(this->wall_vel_ave_[k]);
-        StdLargeVec<Vecd> &n_k = *(this->wall_n_[k]);
-        Neighborhood &wall_neighborhood = (*FluidWallData::contact_configuration_[k])[index_i];
-        for (size_t n = 0; n != wall_neighborhood.current_size_; ++n)
-        {
-            size_t index_j = wall_neighborhood.j_[n];
-            Vecd &e_ij = wall_neighborhood.e_ij_[n];
-            Real dW_ijV_j = wall_neighborhood.dW_ijV_j_[n];
-
-            Vecd vel_in_wall = 2.0 * vel_ave_k[index_j] - this->vel_[index_i];
-            density_change_rate += (this->vel_[index_i] - vel_in_wall).dot(e_ij) * dW_ijV_j;
-            Real u_jump = 2.0 * (this->vel_[index_i] - vel_ave_k[index_j]).dot(n_k[index_j]);
-            p_dissipation += this->riemann_solver_.DissipativePJump(u_jump) * dW_ijV_j * n_k[index_j];
-        }
-    }
-    this->drho_dt_[index_i] += density_change_rate * this->rho_[index_i];
-    this->acc_[index_i] += p_dissipation / this->rho_[index_i];
+    BaseIntegration2ndHalfWithWallKernel<typename BaseIntegration2ndHalfType::DeviceKernel>::interaction(
+            index_i, dt, this->rho_.data(), this->drho_dt_.data(), this->vel_.data(), this->acc_.data(),
+            this->riemann_solver_, FluidWallData::contact_configuration_.size(),
+            [&](auto k){ return this->wall_vel_ave_[k]->data(); },
+            [&](auto k){ return this->wall_n_[k]->data(); },
+            [&](auto k, auto index_i) -> const Neighborhood&
+            { return (*FluidWallData::contact_configuration_[k])[index_i]; },
+            [](const Vecd& v1, const Vecd& v2){ return v1.dot(v2); });
 }
 //=================================================================================================//
 } // namespace fluid_dynamics

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.hpp
@@ -217,20 +217,8 @@ template <class RiemannSolverType>
 void BaseIntegration1stHalf<RiemannSolverType>::
     interaction(size_t index_i, Real dt)
 {
-    Vecd acceleration = Vecd::Zero();
-    Real rho_dissipation(0);
-    const Neighborhood &inner_neighborhood = inner_configuration_[index_i];
-    for (size_t n = 0; n != inner_neighborhood.current_size_; ++n)
-    {
-        size_t index_j = inner_neighborhood.j_[n];
-        Real dW_ijV_j = inner_neighborhood.dW_ijV_j_[n];
-        const Vecd &e_ij = inner_neighborhood.e_ij_[n];
-
-        acceleration -= (p_[index_i] + p_[index_j]) * dW_ijV_j * e_ij;
-        rho_dissipation += riemann_solver_.DissipativeUJump(p_[index_i] - p_[index_j]) * dW_ijV_j;
-    }
-    acc_[index_i] += acceleration / rho_[index_i];
-    drho_dt_[index_i] = rho_dissipation * rho_[index_i];
+    DeviceKernel::interaction(index_i, dt, p_.data(), rho_.data(), drho_dt_.data(), acc_.data(),
+                              inner_configuration_.data(), riemann_solver_);
 }
 //=================================================================================================//
 template <class RiemannSolverType>
@@ -241,35 +229,22 @@ BaseIntegration2ndHalf<RiemannSolverType>::BaseIntegration2ndHalf(BaseInnerRelat
 template <class RiemannSolverType>
 void BaseIntegration2ndHalf<RiemannSolverType>::initialization(size_t index_i, Real dt)
 {
-    pos_[index_i] += vel_[index_i] * dt * 0.5;
+    DeviceKernel::initialization(index_i, dt, pos_.data(), vel_.data());
 }
 //=================================================================================================//
 template <class RiemannSolverType>
 void BaseIntegration2ndHalf<RiemannSolverType>::update(size_t index_i, Real dt)
 {
-    rho_[index_i] += drho_dt_[index_i] * dt * 0.5;
-    Vol_[index_i] = mass_[index_i] / rho_[index_i];
+    DeviceKernel::update(index_i, dt, rho_.data(), drho_dt_.data(), Vol_.data(), mass_.data());
 }
 //=================================================================================================//
 template <class RiemannSolverType>
 void BaseIntegration2ndHalf<RiemannSolverType>::
     interaction(size_t index_i, Real dt)
 {
-    Real density_change_rate(0);
-    Vecd p_dissipation = Vecd::Zero();
-    const Neighborhood &inner_neighborhood = inner_configuration_[index_i];
-    for (size_t n = 0; n != inner_neighborhood.current_size_; ++n)
-    {
-        size_t index_j = inner_neighborhood.j_[n];
-        const Vecd &e_ij = inner_neighborhood.e_ij_[n];
-        Real dW_ijV_j = inner_neighborhood.dW_ijV_j_[n];
-
-        Real u_jump = (vel_[index_i] - vel_[index_j]).dot(e_ij);
-        density_change_rate += u_jump * dW_ijV_j;
-        p_dissipation += riemann_solver_.DissipativePJump(u_jump) * dW_ijV_j * e_ij;
-    }
-    drho_dt_[index_i] += density_change_rate * rho_[index_i];
-    acc_[index_i] = p_dissipation / rho_[index_i];
+    DeviceKernel::interaction(index_i, dt, rho_.data(), drho_dt_.data(), vel_.data(),
+                              acc_.data(), inner_configuration_.data(), riemann_solver_,
+                              [](const Vecd& v1, const Vecd& v2) { return v1.dot(v2); });
 };
 //=================================================================================================//
 } // namespace fluid_dynamics

--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -375,6 +375,7 @@ void BaseParticles::readFromXmlForReloadParticle(std::string &filefullpath)
         registerDeviceVariable<DeviceVecd>("AccelerationPrior", total_real_particles_, acc_prior_.data());
         registerDeviceVariable<DeviceReal>("Density", total_real_particles_, rho_.data());
         registerDeviceVariable<DeviceReal>("Mass", total_real_particles_, mass_.data());
+        registerDeviceVariable<DeviceReal>("Volume", total_real_particles_, Vol_.data());
     }
 
     void BaseParticles::copyToDeviceMemory() {
@@ -384,6 +385,7 @@ void BaseParticles::readFromXmlForReloadParticle(std::string &filefullpath)
         copyDataToDevice(acc_prior_.data(), getDeviceVariableByName<DeviceVecd>("AccelerationPrior"), total_real_particles_);
         copyDataToDevice(rho_.data(), getDeviceVariableByName<DeviceReal>("Density"), total_real_particles_);
         copyDataToDevice(mass_.data(), getDeviceVariableByName<DeviceReal>("Mass"), total_real_particles_);
+        copyDataToDevice(Vol_.data(), getDeviceVariableByName<DeviceReal>("Volume"), total_real_particles_);
     }
 
     void BaseParticles::copyFromDeviceMemory() {
@@ -393,6 +395,7 @@ void BaseParticles::readFromXmlForReloadParticle(std::string &filefullpath)
         copyDataFromDevice(acc_prior_.data(), getDeviceVariableByName<DeviceVecd>("AccelerationPrior"), total_real_particles_);
         copyDataFromDevice(rho_.data(), getDeviceVariableByName<DeviceReal>("Density"), total_real_particles_);
         copyDataFromDevice(mass_.data(), getDeviceVariableByName<DeviceReal>("Mass"), total_real_particles_);
+        copyDataFromDevice(Vol_.data(), getDeviceVariableByName<DeviceReal>("Volume"), total_real_particles_);
     }
 //=================================================================================================//
 } // namespace SPH


### PR DESCRIPTION
- Implemented `BaseIntegration2ndHalfWithWalll` kernel class to enable device execution of density relaxation

Here is the benchmark results with 80'000 particles:

```
SYCL fluid_density_relaxation computation: 0.27803 seconds
Reference fluid_density_relaxation computation: 13.0099 seconds
Speedup fluid_density_relaxation (main loop): 46.793x
```