### PR TITLE
Split Linux CI job into build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         run: cmake --build build --config Release --verbose
 
   ###############################################################################   
-  Linux-double:
+  Linux-build:
     runs-on: ubuntu-22.04
     env:
       VCPKG_DEFAULT_TRIPLET: x64-linux
@@ -146,6 +146,62 @@ jobs:
             
       - name: Build using double
         run: cmake --build build --config Release --verbose
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Linux-build
+          path: ${{github.workspace}}/build
+          if-no-files-found: error
+          retention-days: 1
+
+  Linux-test:
+    needs: Linux-build
+    runs-on: ubuntu-22.04
+    env:
+      VCPKG_DEFAULT_TRIPLET: x64-linux
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install system dependencies
+        run: |
+          sudo apt update 
+          sudo apt install -y \
+            apt-utils \
+            build-essential \
+            curl zip unzip tar `# when starting fresh on a WSL image for bootstrapping vcpkg`\
+            pkg-config `# for installing libraries with vcpkg`\
+            git \
+            cmake \
+            ninja-build \
+            libfontconfig1-dev `# From here required for vcpkg opencascade`\
+            libx11-dev \
+            libgl-dev
+
+      - uses: friendlyanon/setup-vcpkg@v1 # Setup vcpkg into ${{github.workspace}}
+        with: 
+          committish: ${{ env.VCPKG_VERSION }}
+          cache-version: ${{env.VCPKG_VERSION}}
+
+      - name: Install dependencies
+        run: |
+          ${{github.workspace}}/vcpkg/vcpkg install --clean-after-build openblas[dynamic-arch] --allow-unsupported # last argument to remove after regression introduced by microsoft/vcpkg#30192 is addressed
+          # Simbody depends on (open)blas implementation, which -march=native by default, conflicting with cache restore, hence dynamic-arch feature
+          # Above problem might also be resolved by adding the hash of architecture in the cache key, esp. if more package do the same
+          ${{github.workspace}}/vcpkg/vcpkg install --clean-after-build \
+            eigen3 \
+            tbb \
+            boost-program-options \
+            boost-geometry \
+            simbody \
+            gtest \
+            xsimd \
+            pybind11 \
+            opencascade
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: Linux-build
 
       - name: Test with the first try
         id: first-try

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,10 +147,13 @@ jobs:
       - name: Build using double
         run: cmake --build build --config Release --verbose
 
+      - name: Zip build folder
+        run: zip -r build.zip ${{github.workspace}}/build
+
       - uses: actions/upload-artifact@v3
         with:
           name: Linux-build
-          path: ${{github.workspace}}/build
+          path: ${{github.workspace}}/build.zip
           if-no-files-found: error
           retention-days: 1
 
@@ -202,6 +205,9 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: Linux-build
+
+      - name: Unzip build folder
+        run: unzip build.zip
 
       - name: Test with the first try
         id: first-try

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         run: cmake --build build --config Release --verbose
 
       - name: Zip build folder
-        run: zip -r build.zip ${{github.workspace}}/build
+        run: zip -r build.zip ./build
 
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
It is using the Upload/Download artifacts GitHub Actions to share the build folder between jobs. The minimum retention days is 24hr, which might be too much depending on the number of PR with respect to the free quota. 

If the artifacts quota is effectively becoming a problem, further  actions will be required:
1. Deleting the artefacts (e.g. [delete-run-artifacts](https://github.com/marketplace/actions/delete-run-artifacts) or [purge-artifacts](https://github.com/marketplace/actions/purge-artifacts))
2. Make sphinxsys properly installable to reduce the artefacts size