### PR TITLE
Clarify the small rotation of shell formulation.

### DIFF
--- a/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.h
+++ b/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.h
@@ -231,7 +231,7 @@ class ShellStressRelaxationFirstHalf : public BaseShellRelaxation
 
         /** the relation between pseudo-normal and rotations */
         Vecd local_dpseudo_n_d2t = transformation_matrix_[index_i] * dpseudo_n_d2t_[index_i];
-        dangular_vel_dt_[index_i] = getRotationFromPseudoNormalForFiniteDeformation(local_dpseudo_n_d2t, rotation_[index_i], angular_vel_[index_i], dt);
+        dangular_vel_dt_[index_i] = getRotationFromPseudoNormal(local_dpseudo_n_d2t, rotation_[index_i], angular_vel_[index_i], dt);
     };
 
     void update(size_t index_i, Real dt = 0.0);

--- a/src/shared/particle_dynamics/solid_dynamics/thin_structure_math.cpp
+++ b/src/shared/particle_dynamics/solid_dynamics/thin_structure_math.cpp
@@ -63,7 +63,7 @@ Vec3d getVectorChangeRateAfterThinStructureRotation(const Vec3d &initial_vector,
     return Vec3d(dpseudo_n_dt_0, dpseudo_n_dt_1, dpseudo_n_dt_2);
 }
 //=================================================================================================//
-Vec2d getRotationFromPseudoNormalForFiniteDeformation(const Vec2d &dpseudo_n_d2t, const Vec2d &rotation, const Vec2d &angular_vel, Real dt)
+Vec2d getRotationFromPseudoNormal(const Vec2d &dpseudo_n_d2t, const Vec2d &rotation, const Vec2d &angular_vel, Real dt)
 {
     Real cos_rotation_0 = cos(rotation[0]);
     Real sin_rotation_0 = sin(rotation[0]);
@@ -73,7 +73,7 @@ Vec2d getRotationFromPseudoNormalForFiniteDeformation(const Vec2d &dpseudo_n_d2t
     return Vec2d(angle_vel_dt_0, 0.0);
 }
 //=================================================================================================//
-Vec3d getRotationFromPseudoNormalForFiniteDeformation(const Vec3d &dpseudo_n_d2t, const Vec3d &rotation, const Vec3d &angular_vel, Real dt)
+Vec3d getRotationFromPseudoNormal(const Vec3d &dpseudo_n_d2t, const Vec3d &rotation, const Vec3d &angular_vel, Real dt)
 {
     Real sin_rotation_0 = sin(rotation[0]);
     Real cos_rotation_0 = cos(rotation[0]);
@@ -90,16 +90,6 @@ Vec3d getRotationFromPseudoNormalForFiniteDeformation(const Vec3d &dpseudo_n_d2t
     Real angle_vel_dt_1 = rotation_1_a * rotation_1_a * (rotation_1_b1 * cos_rotation_1 + rotation_1_b2 * sin_rotation_1) / (rotation_1_b1 * rotation_1_b1 + rotation_1_b2 * rotation_1_b2 + Eps);
 
     return Vec3d(angle_vel_dt_0, angle_vel_dt_1, 0.0);
-}
-//=================================================================================================//
-Vec2d getRotationFromPseudoNormalForSmallDeformation(const Vec2d &dpseudo_n_d2t, const Vec2d &rotation, const Vec2d &angular_vel, Real dt)
-{
-    return Vec2d(dpseudo_n_d2t[0], 0);
-}
-//=================================================================================================//
-Vec3d getRotationFromPseudoNormalForSmallDeformation(const Vec3d &dpseudo_n_d2t, const Vec3d &rotation, const Vec3d &angular_vel, Real dt)
-{
-    return Vec3d(-dpseudo_n_d2t[1], dpseudo_n_d2t[0], 0.0);
 }
 //=================================================================================================//
 Vec2d getNormalFromDeformationGradientTensor(const Mat2d &F)

--- a/src/shared/particle_dynamics/solid_dynamics/thin_structure_math.h
+++ b/src/shared/particle_dynamics/solid_dynamics/thin_structure_math.h
@@ -52,12 +52,8 @@ Vec2d getVectorChangeRateAfterThinStructureRotation(const Vec2d &initial_vector,
 Vec3d getVectorChangeRateAfterThinStructureRotation(const Vec3d &initial_vector, const Vec3d &rotation_angles, const Vec3d &angular_vel);
 
 /** get the rotation from pseudo-normal for finite deformation. */
-Vec2d getRotationFromPseudoNormalForFiniteDeformation(const Vec2d &dpseudo_n_d2t, const Vec2d &rotation, const Vec2d &angular_vel, Real dt);
-Vec3d getRotationFromPseudoNormalForFiniteDeformation(const Vec3d &dpseudo_n_d2t, const Vec3d &rotation, const Vec3d &angular_vel, Real dt);
-
-/** get the rotation from pseudo-normal for small deformation. */
-Vec2d getRotationFromPseudoNormalForSmallDeformation(const Vec2d &dpseudo_n_d2t, const Vec2d &rotation, const Vec2d &angular_vel, Real dt);
-Vec3d getRotationFromPseudoNormalForSmallDeformation(const Vec3d &dpseudo_n_d2t, const Vec3d &rotation, const Vec3d &angular_vel, Real dt);
+Vec2d getRotationFromPseudoNormal(const Vec2d &dpseudo_n_d2t, const Vec2d &rotation, const Vec2d &angular_vel, Real dt);
+Vec3d getRotationFromPseudoNormal(const Vec3d &dpseudo_n_d2t, const Vec3d &rotation, const Vec3d &angular_vel, Real dt);
 
 /** get the current normal direction from deformation gradient tensor. */
 Vec2d getNormalFromDeformationGradientTensor(const Mat2d &F);


### PR DESCRIPTION
Since there are two different formulations of shell (the original exsited one and the one @rukawaaaaaaa proposed), 
I delete the original code of small rotation to avoid misunderstanding. 

The original formulation is based on initial configuration, while the one @rukawaaaaaaa proposed is based on current configuration and then is transformed to initial configuration. 

The original code of small rotation is applicable only when the rotation is small. 