### PR TITLE
Thermal diffusion refactoring. 

### DIFF
--- a/src/shared/materials/contact_diffusivity.h
+++ b/src/shared/materials/contact_diffusivity.h
@@ -1,0 +1,102 @@
+/* ------------------------------------------------------------------------- *
+ *                                SPHinXsys                                  *
+ * ------------------------------------------------------------------------- *
+ * SPHinXsys (pronunciation: s'finksis) is an acronym from Smoothed Particle *
+ * Hydrodynamics for industrial compleX systems. It provides C++ APIs for    *
+ * physical accurate simulation and aims to model coupled industrial dynamic *
+ * systems including fluid, solid, multi-body dynamics and beyond with SPH   *
+ * (smoothed particle hydrodynamics), a meshless computational method using  *
+ * particle discretization.                                                  *
+ *                                                                           *
+ * SPHinXsys is partially funded by German Research Foundation               *
+ * (Deutsche Forschungsgemeinschaft) DFG HU1527/6-1, HU1527/10-1,            *
+ *  HU1527/12-1 and HU1527/12-4.                                             *
+ *                                                                           *
+ * Portions copyright (c) 2017-2023 Technical University of Munich and       *
+ * the authors' affiliations.                                                *
+ *                                                                           *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may   *
+ * not use this file except in compliance with the License. You may obtain a *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.        *
+ *                                                                           *
+ * ------------------------------------------------------------------------- */
+/**
+ * @file 	  contact_diffusivity.h
+ * @brief 	This is the collection of handling the thermal diffusivity, 
+ *          viz. a = k / rho/ c (https://en.wikipedia.org/wiki/Thermal_diffusivity), 
+ *          at the particle interface, where different 
+ *          materials are involved. 
+ * @author	Chi Zhang
+ */
+
+#ifndef CONTACT_DIFFUSIVITY_H
+#define CONTACT_DIFFUSIVITY_H
+
+#include "base_data_package.h"
+#include "diffusion_reaction.h"
+
+namespace SPH
+{
+    /**
+     * @struct IsotropicContactDiffusivity
+     * @brief  Isotropic thermal diffusivity between different materials. 
+     */
+    template<class DiffusionType>
+    class ContactDiffusivity
+    {
+    public:
+        ContactDiffusivity(DiffusionType &diffusion_i, DiffusionType &diffusion_j){};
+        virtual ~ContactDiffusivity(){};
+    };
+
+    template<>
+    class ContactDiffusivity<BaseDiffusion>
+    {
+    public:
+        ContactDiffusivity(BaseDiffusion &diffusion_i, BaseDiffusion &diffusion_j){};
+        virtual ~ContactDiffusivity(){};
+
+        Real getContactDiffusivity(size_t particle_i, size_t particle_j, const Vecd &r_ij){return 0;};
+    };
+
+    template<>
+    class ContactDiffusivity<IsotropicDiffusion>
+    {
+    public:
+        ContactDiffusivity(IsotropicDiffusion &diffusion_i, IsotropicDiffusion &diffusion_j)
+        {
+            contact_diff_cf_ = 2.0 * diffusion_i.getReferenceDiffusivity()  * diffusion_j.getReferenceDiffusivity() 
+                                    / (diffusion_i.getReferenceDiffusivity()  + diffusion_j.getReferenceDiffusivity()) ;
+        };
+        virtual ~ContactDiffusivity(){};
+
+        Real getContactDiffusivity(size_t particle_i, size_t particle_j, const Vecd &r_ij)
+        {
+            return contact_diff_cf_;
+        };
+
+    private:
+        Real contact_diff_cf_;   /**< contact diffusion coefficient 2 * diff_cf__i * diff_cf__j / (diff_cf__i + diff_cf__j). */
+    };
+    
+    template<>
+    class ContactDiffusivity<IsotropicThermalDiffusion>
+    {
+    public:
+        ContactDiffusivity(IsotropicThermalDiffusion &diffusion_i, IsotropicThermalDiffusion &diffusion_j)
+        {
+            contact_diffusivity_ = 2.0 * diffusion_i.getThermalConductivity()  * diffusion_j.getThermalConductivity() 
+                                    / ( diffusion_i.getThermalConductivity()  + diffusion_j.getThermalConductivity() ) ;
+        };
+        virtual ~ContactDiffusivity(){};
+
+        Real getContactDiffusivity(size_t particle_i, size_t particle_j, const Vecd &r_ij)
+        {
+            return contact_diffusivity_;
+        };
+        
+    private:
+        Real contact_diffusivity_;   /**< contact thermal diffusivity 2 * k_i * k_j / (k_i + k_j) . */
+    };
+}       // namespace SPH
+#endif  //CONTACT_DIFFUSIVITY

--- a/src/shared/materials/diffusion_reaction.cpp
+++ b/src/shared/materials/diffusion_reaction.cpp
@@ -3,39 +3,40 @@
 
 namespace SPH
 {
-//=================================================================================================//
-void LocalIsotropicDiffusion::initializeLocalParameters(BaseParticles* base_particles)
-{
-    base_particles->registerVariable(local_thermal_conductivity_, "ThermalConductivity", [&](size_t i) -> Real {return diff_cf_; });
-    base_particles->addVariableToWrite<Real>("ThermalConductivity");
-}
-//=================================================================================================//
-void DirectionalDiffusion::initializeDirectionalDiffusivity(Real diff_cf, Real bias_diff_cf, Vecd bias_direction)
-{
-    bias_diff_cf_ = bias_diff_cf;
-    bias_direction_ = bias_direction;
-    Matd diff_i = diff_cf_ * Matd::Identity() + bias_diff_cf_ * bias_direction_ * bias_direction_.transpose();
-    transformed_diffusivity_ = inverseCholeskyDecomposition(diff_i);
-};
-//=================================================================================================//
-void LocalDirectionalDiffusion::registerReloadLocalParameters(BaseParticles *base_particles)
-{
-    base_particles->registerVariable(local_bias_direction_, "Fiber");
-    base_particles->addVariableToReload<Vecd>("Fiber");
-}
-//=================================================================================================//
-void LocalDirectionalDiffusion::initializeLocalParameters(BaseParticles *base_particles)
-{
-    DirectionalDiffusion::initializeLocalParameters(base_particles);
-    base_particles->registerVariable(
-        local_transformed_diffusivity_, "LocalTransformedDiffusivity",
-        [&](size_t i) -> Matd
-        {
-            Matd diff_i = diff_cf_ * Matd::Identity() + bias_diff_cf_ * local_bias_direction_[i] * local_bias_direction_[i].transpose();
-            return inverseCholeskyDecomposition(diff_i);
-        });
+    //=================================================================================================//
+    void LocalIsotropicThermalDiffusion::initializeLocalParameters(BaseParticles* base_particles)
+    {
+        base_particles->registerVariable(local_thermal_conductivity_, "ThermalConductivity", [&](size_t i) -> Real {return thermal_conductivity_; });
+        base_particles->addVariableToWrite<Real>("ThermalConductivity");
+    }
+    //=================================================================================================//
+    void DirectionalDiffusion::initializeDirectionalDiffusivity(Real diff_cf, Real bias_diff_cf, Vecd bias_direction)
+    {
+        bias_diff_cf_ = bias_diff_cf;
+        bias_direction_ = bias_direction;
+        Matd diff_i = diff_cf_ * Matd::Identity() + bias_diff_cf_ * bias_direction_ * bias_direction_.transpose();
+        transformed_diffusivity_ = inverseCholeskyDecomposition(diff_i);
+    };
+    //=================================================================================================//
+    void LocalDirectionalDiffusion::registerReloadLocalParameters(BaseParticles *base_particles)
+    {
+        base_particles->registerVariable(local_bias_direction_, "Fiber");
+        base_particles->addVariableToReload<Vecd>("Fiber");
+    }
+    //=================================================================================================//
+    void LocalDirectionalDiffusion::initializeLocalParameters(BaseParticles *base_particles)
+    {
+        DirectionalDiffusion::initializeLocalParameters(base_particles);
+        base_particles->registerVariable(
+            local_transformed_diffusivity_, "LocalTransformedDiffusivity",
+            [&](size_t i) -> Matd
+            {
+                Matd diff_i = diff_cf_ * Matd::Identity() + bias_diff_cf_ * local_bias_direction_[i] * local_bias_direction_[i].transpose();
+                return inverseCholeskyDecomposition(diff_i);
+            });
 
-    std::cout << "\n Local diffusion parameters setup finished " << std::endl;
-};
+        std::cout << "\n Local diffusion parameters setup finished " << std::endl;
+    };
 //=================================================================================================//
 } // namespace SPH
+

--- a/src/shared/materials/diffusion_reaction.h
+++ b/src/shared/materials/diffusion_reaction.h
@@ -26,6 +26,7 @@
  *          the dynamics is characterized by diffusion equation and reactive source terms.
  *			Typical physical processes are diffusion, heat conduction
  *			and chemical and biological reactions.
+ * @author	Chi Zhang and Xiangyu Hu
  */
 
 #ifndef DIFFUSION_REACTION_H
@@ -39,312 +40,355 @@ using namespace std::placeholders;
 
 namespace SPH
 {
-/**
- * @class BaseDiffusion
- * @brief diffusion property abstract base class.
- */
-class BaseDiffusion : public BaseMaterial
-{
-  public:
-    BaseDiffusion(size_t diffusion_species_index, size_t gradient_species_index)
-        : BaseMaterial(), diffusion_species_index_(diffusion_species_index),
-          gradient_species_index_(gradient_species_index)
+    /**
+     * @class BaseDiffusion
+     * @brief diffusion property abstract base class.
+     */
+    class BaseDiffusion : public BaseMaterial
     {
-        material_type_name_ = "BaseDiffusion";
-    };
-    virtual ~BaseDiffusion(){};
-
-    size_t diffusion_species_index_;
-    size_t gradient_species_index_;
-
-    virtual Real getReferenceDiffusivity() = 0;
-    virtual Real getDiffusionCoeffWithBoundary(size_t particle_i) = 0;
-    virtual Real getInterParticleDiffusionCoeff(size_t particle_i, size_t particle_j, const Vecd &direction_from_j_to_i) = 0;
-};
-
-/**
- * @class IsotropicDiffusion
- * @brief isotropic diffusion property.
- */
-class IsotropicDiffusion : public BaseDiffusion
-{
-  protected:
-    Real diff_cf_; /**< diffusion coefficient. */
-
-  public:
-    IsotropicDiffusion(size_t diffusion_species_index, size_t gradient_species_index,
-                       Real diff_cf = 1.0)
-        : BaseDiffusion(diffusion_species_index, gradient_species_index),
-          diff_cf_(diff_cf)
-    {
-        material_type_name_ = "IsotropicDiffusion";
-    };
-    virtual ~IsotropicDiffusion(){};
-
-    virtual Real getReferenceDiffusivity() override { return diff_cf_; };
-    virtual Real getDiffusionCoeffWithBoundary(size_t particle_i) override { return diff_cf_; }
-    virtual Real getInterParticleDiffusionCoeff(size_t particle_i, size_t particle_j, const Vecd &direction_from_j_to_i) override
-    {
-        return diff_cf_;
-    };
-};
-
-/**
- * @class LocalIsotropicDiffusion
- * @brief diffusion coefficient is locally different (k is not uniformly distributed).
- */
-class LocalIsotropicDiffusion : public IsotropicDiffusion
-{
-protected:
-    StdLargeVec<Real> local_thermal_conductivity_;
-
-public:
-    LocalIsotropicDiffusion(size_t diffusion_species_index, size_t gradient_species_index,
-                            Real diff_cf = 1.0)
-        : IsotropicDiffusion(diffusion_species_index, gradient_species_index, diff_cf)
-    {
-        material_type_name_ = "LocalIstropicDiffusion";
-    }
-    virtual ~LocalIsotropicDiffusion() {};
-
-    virtual void initializeLocalParameters(BaseParticles* base_particles) override;
-
-    virtual Real getReferenceDiffusivity() override { return diff_cf_; };
-    virtual Real getDiffusionCoeffWithBoundary(size_t particle_i) override { return local_thermal_conductivity_[particle_i]; };
-    virtual Real getInterParticleDiffusionCoeff(size_t particle_i, size_t particle_j, const Vecd& direction_from_j_to_i) override
-    {
-        return 0.5 * (local_thermal_conductivity_[particle_i] + local_thermal_conductivity_[particle_j]);
-    };
-};
-
-/**
- * @class DirectionalDiffusion
- * @brief Diffusion is biased along a specific direction.
- */
-class DirectionalDiffusion : public IsotropicDiffusion
-{
-  protected:
-    Vecd bias_direction_;          /**< Reference bias direction. */
-    Real bias_diff_cf_;            /**< The bias diffusion coefficient along the fiber direction. */
-    Matd transformed_diffusivity_; /**< The transformed diffusivity with inverse Cholesky decomposition. */
-
-    void initializeDirectionalDiffusivity(Real diff_cf, Real bias_diff_cf, Vecd bias_direction);
-
-  public:
-    DirectionalDiffusion(size_t diffusion_species_index, size_t gradient_species_index,
-                         Real diff_cf, Real bias_diff_cf, Vecd bias_direction)
-        : IsotropicDiffusion(diffusion_species_index, gradient_species_index, diff_cf),
-          bias_direction_(bias_direction), bias_diff_cf_(bias_diff_cf),
-          transformed_diffusivity_(Matd::Identity())
-    {
-        material_type_name_ = "DirectionalDiffusion";
-        initializeDirectionalDiffusivity(diff_cf, bias_diff_cf, bias_direction);
-    };
-    virtual ~DirectionalDiffusion(){};
-
-    virtual Real getReferenceDiffusivity() override
-    {
-        return SMAX(diff_cf_, diff_cf_ + bias_diff_cf_);
-    };
-
-    virtual Real getInterParticleDiffusionCoeff(size_t particle_index_i,
-                                               size_t particle_index_j, const Vecd &inter_particle_direction) override
-    {
-        Vecd grad_ij = transformed_diffusivity_ * inter_particle_direction;
-        return 1.0 / grad_ij.squaredNorm();
-    };
-};
-
-/**
- * @class LocalDirectionalDiffusion
- * @brief Diffusion is biased along a specific direction.
- */
-class LocalDirectionalDiffusion : public DirectionalDiffusion
-{
-  protected:
-    StdLargeVec<Vecd> local_bias_direction_;
-    StdLargeVec<Matd> local_transformed_diffusivity_;
-
-  public:
-    LocalDirectionalDiffusion(size_t diffusion_species_index, size_t gradient_species_index,
-                              Real diff_cf, Real bias_diff_cf, Vecd bias_direction)
-        : DirectionalDiffusion(diffusion_species_index, gradient_species_index, diff_cf, bias_diff_cf, bias_direction)
-    {
-        material_type_name_ = "LocalDirectionalDiffusion";
-    };
-    virtual ~LocalDirectionalDiffusion(){};
-
-    virtual void registerReloadLocalParameters(BaseParticles *base_particles) override;
-    virtual void initializeLocalParameters(BaseParticles *base_particles) override;
-
-    virtual Real getInterParticleDiffusionCoeff(size_t particle_index_i, size_t particle_index_j, const Vecd &inter_particle_direction) override
-    {
-        Matd trans_diffusivity = getAverageValue(local_transformed_diffusivity_[particle_index_i], local_transformed_diffusivity_[particle_index_j]);
-        Vecd grad_ij = trans_diffusivity * inter_particle_direction;
-        return 1.0 / grad_ij.squaredNorm();
-    };
-};
-
-/**
- * @class BaseReactionModel
- * @brief Base class for all reaction models.
- */
-template <int NUM_SPECIES>
-class BaseReactionModel
-{
-  public:
-    static constexpr int NumSpecies = NUM_SPECIES;
-    typedef std::array<Real, NUM_SPECIES> LocalSpecies;
-    typedef std::array<std::string, NUM_SPECIES> SpeciesNames;
-    typedef std::function<Real(LocalSpecies &)> ReactionFunctor;
-    StdVec<ReactionFunctor> get_production_rates_;
-    StdVec<ReactionFunctor> get_loss_rates_;
-
-    BaseReactionModel()
-    {
-        std::cout << "\n Error: default constructor for non-empty reaction model!" << std::endl;
-        std::cout << __FILE__ << ':' << __LINE__ << std::endl;
-        exit(1);
-    };
-
-    explicit BaseReactionModel(const SpeciesNames &species_names)
-        : species_names_(species_names)
-    {
-        if constexpr (NUM_SPECIES == 0)
+    public:
+        BaseDiffusion(size_t diffusion_species_index, size_t gradient_species_index)
+            : BaseMaterial()
+            , diffusion_species_index_(diffusion_species_index)
+            , gradient_species_index_(gradient_species_index)
         {
-            reaction_model_ = "EmptyReactionModel";
-        }
-        else
-        {
-            reaction_model_ = "BaseReactionModel";
-            for (size_t i = 0; i != species_names.size(); ++i)
-            {
-                species_indexes_map_.insert(make_pair(species_names[i], i));
-            }
-        }
-    };
-    virtual ~BaseReactionModel(){};
-    SpeciesNames &getSpeciesNames() { return species_names_; };
+            material_type_name_ = "BaseDiffusion";
+        };
+        virtual ~BaseDiffusion(){};
 
-  protected:
-    std::string reaction_model_;
-    SpeciesNames species_names_;
-    std::map<std::string, size_t> species_indexes_map_;
-};
-/** explicit specialization for empty reaction model */
-template <>
-inline BaseReactionModel<0>::BaseReactionModel() : reaction_model_("EmptyReactionModel"){};
-using NoReaction = BaseReactionModel<0>;
+        size_t diffusion_species_index_;
+        size_t gradient_species_index_;
 
-/**
- * @class DiffusionReaction
- * @brief Complex material for diffusion or/and reactions.
- */
-template <class BaseMaterialType = BaseMaterial, int NUM_REACTIVE_SPECIES = 0>
-class DiffusionReaction : public BaseMaterialType
-{
-  public:
-    static constexpr int NumReactiveSpecies = NUM_REACTIVE_SPECIES;
-
-  private:
-    UniquePtrsKeeper<BaseDiffusion> diffusion_ptr_keeper_;
-    SharedPtrKeeper<BaseReactionModel<NUM_REACTIVE_SPECIES>> reaction_ptr_keeper_;
-
-  protected:
-    typedef std::array<std::string, NUM_REACTIVE_SPECIES> ReactiveSpeciesNames;
-    StdVec<std::string> all_species_names_;
-    BaseReactionModel<NUM_REACTIVE_SPECIES> &reaction_model_;
-    std::map<std::string, size_t> all_species_indexes_map_;
-    StdVec<BaseDiffusion *> all_diffusions_;
-    IndexVector reactive_species_indexes_;
-    IndexVector diffusion_species_indexes_;
-    IndexVector gradient_species_indexes_;
-
-  public:
-    /** Constructor for material with diffusion and reaction. */
-    template <typename... MaterialArgs>
-    DiffusionReaction(const StdVec<std::string> &all_species_names,
-                      SharedPtr<BaseReactionModel<NUM_REACTIVE_SPECIES>> reaction_model_ptr,
-                      MaterialArgs &&...material_args)
-        : BaseMaterialType(std::forward<MaterialArgs>(material_args)...),
-          all_species_names_(all_species_names),
-          reaction_model_(reaction_ptr_keeper_.assignRef(reaction_model_ptr))
-    {
-        BaseMaterialType::material_type_name_ =
-            NUM_REACTIVE_SPECIES == 0 ? "Diffusion" : "DiffusionReaction";
-
-        for (size_t i = 0; i != all_species_names.size(); ++i)
-        {
-            all_species_indexes_map_.insert(make_pair(all_species_names[i], i));
-        }
-
-        for (size_t i = 0; i != NUM_REACTIVE_SPECIES; ++i)
-        {
-            const ReactiveSpeciesNames &reactive_species_names = reaction_model_.getSpeciesNames();
-            size_t reactive_species_index = all_species_indexes_map_[reactive_species_names[i]];
-            if (reactive_species_index != all_species_indexes_map_.size())
-            {
-                reactive_species_indexes_.push_back(reactive_species_index);
-            }
-            else
-            {
-                std::cout << "\n Error: reactive species '" << reactive_species_names[i] << "' not defined!" << std::endl;
-                std::cout << __FILE__ << ':' << __LINE__ << std::endl;
-                exit(1);
-            }
-        }
-    };
-    virtual ~DiffusionReaction(){};
-    StdVec<std::string> &AllSpeciesNames() { return all_species_names_; };
-    std::map<std::string, size_t> AllSpeciesIndexMap() { return all_species_indexes_map_; };
-    IndexVector &ReactiveSpeciesIndexes() { return reactive_species_indexes_; };
-    IndexVector &DiffusionSpeciesIndexes() { return diffusion_species_indexes_; };
-    IndexVector &GradientSpeciesIndexes() { return gradient_species_indexes_; };
-    StdVec<BaseDiffusion *> &AllDiffusions() { return all_diffusions_; };
-    BaseReactionModel<NUM_REACTIVE_SPECIES> &ReactionModel() { return reaction_model_; };
-
-    virtual void registerReloadLocalParameters(BaseParticles *base_particles) override
-    {
-        BaseMaterialType::registerReloadLocalParameters(base_particles);
-        for (size_t k = 0; k < all_diffusions_.size(); ++k)
-            all_diffusions_[k]->registerReloadLocalParameters(base_particles);
-    };
-
-    virtual void initializeLocalParameters(BaseParticles *base_particles) override
-    {
-        BaseMaterialType::initializeLocalParameters(base_particles);
-        for (size_t k = 0; k < all_diffusions_.size(); ++k)
-            all_diffusions_[k]->initializeLocalParameters(base_particles);
+        virtual Real getReferenceDiffusivity() = 0;
+        virtual Real getThermalCapacityReciprocal() = 0;
+        virtual Real getLocalDiffusivity(size_t particle_i) = 0;
+        virtual Real getInterParticleDiffusionCoeff(size_t particle_i, size_t particle_j, const Vecd &r_ij) = 0;
     };
 
     /**
-     * @brief Get diffusion time step size. Here, I follow the reference:
-     * https://www.uni-muenster.de/imperia/md/content/physik_tp/lectures/ws2016-2017/num_methods_i/heat.pdf
+     * @class IsotropicDiffusion
+     * @brief isotropic diffusion property.
      */
-    Real getDiffusionTimeStepSize(Real smoothing_length)
+    class IsotropicDiffusion : public BaseDiffusion
     {
-        Real diff_coeff_max = 0.0;
-        for (size_t k = 0; k < all_diffusions_.size(); ++k)
-            diff_coeff_max = SMAX(diff_coeff_max, all_diffusions_[k]->getReferenceDiffusivity());
-        return 0.5 * smoothing_length * smoothing_length / diff_coeff_max / Real(Dimensions);
+    protected:
+        Real diff_cf_; /**< diffusion coefficient. */
+
+    public:
+        IsotropicDiffusion(size_t diffusion_species_index, size_t gradient_species_index, Real diff_cf = 1.0)
+            : BaseDiffusion(diffusion_species_index, gradient_species_index)
+            , diff_cf_(diff_cf)
+        {
+            material_type_name_ = "IsotropicDiffusion";
+        };
+        virtual ~IsotropicDiffusion(){};
+
+        virtual Real getReferenceDiffusivity() override { return diff_cf_; };
+        virtual Real getThermalCapacityReciprocal() override { return 1.0; };
+        virtual Real getLocalDiffusivity(size_t particle_i) override { return diff_cf_; };
+        virtual Real getInterParticleDiffusionCoeff(size_t particle_i, size_t particle_j, const Vecd &r_ij) override
+        {
+            return diff_cf_;
+        };
     };
 
-    /** Initialize a diffusion material. */
-    template <class DiffusionType, typename... ConstructorArgs>
-    void initializeAnDiffusion(const std::string &diffusion_species_name,
-                               const std::string &gradient_species_name, ConstructorArgs &&...args)
+    /**
+     * @class IsotropicDiffusion
+     * @brief isotropic diffusion property.
+     */
+    class IsotropicThermalDiffusion : public BaseDiffusion
     {
-        size_t diffusion_species_index = all_species_indexes_map_[diffusion_species_name];
-        size_t gradient_species_index = all_species_indexes_map_[gradient_species_name];
-        diffusion_species_indexes_.push_back(diffusion_species_index);
-        gradient_species_indexes_.push_back(gradient_species_index);
+    protected:
+        Real thermal_conductivity_; /**< thermal conductivity (W/(m·K)). */
+        Real thermal_capacity_;     /**< specific heat capacity (J/(kg·K)). */
+        Real thermal_diffusivity_;  /**< thermal diffusivity is the thermal conductivity divided by density and specific heat capacity with unit of (m2/s). */
 
-        all_diffusions_.push_back(
-            diffusion_ptr_keeper_.createPtr<DiffusionType>(
-                diffusion_species_index, gradient_species_index, std::forward<ConstructorArgs>(args)...));
+    public:
+        IsotropicThermalDiffusion(size_t diffusion_species_index
+                                , size_t gradient_species_index
+                                , Real  thermal_conductivity = 1.0
+                                , Real thermal_capacity = 1.0 )
+            : BaseDiffusion(diffusion_species_index, gradient_species_index)
+            , thermal_conductivity_(thermal_conductivity)
+            , thermal_capacity_(thermal_capacity)
+        {
+            material_type_name_ = "IsotropicThermalDiffusion";
+            thermal_diffusivity_ = thermal_conductivity_ / thermal_capacity_ / ReferenceDensity() ;
+        };
+        virtual ~IsotropicThermalDiffusion(){};
+    
+    public:
+        Real getThermalConductivity() { return thermal_conductivity_; };
+
+        virtual Real getThermalCapacityReciprocal() override { return 1.0 / thermal_capacity_; };
+        virtual Real getReferenceDiffusivity() override { return thermal_diffusivity_; };
+
+        virtual Real getLocalDiffusivity(size_t particle_i) override { return thermal_conductivity_; };
+        virtual Real getInterParticleDiffusionCoeff(size_t particle_i, size_t particle_j, const Vecd &r_ij) override
+        {
+            return thermal_conductivity_;
+        };
     };
 
-    virtual DiffusionReaction<BaseMaterialType, NUM_REACTIVE_SPECIES> *ThisObjectPtr() override { return this; };
-};
+    /**
+     * @class LocalIsotropicThermalDiffusion
+     * @brief diffusion coefficient is locally different (k is not uniformly distributed).
+     */
+    class LocalIsotropicThermalDiffusion : public IsotropicThermalDiffusion
+    {
+    protected:
+        StdLargeVec<Real> local_thermal_conductivity_;
+
+    public:
+        LocalIsotropicThermalDiffusion(size_t diffusion_species_index
+                                      , size_t gradient_species_index
+                                      , Real  thermal_conductivity = 1.0
+                                      , Real thermal_capacity = 1.0 )
+            : IsotropicThermalDiffusion(diffusion_species_index, gradient_species_index, thermal_conductivity, thermal_capacity)
+        {
+            material_type_name_ = "LocalIsotropicThermalDiffusion";
+        }
+        virtual ~LocalIsotropicThermalDiffusion() {};
+
+        virtual void initializeLocalParameters(BaseParticles* base_particles) override;
+
+        virtual Real getLocalDiffusivity(size_t particle_i) override { return local_thermal_conductivity_[particle_i]; };
+        virtual Real getInterParticleDiffusionCoeff(size_t particle_i, size_t particle_j, const Vecd& direction_from_j_to_i) override
+        {
+            return 0.5 * (local_thermal_conductivity_[particle_i] + local_thermal_conductivity_[particle_j]);
+        };
+    };
+
+    /**
+     * @class DirectionalDiffusion
+     * @brief Diffusion is biased along a specific direction.
+     */
+    class DirectionalDiffusion : public IsotropicDiffusion
+    {
+    protected:
+        Vecd bias_direction_;          /**< Reference bias direction. */
+        Real bias_diff_cf_;            /**< The bias diffusion coefficient along the fiber direction. */
+        Matd transformed_diffusivity_; /**< The transformed diffusivity with inverse Cholesky decomposition. */
+
+        void initializeDirectionalDiffusivity(Real diff_cf, Real bias_diff_cf, Vecd bias_direction);
+
+    public:
+        DirectionalDiffusion(size_t diffusion_species_index, size_t gradient_species_index, Real diff_cf, Real bias_diff_cf, Vecd bias_direction)
+            : IsotropicDiffusion(diffusion_species_index, gradient_species_index, diff_cf)
+            , bias_direction_(bias_direction)
+            , bias_diff_cf_(bias_diff_cf)
+            , transformed_diffusivity_(Matd::Identity())
+        {
+            material_type_name_ = "DirectionalDiffusion";
+            initializeDirectionalDiffusivity(diff_cf, bias_diff_cf, bias_direction);
+        };
+        virtual ~DirectionalDiffusion(){};
+
+        virtual Real getReferenceDiffusivity() override
+        {
+            return SMAX(diff_cf_, diff_cf_ + bias_diff_cf_);
+        };
+
+        virtual Real getInterParticleDiffusionCoeff(size_t particle_index_i,
+                                                size_t particle_index_j, const Vecd &inter_particle_direction) override
+        {
+            Vecd grad_ij = transformed_diffusivity_ * inter_particle_direction;
+            return 1.0 / grad_ij.squaredNorm();
+        };
+    };
+
+    /**
+     * @class LocalDirectionalDiffusion
+     * @brief Diffusion is biased along a specific direction.
+     */
+    class LocalDirectionalDiffusion : public DirectionalDiffusion
+    {
+    protected:
+        StdLargeVec<Vecd> local_bias_direction_;
+        StdLargeVec<Matd> local_transformed_diffusivity_;
+
+    public:
+        LocalDirectionalDiffusion(size_t diffusion_species_index, size_t gradient_species_index, Real diff_cf, Real bias_diff_cf, Vecd bias_direction)
+            : DirectionalDiffusion(diffusion_species_index, gradient_species_index, diff_cf, bias_diff_cf, bias_direction)
+        {
+            material_type_name_ = "LocalDirectionalDiffusion";
+        };
+        virtual ~LocalDirectionalDiffusion(){};
+
+        virtual void registerReloadLocalParameters(BaseParticles *base_particles) override;
+        virtual void initializeLocalParameters(BaseParticles *base_particles) override;
+
+        virtual Real getInterParticleDiffusionCoeff(size_t particle_index_i, size_t particle_index_j, const Vecd &inter_particle_direction) override
+        {
+            Matd trans_diffusivity = getAverageValue(local_transformed_diffusivity_[particle_index_i], local_transformed_diffusivity_[particle_index_j]);
+            Vecd grad_ij = trans_diffusivity * inter_particle_direction;
+            return 1.0 / grad_ij.squaredNorm();
+        };
+    };
+
+    /**
+     * @class BaseReactionModel
+     * @brief Base class for all reaction models.
+     */
+    template <int NUM_SPECIES>
+    class BaseReactionModel
+    {
+    public:
+        static constexpr int NumSpecies = NUM_SPECIES;
+        typedef std::array<Real, NUM_SPECIES> LocalSpecies;
+        typedef std::array<std::string, NUM_SPECIES> SpeciesNames;
+        typedef std::function<Real(LocalSpecies &)> ReactionFunctor;
+        StdVec<ReactionFunctor> get_production_rates_;
+        StdVec<ReactionFunctor> get_loss_rates_;
+
+        BaseReactionModel()
+        {
+            std::cout << "\n Error: default constructor for non-empty reaction model!" << std::endl;
+            std::cout << __FILE__ << ':' << __LINE__ << std::endl;
+            exit(1);
+        };
+
+        explicit BaseReactionModel(const SpeciesNames &species_names)
+            : species_names_(species_names)
+        {
+            if constexpr (NUM_SPECIES == 0)
+            {
+                reaction_model_ = "EmptyReactionModel";
+            }
+            else
+            {
+                reaction_model_ = "BaseReactionModel";
+                for (size_t i = 0; i != species_names.size(); ++i)
+                {
+                    species_indexes_map_.insert(make_pair(species_names[i], i));
+                }
+            }
+        };
+        virtual ~BaseReactionModel(){};
+        SpeciesNames &getSpeciesNames() { return species_names_; };
+
+    protected:
+        std::string reaction_model_;
+        SpeciesNames species_names_;
+        std::map<std::string, size_t> species_indexes_map_;
+    };
+
+    /** explicit specialization for empty reaction model */
+    template <>
+    inline BaseReactionModel<0>::BaseReactionModel() : reaction_model_("EmptyReactionModel"){};
+    using NoReaction = BaseReactionModel<0>;
+
+    /**
+     * @class DiffusionReaction
+     * @brief Complex material for diffusion or/and reactions.
+     */
+    template <class BaseMaterialType = BaseMaterial, int NUM_REACTIVE_SPECIES = 0>
+    class DiffusionReaction : public BaseMaterialType
+    {
+    public:
+        static constexpr int NumReactiveSpecies = NUM_REACTIVE_SPECIES;
+
+    private:
+        UniquePtrsKeeper<BaseDiffusion> diffusion_ptr_keeper_;
+        SharedPtrKeeper<BaseReactionModel<NUM_REACTIVE_SPECIES>> reaction_ptr_keeper_;
+
+    protected:
+        typedef std::array<std::string, NUM_REACTIVE_SPECIES> ReactiveSpeciesNames;
+        StdVec<std::string> all_species_names_;
+        BaseReactionModel<NUM_REACTIVE_SPECIES> &reaction_model_;
+        std::map<std::string, size_t> all_species_indexes_map_;
+        StdVec<BaseDiffusion *> all_diffusions_;
+        IndexVector reactive_species_indexes_;
+        IndexVector diffusion_species_indexes_;
+        IndexVector gradient_species_indexes_;
+
+    public:
+        /** Constructor for material with diffusion and reaction. */
+        template <typename... MaterialArgs>
+        DiffusionReaction(const StdVec<std::string> &all_species_names
+                        , SharedPtr<BaseReactionModel<NUM_REACTIVE_SPECIES>> reaction_model_ptr
+                        , MaterialArgs &&...material_args)
+            : BaseMaterialType(std::forward<MaterialArgs>(material_args)...)
+            , all_species_names_(all_species_names)
+            , reaction_model_(reaction_ptr_keeper_.assignRef(reaction_model_ptr))
+        {
+            BaseMaterialType::material_type_name_ =
+                NUM_REACTIVE_SPECIES == 0 ? "Diffusion" : "DiffusionReaction";
+
+            for (size_t i = 0; i != all_species_names.size(); ++i)
+            {
+                all_species_indexes_map_.insert(make_pair(all_species_names[i], i));
+            }
+
+            for (size_t i = 0; i != NUM_REACTIVE_SPECIES; ++i)
+            {
+                const ReactiveSpeciesNames &reactive_species_names = reaction_model_.getSpeciesNames();
+                size_t reactive_species_index = all_species_indexes_map_[reactive_species_names[i]];
+                if (reactive_species_index != all_species_indexes_map_.size())
+                {
+                    reactive_species_indexes_.push_back(reactive_species_index);
+                }
+                else
+                {
+                    std::cout << "\n Error: reactive species '" << reactive_species_names[i] << "' not defined!" << std::endl;
+                    std::cout << __FILE__ << ':' << __LINE__ << std::endl;
+                    exit(1);
+                }
+            }
+        };
+        virtual ~DiffusionReaction(){};
+    
+    public:
+        StdVec<std::string> &AllSpeciesNames() { return all_species_names_; };
+        std::map<std::string, size_t> AllSpeciesIndexMap() { return all_species_indexes_map_; };
+        IndexVector &ReactiveSpeciesIndexes() { return reactive_species_indexes_; };
+        IndexVector &DiffusionSpeciesIndexes() { return diffusion_species_indexes_; };
+        IndexVector &GradientSpeciesIndexes() { return gradient_species_indexes_; };
+        StdVec<BaseDiffusion *> &AllDiffusions() { return all_diffusions_; };
+        BaseReactionModel<NUM_REACTIVE_SPECIES> &ReactionModel() { return reaction_model_; };
+
+        virtual void registerReloadLocalParameters(BaseParticles *base_particles) override
+        {
+            BaseMaterialType::registerReloadLocalParameters(base_particles);
+            for (size_t k = 0; k < all_diffusions_.size(); ++k)
+                all_diffusions_[k]->registerReloadLocalParameters(base_particles);
+        };
+
+        virtual void initializeLocalParameters(BaseParticles *base_particles) override
+        {
+            BaseMaterialType::initializeLocalParameters(base_particles);
+            for (size_t k = 0; k < all_diffusions_.size(); ++k)
+                all_diffusions_[k]->initializeLocalParameters(base_particles);
+        };
+
+        /**
+         * @brief Get diffusion time step size. Here, I follow the reference:
+         * https://www.uni-muenster.de/imperia/md/content/physik_tp/lectures/ws2016-2017/num_methods_i/heat.pdf
+         */
+        Real getDiffusionTimeStepSize(Real smoothing_length)
+        {
+            Real diff_coeff_max = 0.0;
+            for (size_t k = 0; k < all_diffusions_.size(); ++k)
+                diff_coeff_max = SMAX(diff_coeff_max, all_diffusions_[k]->getReferenceDiffusivity());
+            return 0.5 * smoothing_length * smoothing_length / diff_coeff_max / Real(Dimensions);
+        };
+
+        /** Initialize a diffusion material. */
+        template <class DiffusionType, typename... ConstructorArgs>
+        void initializeAnDiffusion(const std::string &diffusion_species_name,
+                                const std::string &gradient_species_name, ConstructorArgs &&...args)
+        {
+            size_t diffusion_species_index = all_species_indexes_map_[diffusion_species_name];
+            size_t gradient_species_index = all_species_indexes_map_[gradient_species_name];
+            diffusion_species_indexes_.push_back(diffusion_species_index);
+            gradient_species_indexes_.push_back(gradient_species_index);
+
+            all_diffusions_.push_back( diffusion_ptr_keeper_.createPtr<DiffusionType>(
+                    diffusion_species_index, gradient_species_index, std::forward<ConstructorArgs>(args)...)
+                    );
+        };
+
+        virtual DiffusionReaction<BaseMaterialType, NUM_REACTIVE_SPECIES> *ThisObjectPtr() override { return this; };
+    };
 } // namespace SPH
 #endif // DIFFUSION_REACTION_H

--- a/src/shared/particle_dynamics/diffusion_optimization_dynamics/diffusion_splitting_state.hpp
+++ b/src/shared/particle_dynamics/diffusion_optimization_dynamics/diffusion_splitting_state.hpp
@@ -112,7 +112,7 @@ namespace SPH
 				{
 					// linear projection
 					VariableType variable_derivative = (variable_i - variable_k[index_j]);
-					Real diff_coff_ij = this->all_diffusion_[this->phi_]->getDiffusionCoeffWithBoundary(index_i);
+					Real diff_coff_ij = this->all_diffusion_[this->phi_]->getLocalDiffusivity(index_i);
 					Real parameter_b = 2.0 * diff_coff_ij * contact_neighborhood.dW_ijV_j_[n] * dt / contact_neighborhood.r_ij_[n];
 
 					error_and_parameters.error_ -= variable_derivative * parameter_b;

--- a/src/shared/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics.h
+++ b/src/shared/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics.h
@@ -138,11 +138,28 @@ namespace SPH
     };
 
     /**
-     * @class DiffusionRelaxationInner
+     * @class BaseThermalDiffusionRelaxation
+     * @brief Base for compute the diffusion of all species in thermal dynamics.
+     */
+    template <class ParticlesType>
+    class BaseThermalDiffusionRelaxation : public BaseDiffusionRelaxation<ParticlesType>
+    {
+    protected:
+        StdLargeVec<Real> &rho_;
+
+    public:
+        explicit BaseThermalDiffusionRelaxation(SPHBody &sph_body);
+        virtual ~BaseThermalDiffusionRelaxation(){};
+
+        void update(size_t index_i, Real dt = 0.0);
+    };
+
+    /**
+     * @class BaseDiffusionRelaxationInner
      * @brief Compute the diffusion relaxation process of all species
      */
-    template <class ParticlesType, class KernelGradientType = KernelGradientInner>
-    class DiffusionRelaxationInner : public BaseDiffusionRelaxation<ParticlesType>
+    template <class ParticlesType, class KernelGradientType = KernelGradientInner, template<class> class BaseDiffusionRelaxationType = BaseDiffusionRelaxation>
+    class BaseDiffusionRelaxationInner : public BaseDiffusionRelaxationType<ParticlesType>
                                    , public DataDelegateInner<ParticlesType, DataDelegateEmptyBase>
     {
     protected:
@@ -151,29 +168,17 @@ namespace SPH
 
     public:
         typedef BaseInnerRelation BodyRelationType;
-        explicit DiffusionRelaxationInner(BaseInnerRelation &inner_relation);
-        virtual ~DiffusionRelaxationInner(){};
+        explicit BaseDiffusionRelaxationInner(BaseInnerRelation &inner_relation);
+        virtual ~BaseDiffusionRelaxationInner(){};
 
         inline void interaction(size_t index_i, Real dt = 0.0);
     };
 
-    /**
-     * @class ThermalDiffusionRelaxationInner
-     * @brief Base for compute the diffusion of all species in thermal dynamics.
-     */
     template <class ParticlesType, class KernelGradientType = KernelGradientInner>
-    class ThermalDiffusionRelaxationInner : public DiffusionRelaxationInner<ParticlesType, KernelGradientType>
-    {
-    protected:
-        StdLargeVec<Real> &rho_;
+    using DiffusionRelaxationInner = BaseDiffusionRelaxationInner<ParticlesType, KernelGradientType, BaseDiffusionRelaxation>;
 
-    public:
-        explicit ThermalDiffusionRelaxationInner(BaseInnerRelation &inner_relation);
-        virtual ~ThermalDiffusionRelaxationInner(){};
-
-        void update(size_t index_i, Real dt = 0.0);
-    };
-
+    template <class ParticlesType, class KernelGradientType = KernelGradientInner>
+    using ThermalDiffusionRelaxationInner = BaseDiffusionRelaxationInner<ParticlesType, KernelGradientType, BaseThermalDiffusionRelaxation>;
     /**
      * @class DiffusionRelaxationContact
      * @brief Base class for diffusion relaxation process between two contact bodies.

--- a/src/shared/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics.h
+++ b/src/shared/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics.h
@@ -137,23 +137,6 @@ namespace SPH
         void update(size_t index_i, Real dt = 0.0);
     };
 
-        /**
-     * @class BaseThermalDiffusionRelaxation
-     * @brief Base for compute the diffusion of all species
-     */
-    template <class ParticlesType>
-    class BaseThermalDiffusionRelaxation : public BaseDiffusionRelaxation<ParticlesType>
-    {
-    protected:
-        StdLargeVec<Real> &rho_;
-
-    public:
-        explicit BaseThermalDiffusionRelaxation(SPHBody &sph_body);
-        virtual ~BaseThermalDiffusionRelaxation(){};
-
-        void update(size_t index_i, Real dt = 0.0);
-    };
-
     /**
      * @class DiffusionRelaxationInner
      * @brief Compute the diffusion relaxation process of all species
@@ -172,6 +155,23 @@ namespace SPH
         virtual ~DiffusionRelaxationInner(){};
 
         inline void interaction(size_t index_i, Real dt = 0.0);
+    };
+
+    /**
+     * @class ThermalDiffusionRelaxationInner
+     * @brief Base for compute the diffusion of all species in thermal dynamics.
+     */
+    template <class ParticlesType, class KernelGradientType = KernelGradientInner>
+    class ThermalDiffusionRelaxationInner : public DiffusionRelaxationInner<ParticlesType, KernelGradientType>
+    {
+    protected:
+        StdLargeVec<Real> &rho_;
+
+    public:
+        explicit ThermalDiffusionRelaxationInner(BaseInnerRelation &inner_relation);
+        virtual ~ThermalDiffusionRelaxationInner(){};
+
+        void update(size_t index_i, Real dt = 0.0);
     };
 
     /**

--- a/src/shared/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics.h
+++ b/src/shared/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics.h
@@ -30,267 +30,278 @@
 #define DIFFUSION_DYNAMICS_H
 
 #include "general_diffusion_reaction_dynamics.h"
+#include "contact_diffusivity.h"
 
 namespace SPH
 {
-/**
- * @class GetDiffusionTimeStepSize
- * @brief Computing the time step size based on diffusion coefficient and particle smoothing length
- */
-template <class ParticlesType>
-class GetDiffusionTimeStepSize
-    : public BaseDynamics<Real>,
-      public DiffusionReactionSimpleData<ParticlesType>
-{
-  public:
-    explicit GetDiffusionTimeStepSize(SPHBody &sph_body);
-    virtual ~GetDiffusionTimeStepSize(){};
-
-    virtual Real exec(Real dt = 0.0) override { return diff_time_step_; };
-
-  protected:
-    Real diff_time_step_;
-};
-
-/**
- * @class BaseDiffusionRelaxation
- * @brief Base for compute the diffusion of all species
- */
-template <class ParticlesType>
-class BaseDiffusionRelaxation
-    : public LocalDynamics,
-      public DiffusionReactionSimpleData<ParticlesType>
-{
-  protected:
-   typedef typename ParticlesType::DiffusionReactionMaterial Material;
-    Material &material_;
-    StdVec<BaseDiffusion *> &all_diffusions_;
-    StdVec<StdLargeVec<Real> *> &diffusion_species_;
-    StdVec<StdLargeVec<Real> *> &gradient_species_;
-    StdVec<StdLargeVec<Real> *> diffusion_dt_;
-
-  public:
-    typedef ParticlesType InnerParticlesType;
-    explicit BaseDiffusionRelaxation(SPHBody &sph_body);
-    virtual ~BaseDiffusionRelaxation(){};
-    StdVec<BaseDiffusion *> &AllDiffusions() { return material_.AllDiffusions(); };
-    void initialization(size_t index_i, Real dt = 0.0);
-    void update(size_t index_i, Real dt = 0.0);
-};
-
-class KernelGradientInner
-{
-  public:
-    explicit KernelGradientInner(BaseParticles *inner_particles){};
-    Vecd operator()(size_t index_i, size_t index_j, Real dW_ijV_j, const Vecd &e_ij)
+    /**
+     * Kernel gradient operator, viz. first order or renormalized with correct matrix. 
+    */
+    class KernelGradientInner
     {
-        return dW_ijV_j * e_ij;
+    public:
+        explicit KernelGradientInner(BaseParticles *inner_particles){};
+
+        Vecd operator()(size_t index_i, size_t index_j, Real dW_ijV_j, const Vecd &e_ij)
+        {
+            return dW_ijV_j * e_ij;
+        };
     };
-};
 
-class CorrectedKernelGradientInner
-{
-    StdLargeVec<Matd> &B_;
-
-  public:
-    explicit CorrectedKernelGradientInner(BaseParticles *inner_particles)
-        : B_(*inner_particles->getVariableByName<Matd>("KernelCorrectionMatrix")){};
-    Vecd operator()(size_t index_i, size_t index_j, Real dW_ijV_j, const Vecd &e_ij)
+    class CorrectedKernelGradientInner
     {
-        return 0.5 * dW_ijV_j * (B_[index_i] + B_[index_j]) * e_ij;
+        StdLargeVec<Matd> &B_;
+
+    public:
+        explicit CorrectedKernelGradientInner(BaseParticles *inner_particles)
+            : B_(*inner_particles->getVariableByName<Matd>("KernelCorrectionMatrix"))
+        {};
+
+        Vecd operator()(size_t index_i, size_t index_j, Real dW_ijV_j, const Vecd &e_ij)
+        {
+            return 0.5 * dW_ijV_j * (B_[index_i] + B_[index_j]) * e_ij;
+        };
     };
-};
 
-/**
- * @class DiffusionRelaxationInner
- * @brief Compute the diffusion relaxation process of all species
- */
-template <class ParticlesType, class KernelGradientType = KernelGradientInner>
-class DiffusionRelaxationInner
-    : public BaseDiffusionRelaxation<ParticlesType>,
-      public DataDelegateInner<ParticlesType, DataDelegateEmptyBase>
-{
-  protected:
-    KernelGradientType kernel_gradient_;
-    void getDiffusionChangeRate(size_t particle_i, size_t particle_j, Vecd &e_ij, Real surface_area_ij);
-
-  public:
-    typedef BaseInnerRelation BodyRelationType;
-    explicit DiffusionRelaxationInner(BaseInnerRelation &inner_relation);
-    virtual ~DiffusionRelaxationInner(){};
-    inline void interaction(size_t index_i, Real dt = 0.0);
-};
-
-class KernelGradientContact
-{
-  public:
-    KernelGradientContact(BaseParticles *inner_particles, BaseParticles *contact_particles){};
-    Vecd operator()(size_t index_i, size_t index_j, Real dW_ijV_j, const Vecd &e_ij)
+    class KernelGradientContact
     {
-        return dW_ijV_j * e_ij;
+    public:
+        KernelGradientContact(BaseParticles *inner_particles, BaseParticles *contact_particles){};
+
+        Vecd operator()(size_t index_i, size_t index_j, Real dW_ijV_j, const Vecd &e_ij)
+        {
+            return dW_ijV_j * e_ij;
+        };
     };
-};
 
-class CorrectedKernelGradientContact
-{
-    StdLargeVec<Matd> &B_;
-    StdLargeVec<Matd> &contact_B_;
-
-  public:
-    CorrectedKernelGradientContact(BaseParticles *inner_particles, BaseParticles *contact_particles)
-        : B_(*inner_particles->getVariableByName<Matd>("KernelCorrectionMatrix")),
-          contact_B_(*contact_particles->getVariableByName<Matd>("KernelCorrectionMatrix")){};
-    Vecd operator()(size_t index_i, size_t index_j, Real dW_ijV_j, const Vecd &e_ij)
+    class CorrectedKernelGradientContact
     {
-        return 0.5 * dW_ijV_j * (B_[index_i] + contact_B_[index_j]) * e_ij;
+        StdLargeVec<Matd> &B_;
+        StdLargeVec<Matd> &contact_B_;
+
+    public:
+        CorrectedKernelGradientContact(BaseParticles *inner_particles, BaseParticles *contact_particles)
+            : B_(*inner_particles->getVariableByName<Matd>("KernelCorrectionMatrix"))
+            , contact_B_(*contact_particles->getVariableByName<Matd>("KernelCorrectionMatrix"))
+        {};
+
+        Vecd operator()(size_t index_i, size_t index_j, Real dW_ijV_j, const Vecd &e_ij)
+        {
+            return 0.5 * dW_ijV_j * (B_[index_i] + contact_B_[index_j]) * e_ij;
+        };
     };
-};
 
-/**
- * @class DiffusionRelaxationContact
- * @brief Base class for diffusion relaxation process between two contact bodies.
- */
-template <class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact>
-class BaseDiffusionRelaxationContact
-    : public BaseDiffusionRelaxation<ParticlesType>,
-      public DataDelegateContact<ParticlesType, ContactParticlesType, DataDelegateEmptyBase>
-{
-  protected:
-    StdVec<StdVec<std::string>> contact_gradient_species_names_;
-    StdVec<KernelGradientType> contact_kernel_gradients_;
+    /**
+     * @class GetDiffusionTimeStepSize
+     * @brief Computing the time step size based on diffusion coefficient and particle smoothing length
+     */
+    template <class ParticlesType>
+    class GetDiffusionTimeStepSize : public BaseDynamics<Real>
+                                   , public DiffusionReactionSimpleData<ParticlesType>
+    {
+    public:
+        explicit GetDiffusionTimeStepSize(SPHBody &sph_body);
+        virtual ~GetDiffusionTimeStepSize(){};
 
-  public:
-    typedef BaseContactRelation BodyRelationType;
+        virtual Real exec(Real dt = 0.0) override { return diff_time_step_; };
 
-    explicit BaseDiffusionRelaxationContact(BaseContactRelation &contact_relation);
-    virtual ~BaseDiffusionRelaxationContact(){};
-};
+    protected:
+        Real diff_time_step_;
+    };
 
-/**
- * @class DiffusionRelaxationDirichlet
- * @brief Contact diffusion relaxation with Dirichlet boundary condition.
- */
-template <class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact>
-class DiffusionRelaxationDirichlet
-    : public BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>
-{
-  protected:
-    StdVec<StdVec<StdLargeVec<Real> *>> contact_gradient_species_;
-    void getDiffusionChangeRateDirichlet(
-        size_t particle_i, size_t particle_j, Vecd &e_ij, Real surface_area_ij,
-        const StdVec<StdLargeVec<Real> *> &gradient_species_k);
+    /**
+     * @class BaseDiffusionRelaxation
+     * @brief Base for compute the diffusion of all species
+     */
+    template <class ParticlesType>
+    class BaseDiffusionRelaxation : public LocalDynamics
+                                  , public DiffusionReactionSimpleData<ParticlesType>
+    {
+    protected:
+        typedef typename ParticlesType::DiffusionReactionMaterial Material;
+        Material &material_;
+        StdVec<BaseDiffusion *> &all_diffusions_;
+        StdVec<StdLargeVec<Real> *> &diffusion_species_;
+        StdVec<StdLargeVec<Real> *> &gradient_species_;
+        StdVec<StdLargeVec<Real> *> diffusion_dt_;
+        StdVec<Real> all_thermal_capcity_reciprocal_;
 
-  public:
-    explicit DiffusionRelaxationDirichlet(BaseContactRelation &contact_relation);
-    virtual ~DiffusionRelaxationDirichlet(){};
-    inline void interaction(size_t index_i, Real dt = 0.0);
-};
+    public:
+        typedef ParticlesType InnerParticlesType;
+        explicit BaseDiffusionRelaxation(SPHBody &sph_body);
+        virtual ~BaseDiffusionRelaxation(){};
+    
+        StdVec<BaseDiffusion *> &AllDiffusions() { return material_.AllDiffusions(); };
 
-/**
- * @class DiffusionRelaxationNeumann
- * @brief Contact diffusion relaxation with Neumann boundary condition.
- */
-template <class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact>
-class DiffusionRelaxationNeumann
-    : public BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>
-{
-    StdLargeVec<Vecd> &n_;
-    StdVec<StdLargeVec<Real> *> contact_heat_flux_;
-    StdVec<StdLargeVec<Vecd> *> contact_n_;
+        void initialization(size_t index_i, Real dt = 0.0);
+        void update(size_t index_i, Real dt = 0.0);
+    };
 
-  protected:
-    void getDiffusionChangeRateNeumann(size_t particle_i, size_t particle_j,
-                                              Real surface_area_ij_Neumann, StdLargeVec<Real> &heat_flux_k);
+    /**
+     * @class DiffusionRelaxationInner
+     * @brief Compute the diffusion relaxation process of all species
+     */
+    template <class ParticlesType, class KernelGradientType = KernelGradientInner>
+    class DiffusionRelaxationInner : public BaseDiffusionRelaxation<ParticlesType>
+                                   , public DataDelegateInner<ParticlesType, DataDelegateEmptyBase>
+    {
+    protected:
+        StdLargeVec<Real> &rho_;
+        KernelGradientType kernel_gradient_;
+        void getDiffusionChangeRate(size_t particle_i, size_t particle_j, Vecd &e_ij, Real surface_area_ij);
 
-  public:
-    explicit DiffusionRelaxationNeumann(BaseContactRelation &contact_relation);
-    virtual ~DiffusionRelaxationNeumann(){};
+    public:
+        typedef BaseInnerRelation BodyRelationType;
+        explicit DiffusionRelaxationInner(BaseInnerRelation &inner_relation);
+        virtual ~DiffusionRelaxationInner(){};
 
-    inline void interaction(size_t index_i, Real dt = 0.0);
-};
+        inline void interaction(size_t index_i, Real dt = 0.0);
+    };
 
-/**
- * @class RelaxationOfAllDiffusionSpeciesRobinContact
- * @brief Contact diffusion relaxation with Robin boundary condition.
- */
-template <class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact>
-class DiffusionRelaxationRobin
-    : public BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>
-{
-    StdLargeVec<Vecd> &n_;
-    StdVec<StdLargeVec<Real> *> contact_convection_;
-    StdVec<Real *> contact_T_infinity_;
-    StdVec<StdLargeVec<Vecd> *> contact_n_;
+    /**
+     * @class DiffusionRelaxationContact
+     * @brief Base class for diffusion relaxation process between two contact bodies.
+     */
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact>
+    class BaseDiffusionRelaxationContact : public BaseDiffusionRelaxation<ParticlesType>
+                                         , public DataDelegateContact<ParticlesType, ContactParticlesType, DataDelegateEmptyBase>
+    {
+    protected:
+        StdVec<StdVec<std::string>> contact_gradient_species_names_;
+        StdVec<KernelGradientType> contact_kernel_gradients_;
 
-  protected:
-    void getDiffusionChangeRateRobin(size_t particle_i, size_t particle_j, Real surface_area_ij_Robin, StdLargeVec<Real> &convection_k, Real &T_infinity_k);
+    public:
+        typedef BaseContactRelation BodyRelationType;
 
-  public:
-    explicit DiffusionRelaxationRobin(BaseContactRelation &contact_relation);
-    virtual ~DiffusionRelaxationRobin(){};
+        explicit BaseDiffusionRelaxationContact(BaseContactRelation &contact_relation);
+        virtual ~BaseDiffusionRelaxationContact(){};
+    };
 
-    inline void interaction(size_t index_i, Real dt = 0.0);
-};
+    /**
+     * @class DiffusionRelaxationDirichlet
+     * @brief Contact diffusion relaxation with Dirichlet boundary condition.
+     */
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact>
+    class DiffusionRelaxationDirichlet
+        : public BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>
+    {
+    protected:
+        StdVec<StdVec<StdLargeVec<Real> *>> contact_gradient_species_;
+        void getDiffusionChangeRateDirichlet(size_t particle_i, size_t particle_j, Vecd &e_ij, Real surface_area_ij, size_t k);
 
-/**
- * @class InitializationRK
- * @brief Initialization of a runge-kutta integration scheme.
- */
-template <class ParticlesType>
-class InitializationRK : public BaseDiffusionRelaxation<ParticlesType>
-{
-  protected:
-    StdVec<StdLargeVec<Real>> &diffusion_species_s_;
+    public:
+        explicit DiffusionRelaxationDirichlet(BaseContactRelation &contact_relation);
+        virtual ~DiffusionRelaxationDirichlet(){};
+        inline void interaction(size_t index_i, Real dt = 0.0);
+    };
 
-  public:
-    InitializationRK(SPHBody &sph_body, StdVec<StdLargeVec<Real>> &diffusion_species_s);
-    virtual ~InitializationRK(){};
-    void update(size_t index_i, Real dt = 0.0);
-};
+    /**
+     * @class DiffusionRelaxationNeumann
+     * @brief Contact diffusion relaxation with Neumann boundary condition.
+     */
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact>
+    class DiffusionRelaxationNeumann
+        : public BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>
+    {
+        StdLargeVec<Vecd> &n_;
+        StdVec<StdLargeVec<Real> *> contact_heat_flux_;
+        StdVec<StdLargeVec<Vecd> *> contact_n_;
 
-/**
- * @class SecondStageRK2
- * @brief The second stage of the 2nd-order Runge-Kutta scheme.
- */
-template <class FirstStageType>
-class SecondStageRK2 : public FirstStageType
-{
-  protected:
-    StdVec<StdLargeVec<Real>> &diffusion_species_s_;
+    protected:
+        void getDiffusionChangeRateNeumann(size_t particle_i, size_t particle_j, Real surface_area_ij_Neumann, size_t k);
 
-  public:
-    template <typename... ContactArgsType>
-    SecondStageRK2(typename FirstStageType::BodyRelationType &body_relation,
-                   StdVec<StdLargeVec<Real>> &diffusion_species_s, ContactArgsType &&...contact_args)
-        : FirstStageType(body_relation, std::forward<ContactArgsType>(contact_args)...),
-          diffusion_species_s_(diffusion_species_s){};
-    virtual ~SecondStageRK2(){};
+    public:
+        explicit DiffusionRelaxationNeumann(BaseContactRelation &contact_relation);
+        virtual ~DiffusionRelaxationNeumann(){};
 
-    void update(size_t index_i, Real dt = 0.0);
-};
+        inline void interaction(size_t index_i, Real dt = 0.0);
+    };
 
-/**
- * @class DiffusionRelaxationRK2
- * @brief The 2nd-order runge-kutta integration scheme.
- * A intermediate state for species is introduced here to achieve multi-step integration.
- */
-template <class FirstStageType>
-class DiffusionRelaxationRK2 : public BaseDynamics<void>
-{
-  protected:
-    StdVec<StdLargeVec<Real>> diffusion_species_s_; /**< Intermediate state */
-    SimpleDynamics<InitializationRK<typename FirstStageType::InnerParticlesType>> rk2_initialization_;
-    Dynamics1Level<FirstStageType> rk2_1st_stage_;
-    Dynamics1Level<SecondStageRK2<FirstStageType>> rk2_2nd_stage_;
-    StdVec<BaseDiffusion *> all_diffusions_;
+    /**
+     * @class RelaxationOfAllDiffusionSpeciesRobinContact
+     * @brief Contact diffusion relaxation with Robin boundary condition.
+     */
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact>
+    class DiffusionRelaxationRobin
+        : public BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>
+    {
+        StdLargeVec<Vecd> &n_;
+        StdVec<StdLargeVec<Real> *> contact_convection_;
+        StdVec<Real *> contact_T_infinity_;
+        StdVec<StdLargeVec<Vecd> *> contact_n_;
 
-  public:
-    template <typename... ContactArgsType>
-    explicit DiffusionRelaxationRK2(typename FirstStageType::BodyRelationType &body_relation,
-                                    ContactArgsType &&...contact_args);
-    virtual ~DiffusionRelaxationRK2(){};
+    protected:
+        void getDiffusionChangeRateRobin(size_t particle_i, size_t particle_j, Real surface_area_ij_Robin, size_t k);
 
-    virtual void exec(Real dt = 0.0) override;
-};
-} // namespace SPH
-#endif // DIFFUSION_DYNAMICS_H
+    public:
+        explicit DiffusionRelaxationRobin(BaseContactRelation &contact_relation);
+        virtual ~DiffusionRelaxationRobin(){};
+
+        inline void interaction(size_t index_i, Real dt = 0.0);
+    };
+
+    /**
+     * @class InitializationRK
+     * @brief Initialization of a runge-kutta integration scheme.
+     */
+    template <class ParticlesType>
+    class InitializationRK : public BaseDiffusionRelaxation<ParticlesType>
+    {
+    protected:
+        StdVec<StdLargeVec<Real>> &diffusion_species_s_;
+
+    public:
+        InitializationRK(SPHBody &sph_body, StdVec<StdLargeVec<Real>> &diffusion_species_s);
+        virtual ~InitializationRK(){};
+
+        void update(size_t index_i, Real dt = 0.0);
+    };
+
+    /**
+     * @class SecondStageRK2
+     * @brief The second stage of the 2nd-order Runge-Kutta scheme.
+     */
+    template <class FirstStageType>
+    class SecondStageRK2 : public FirstStageType
+    {
+    protected:
+        StdVec<StdLargeVec<Real>> &diffusion_species_s_;
+
+    public:
+        template <typename... ContactArgsType>
+        SecondStageRK2(typename FirstStageType::BodyRelationType &body_relation
+                     , StdVec<StdLargeVec<Real>> &diffusion_species_s
+                     , ContactArgsType &&...contact_args)
+            : FirstStageType(body_relation, std::forward<ContactArgsType>(contact_args)...)
+            , diffusion_species_s_(diffusion_species_s)
+        {};
+        virtual ~SecondStageRK2(){};
+
+        void update(size_t index_i, Real dt = 0.0);
+    };
+
+    /**
+     * @class DiffusionRelaxationRK2
+     * @brief The 2nd-order runge-kutta integration scheme.
+     *        A intermediate state for species is introduced here to achieve multi-step integration.
+     */
+    template <class FirstStageType>
+    class DiffusionRelaxationRK2 : public BaseDynamics<void>
+    {
+    protected:
+        StdVec<StdLargeVec<Real>> diffusion_species_s_;                         /**< Intermediate state */
+
+        SimpleDynamics<InitializationRK<typename FirstStageType::InnerParticlesType>> rk2_initialization_;
+        Dynamics1Level<FirstStageType> rk2_1st_stage_;
+        Dynamics1Level<SecondStageRK2<FirstStageType>> rk2_2nd_stage_;
+        StdVec<BaseDiffusion *> all_diffusions_;
+
+    public:
+        template <typename... ContactArgsType>
+        explicit DiffusionRelaxationRK2(typename FirstStageType::BodyRelationType &body_relation, ContactArgsType &&...contact_args);
+        virtual ~DiffusionRelaxationRK2(){};
+
+        virtual void exec(Real dt = 0.0) override;
+    };
+}         // namespace SPH
+#endif    // DIFFUSION_DYNAMICS_H

--- a/src/shared/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics.h
+++ b/src/shared/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics.h
@@ -183,8 +183,8 @@ namespace SPH
      * @class DiffusionRelaxationContact
      * @brief Base class for diffusion relaxation process between two contact bodies.
      */
-    template <class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact>
-    class BaseDiffusionRelaxationContact : public BaseDiffusionRelaxation<ParticlesType>
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact, template<class> class BaseDiffusionRelaxationType = BaseDiffusionRelaxation>
+    class BaseDiffusionRelaxationContact : public BaseDiffusionRelaxationType<ParticlesType>
                                          , public DataDelegateContact<ParticlesType, ContactParticlesType, DataDelegateEmptyBase>
     {
     protected:
@@ -202,9 +202,9 @@ namespace SPH
      * @class DiffusionRelaxationContact
      * @brief Contact diffusion relaxation with Dirichlet boundary condition.
      */
-    template < class DiffusionType, class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact>
+    template < class DiffusionType, class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact, template<class> class BaseDiffusionRelaxationType = BaseDiffusionRelaxation>
     class DiffusionRelaxationContact
-        : public BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>
+        : public BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
     {
         StdVec<StdVec<BaseDiffusion *>> all_contact_diffusions_;
         StdVec<StdVec< ContactDiffusivity<DiffusionType> >> contact_thermal_diffusivities_;
@@ -220,13 +220,16 @@ namespace SPH
         inline void interaction(size_t index_i, Real dt = 0.0);
     };
 
+    template <class DiffusionType, class ParticlesType, class KernelGradientType = KernelGradientContact>
+    using ThermalDiffusionRelaxationContact = DiffusionRelaxationContact<DiffusionType, ParticlesType, KernelGradientType, BaseThermalDiffusionRelaxation<ParticlesType>>;
+
     /**
      * @class DiffusionRelaxationDirichlet
      * @brief Contact diffusion relaxation with Dirichlet boundary condition.
      */
-    template <class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact>
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact, template<class> class BaseDiffusionRelaxationType = BaseDiffusionRelaxation>
     class DiffusionRelaxationDirichlet
-        : public BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>
+        : public BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
     {
     protected:
         StdVec<StdVec<StdLargeVec<Real> *>> contact_gradient_species_;
@@ -238,13 +241,16 @@ namespace SPH
         inline void interaction(size_t index_i, Real dt = 0.0);
     };
 
+    template <class ParticlesType, class KernelGradientType = KernelGradientContact>
+    using ThermalDiffusionRelaxationDirichlet = DiffusionRelaxationDirichlet<ParticlesType, KernelGradientType, BaseThermalDiffusionRelaxation<ParticlesType>>;
+
     /**
      * @class DiffusionRelaxationNeumann
      * @brief Contact diffusion relaxation with Neumann boundary condition.
      */
-    template <class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact>
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact, template<class> class BaseDiffusionRelaxationType = BaseDiffusionRelaxation>
     class DiffusionRelaxationNeumann
-        : public BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>
+        : public BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
     {
         StdLargeVec<Vecd> &n_;
         StdVec<StdLargeVec<Real> *> contact_heat_flux_;
@@ -260,13 +266,16 @@ namespace SPH
         inline void interaction(size_t index_i, Real dt = 0.0);
     };
 
+    template <class ParticlesType, class KernelGradientType = KernelGradientContact>
+    using ThermalDiffusionRelaxationNeumann = DiffusionRelaxationNeumann<ParticlesType, KernelGradientType, BaseThermalDiffusionRelaxation<ParticlesType>>;
+
     /**
      * @class RelaxationOfAllDiffusionSpeciesRobinContact
      * @brief Contact diffusion relaxation with Robin boundary condition.
      */
-    template <class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact>
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact, template<class> class BaseDiffusionRelaxationType = BaseDiffusionRelaxation>
     class DiffusionRelaxationRobin
-        : public BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>
+        : public BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
     {
         StdLargeVec<Vecd> &n_;
         StdVec<StdLargeVec<Real> *> contact_convection_;
@@ -282,6 +291,9 @@ namespace SPH
 
         inline void interaction(size_t index_i, Real dt = 0.0);
     };
+
+    template <class ParticlesType, class KernelGradientType = KernelGradientContact>
+    using ThermalDiffusionRelaxationRobin = DiffusionRelaxationRobin<ParticlesType, KernelGradientType, BaseThermalDiffusionRelaxation<ParticlesType>>;
 
     /**
      * @class InitializationRK

--- a/src/shared/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics.h
+++ b/src/shared/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics.h
@@ -241,6 +241,27 @@ namespace SPH
     };
 
     /**
+     * @class DiffusionRelaxationContact
+     * @brief Contact diffusion relaxation with Dirichlet boundary condition.
+     */
+    template < class DiffusionType, class ParticlesType, class ContactParticlesType, class KernelGradientType = KernelGradientContact>
+    class DiffusionRelaxationMutimaterialContact
+        : public BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>
+    {
+        StdVec<StdVec<BaseDiffusion *>> all_contact_diffusions_;
+        StdVec<StdVec< ThermalDiffusivity<DiffusionType> >> contact_thermal_diffusivities_;
+        StdVec<StdVec<StdLargeVec<Real> *>> contact_gradient_species_;
+
+     protected: 
+        void getDiffusionChangeRateMultimaterialContact(size_t particle_i, size_t particle_j, Vecd &e_ij, Real surface_area_ij, size_t contact_k);
+
+    public:
+        explicit DiffusionRelaxationMutimaterialContact(BaseContactRelation &contact_relation);
+        virtual ~DiffusionRelaxationMutimaterialContact(){};
+        inline void interaction(size_t index_i, Real dt = 0.0);
+    };
+
+    /**
      * @class InitializationRK
      * @brief Initialization of a runge-kutta integration scheme.
      */

--- a/src/shared/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics.hpp
+++ b/src/shared/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics.hpp
@@ -11,405 +11,418 @@
 
 namespace SPH
 {
-//=================================================================================================//
-template <class ParticlesType>
-GetDiffusionTimeStepSize<ParticlesType>::GetDiffusionTimeStepSize(SPHBody &sph_body)
-    : BaseDynamics<Real>(sph_body)
-    , DiffusionReactionSimpleData<ParticlesType>(sph_body)
-{
-    Real smoothing_length = sph_body.sph_adaptation_->ReferenceSmoothingLength();
-    diff_time_step_ = this->particles_->diffusion_reaction_material_.getDiffusionTimeStepSize(smoothing_length);
-}
-//=================================================================================================//
-template <class ParticlesType>
-BaseDiffusionRelaxation<ParticlesType>::BaseDiffusionRelaxation(SPHBody &sph_body)
-    : LocalDynamics(sph_body)
-    , DiffusionReactionSimpleData<ParticlesType>(sph_body)
-    , material_(this->particles_->diffusion_reaction_material_)
-    , all_diffusions_(material_.AllDiffusions())
-    , diffusion_species_(this->particles_->DiffusionSpecies())
-    , gradient_species_(this->particles_->GradientSpecies())
-{
-    diffusion_dt_.resize(all_diffusions_.size());
-    StdVec<std::string> &all_species_names = this->particles_->AllSpeciesNames();
-    IndexVector &diffusion_species_indexes = material_.DiffusionSpeciesIndexes();
+    //=================================================================================================//
+    template <class ParticlesType>
+    GetDiffusionTimeStepSize<ParticlesType>::GetDiffusionTimeStepSize(SPHBody &sph_body)
+        : BaseDynamics<Real>(sph_body)
+        , DiffusionReactionSimpleData<ParticlesType>(sph_body)
+    {
+        Real smoothing_length = sph_body.sph_adaptation_->ReferenceSmoothingLength();
+        diff_time_step_ = this->particles_->diffusion_reaction_material_.getDiffusionTimeStepSize(smoothing_length);
+    }
+    //=================================================================================================//
+    template <class ParticlesType>
+    BaseDiffusionRelaxation<ParticlesType>::BaseDiffusionRelaxation(SPHBody &sph_body)
+        : LocalDynamics(sph_body)
+        , DiffusionReactionSimpleData<ParticlesType>(sph_body)
+        , material_(this->particles_->diffusion_reaction_material_)
+        , all_diffusions_(material_.AllDiffusions())
+        , diffusion_species_(this->particles_->DiffusionSpecies())
+        , gradient_species_(this->particles_->GradientSpecies())
+    {
+        diffusion_dt_.resize(all_diffusions_.size());
+        StdVec<std::string> &all_species_names = this->particles_->AllSpeciesNames();
+        IndexVector &diffusion_species_indexes = material_.DiffusionSpeciesIndexes();
 
-    for (size_t i = 0; i != all_diffusions_.size(); ++i)
-    {
-        std::string &diffusion_species_name = all_species_names[diffusion_species_indexes[i]];
-        diffusion_dt_[i] = this->particles_->template registerSharedVariable<Real>(diffusion_species_name + "ChangeRate");
-        all_thermal_capcity_reciprocal_.push_back(all_diffusions_[i]->getThermalCapacityReciprocal());
-    }
-}
-//=================================================================================================//
-template <class ParticlesType>
-void BaseDiffusionRelaxation<ParticlesType>::initialization(size_t index_i, Real dt)
-{
-    for (size_t m = 0; m < all_diffusions_.size(); ++m)
-    {
-        (*diffusion_dt_[m])[index_i] = 0;
-    }
-}
-//=================================================================================================//
-template <class ParticlesType>
-void BaseDiffusionRelaxation<ParticlesType>::update(size_t index_i, Real dt)
-{
-    for (size_t m = 0; m < all_diffusions_.size(); ++m)
-    {
-        (*diffusion_species_[m])[index_i] += dt * (*diffusion_dt_[m])[index_i];
-    }
-}
-//=================================================================================================//
-template <class ParticlesType, class KernelGradientType>
-DiffusionRelaxationInner<ParticlesType, KernelGradientType>::DiffusionRelaxationInner(BaseInnerRelation &inner_relation)
-    : BaseDiffusionRelaxation<ParticlesType>(inner_relation.getSPHBody())
-    , DataDelegateInner<ParticlesType, DataDelegateEmptyBase>(inner_relation)
-    , rho_(this->particles_->rho_)
-    , kernel_gradient_(this->particles_) 
-{}
-//=================================================================================================//
-template <class ParticlesType, class KernelGradientType>
-void DiffusionRelaxationInner<ParticlesType, KernelGradientType>
-    ::getDiffusionChangeRate(size_t particle_i, size_t particle_j, Vecd &e_ij, Real surface_area_ij)
-{
-    for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
-    {
-        Real diff_coeff_ij = this->all_diffusions_[m]->getInterParticleDiffusionCoeff(particle_i, particle_j, e_ij);
-        StdLargeVec<Real> &gradient_species = *this->gradient_species_[m];
-        Real phi_ij = gradient_species[particle_i] - gradient_species[particle_j];
-
-        (*this->diffusion_dt_[m])[particle_i] += this->all_thermal_capcity_reciprocal_[m] * diff_coeff_ij * phi_ij * surface_area_ij;
-    }
-}
-//=================================================================================================//
-template <class ParticlesType, class KernelGradientType>
-void DiffusionRelaxationInner<ParticlesType, KernelGradientType>::interaction(size_t index_i, Real dt)
-{
-    Real rho_reciprocal = 1.0 / rho_[index_i]; 
-    Neighborhood &inner_neighborhood = this->inner_configuration_[index_i];
-    for (size_t n = 0; n != inner_neighborhood.current_size_; ++n)
-    {
-        size_t index_j = inner_neighborhood.j_[n];
-        Real dW_ijV_j_ = inner_neighborhood.dW_ijV_j_[n];
-        Real r_ij_ = inner_neighborhood.r_ij_[n];
-        Vecd &e_ij = inner_neighborhood.e_ij_[n];
-
-        const Vecd &grad_ijV_j = this->kernel_gradient_(index_i, index_j, dW_ijV_j_, e_ij);
-        Real area_ij = 2.0 * rho_reciprocal * grad_ijV_j.dot(e_ij) / r_ij_;
-        getDiffusionChangeRate(index_i, index_j, e_ij, area_ij);
-    }
-}
-//=================================================================================================//
-template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>
-    :: BaseDiffusionRelaxationContact(BaseContactRelation &contact_relation)
-    : BaseDiffusionRelaxation<ParticlesType>(contact_relation.getSPHBody()),
-      DataDelegateContact<ParticlesType, ContactParticlesType, DataDelegateEmptyBase>
-(contact_relation)
-{
-    StdVec<std::string> &all_species_names = this->particles_->AllSpeciesNames();
-    contact_gradient_species_names_.resize(this->contact_particles_.size());
-
-    for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
-    {
-        size_t l = this->all_diffusions_[m]->gradient_species_index_;
-        std::string &inner_species_name_m = all_species_names[l];
-        for (size_t k = 0; k != this->contact_particles_.size(); ++k)
+        for (size_t i = 0; i != all_diffusions_.size(); ++i)
         {
-            auto all_species_map_k = this->contact_particles_[k]->AllSpeciesIndexMap();
-            if (all_species_map_k.find(inner_species_name_m) != all_species_map_k.end())
-            {
-                contact_gradient_species_names_[k].push_back(inner_species_name_m);
-            }
-            else
-            {
-                std::cout << "\n Error: inner species '" << inner_species_name_m
-                          << "' is not found in contact particles" << std::endl;
-                std::cout << __FILE__ << ':' << __LINE__ << std::endl;
-                exit(1);
-            }
+            std::string &diffusion_species_name = all_species_names[diffusion_species_indexes[i]];
+            diffusion_dt_[i] = this->particles_->template registerSharedVariable<Real>(diffusion_species_name + "ChangeRate");
+            all_thermal_capcity_reciprocal_.push_back(all_diffusions_[i]->getThermalCapacityReciprocal());
         }
     }
-
-    for (size_t k = 0; k != this->contact_particles_.size(); ++k)
+    //=================================================================================================//
+    template <class ParticlesType>
+    void BaseDiffusionRelaxation<ParticlesType>::initialization(size_t index_i, Real dt)
     {
-        contact_kernel_gradients_.push_back(KernelGradientType(this->particles_, this->contact_particles_[k]));
-    }
-}
-//=================================================================================================//
-template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-DiffusionRelaxationDirichlet<ParticlesType, ContactParticlesType, KernelGradientType>
-    :: DiffusionRelaxationDirichlet(BaseContactRelation &contact_relation)
-    : BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>
-(contact_relation)
-{
-    contact_gradient_species_.resize(this->contact_particles_.size());
-
-    for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
-    {
-        for (size_t k = 0; k != this->contact_particles_.size(); ++k)
+        for (size_t m = 0; m < all_diffusions_.size(); ++m)
         {
-            std::string contact_species_names_k_m = this->contact_gradient_species_names_[k][m];
-            auto all_species_map_k = this->contact_particles_[k]->AllSpeciesIndexMap();
-            size_t contact_species_index_k_m = all_species_map_k[contact_species_names_k_m];
-            StdVec<StdLargeVec<Real>> &all_contact_species_k = this->contact_particles_[k]->all_species_;
-            contact_gradient_species_[k].push_back(&all_contact_species_k[contact_species_index_k_m]);
+            (*diffusion_dt_[m])[index_i] = 0;
         }
     }
-}
-//=================================================================================================//
-template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-void DiffusionRelaxationDirichlet<ParticlesType, ContactParticlesType, KernelGradientType>
-    :: getDiffusionChangeRateDirichlet(size_t particle_i, size_t particle_j, Vecd &e_ij, Real surface_area_ij, size_t k)
-{
-    for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
+    //=================================================================================================//
+    template <class ParticlesType>
+    void BaseDiffusionRelaxation<ParticlesType>::update(size_t index_i, Real dt)
     {
-        Real diff_coeff_ij =
-            this->all_diffusions_[m]->getInterParticleDiffusionCoeff(particle_i, particle_i, e_ij);
-        Real phi_ij = (*this->gradient_species_[m])[particle_i] - (*contact_gradient_species_[k][m])[particle_j];
-        (*this->diffusion_dt_[m])[particle_i] += diff_coeff_ij * phi_ij * surface_area_ij;
-    }
-}
-//=================================================================================================//
-template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-void DiffusionRelaxationDirichlet<ParticlesType, ContactParticlesType, KernelGradientType>
-    :: interaction(size_t index_i, Real dt)
-{
-    for (size_t k = 0; k < this->contact_configuration_.size(); ++k)
-    {
-        Neighborhood &contact_neighborhood = (*this->contact_configuration_[k])[index_i];
-        for (size_t n = 0; n != contact_neighborhood.current_size_; ++n)
+        for (size_t m = 0; m < all_diffusions_.size(); ++m)
         {
-            size_t index_j = contact_neighborhood.j_[n];
-            Real r_ij_ = contact_neighborhood.r_ij_[n];
-            Real dW_ijV_j_ = contact_neighborhood.dW_ijV_j_[n];
-            Vecd &e_ij = contact_neighborhood.e_ij_[n];
+            (*diffusion_species_[m])[index_i] += dt * (*diffusion_dt_[m])[index_i];
+        }
+    }
+    //=================================================================================================//
+    template <class ParticlesType>
+    BaseThermalDiffusionRelaxation<ParticlesType>::BaseThermalDiffusionRelaxation(SPHBody &sph_body)
+        : BaseDiffusionRelaxation<ParticlesType>(sph_body)
+        , rho_(this->particles_->rho_)
+    {}
+    //=================================================================================================//
+    template <class ParticlesType>
+    void BaseThermalDiffusionRelaxation<ParticlesType>::update(size_t index_i, Real dt)
+    {
+        Real rho_reciprocal = 1.0 / rho_[index_i]; 
+        for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
+        {
+            (*this->diffusion_species_[m])[index_i] += dt * rho_reciprocal * (*this->diffusion_dt_[m])[index_i];
+        }
+    }
+    //=================================================================================================//
+    template <class ParticlesType, class KernelGradientType>
+    DiffusionRelaxationInner<ParticlesType, KernelGradientType>::DiffusionRelaxationInner(BaseInnerRelation &inner_relation)
+        : BaseDiffusionRelaxation<ParticlesType>(inner_relation.getSPHBody())
+        , DataDelegateInner<ParticlesType, DataDelegateEmptyBase>(inner_relation)
+        , kernel_gradient_(this->particles_) 
+    {}
+    //=================================================================================================//
+    template <class ParticlesType, class KernelGradientType>
+    void DiffusionRelaxationInner<ParticlesType, KernelGradientType>
+        ::getDiffusionChangeRate(size_t particle_i, size_t particle_j, Vecd &e_ij, Real surface_area_ij)
+    {
+        for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
+        {
+            Real diff_coeff_ij = this->all_diffusions_[m]->getInterParticleDiffusionCoeff(particle_i, particle_j, e_ij);
+            StdLargeVec<Real> &gradient_species = *this->gradient_species_[m];
+            Real phi_ij = gradient_species[particle_i] - gradient_species[particle_j];
 
-            const Vecd &grad_ijV_j = this->contact_kernel_gradients_[k](index_i, index_j, dW_ijV_j_, e_ij);
+            (*this->diffusion_dt_[m])[particle_i] += this->all_thermal_capcity_reciprocal_[m] * diff_coeff_ij * phi_ij * surface_area_ij;
+        }
+    }
+    //=================================================================================================//
+    template <class ParticlesType, class KernelGradientType>
+    void DiffusionRelaxationInner<ParticlesType, KernelGradientType>::interaction(size_t index_i, Real dt)
+    { 
+        Neighborhood &inner_neighborhood = this->inner_configuration_[index_i];
+        for (size_t n = 0; n != inner_neighborhood.current_size_; ++n)
+        {
+            size_t index_j = inner_neighborhood.j_[n];
+            Real dW_ijV_j_ = inner_neighborhood.dW_ijV_j_[n];
+            Real r_ij_ = inner_neighborhood.r_ij_[n];
+            Vecd &e_ij = inner_neighborhood.e_ij_[n];
+
+            const Vecd &grad_ijV_j = this->kernel_gradient_(index_i, index_j, dW_ijV_j_, e_ij);
             Real area_ij = 2.0 * grad_ijV_j.dot(e_ij) / r_ij_;
-            getDiffusionChangeRateDirichlet(index_i, index_j, e_ij, area_ij, k);
+            getDiffusionChangeRate(index_i, index_j, e_ij, area_ij);
         }
     }
-}
-//=================================================================================================//
-template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-DiffusionRelaxationNeumann<ParticlesType, ContactParticlesType, KernelGradientType>
-    :: DiffusionRelaxationNeumann(BaseContactRelation &contact_relation)
-    : BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>(contact_relation)
-    , n_(this->particles_->n_)
-{
-    contact_heat_flux_.resize(this->contact_particles_.size());
-    for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
+    //=================================================================================================//
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
+    BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>
+        :: BaseDiffusionRelaxationContact(BaseContactRelation &contact_relation)
+        : BaseDiffusionRelaxation<ParticlesType>(contact_relation.getSPHBody())
+        , DataDelegateContact<ParticlesType, ContactParticlesType, DataDelegateEmptyBase>(contact_relation)
     {
-        for (size_t k = 0; k != this->contact_particles_.size(); ++k)
-        {
-            contact_n_.push_back(&(this->contact_particles_[k]->n_));
-            contact_heat_flux_[k] = this->contact_particles_[k]->template registerSharedVariable<Real>("HeatFlux");
-        }
-    }
-}
-//=================================================================================================//
-template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-void DiffusionRelaxationNeumann<ParticlesType, ContactParticlesType, KernelGradientType>
-    :: getDiffusionChangeRateNeumann(size_t particle_i, size_t particle_j, Real surface_area_ij_Neumann, size_t k)
-{
-    for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
-    {
-        (*this->diffusion_dt_[m])[particle_i] += surface_area_ij_Neumann * (*contact_heat_flux_[k])[particle_j];
-    }
-}
-//=================================================================================================//
-template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-void DiffusionRelaxationNeumann<ParticlesType, ContactParticlesType, KernelGradientType>
-    :: interaction(size_t index_i, Real dt)
-{
-    for (size_t k = 0; k < this->contact_configuration_.size(); ++k)
-    {
-        StdLargeVec<Vecd> &n_k = *(contact_n_[k]);
-        Neighborhood &contact_neighborhood = (*this->contact_configuration_[k])[index_i];
-
-        for (size_t n = 0; n != contact_neighborhood.current_size_; ++n)
-        {
-            size_t index_j = contact_neighborhood.j_[n];
-            Real dW_ijV_j_ = contact_neighborhood.dW_ijV_j_[n];
-            Vecd &e_ij = contact_neighborhood.e_ij_[n];
-
-            const Vecd &grad_ijV_j = this->contact_kernel_gradients_[k](index_i, index_j, dW_ijV_j_, e_ij);
-            Vecd n_ij = n_[index_i] - n_k[index_j];
-            Real area_ij_Neumann = grad_ijV_j.dot(n_ij);
-            getDiffusionChangeRateNeumann(index_i, index_j, area_ij_Neumann, k);
-        }
-    }
-}
-//=================================================================================================//
-template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-DiffusionRelaxationRobin<ParticlesType, ContactParticlesType, KernelGradientType>
-    :: DiffusionRelaxationRobin(BaseContactRelation &contact_relation)
-    : BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>(contact_relation)
-    , n_(this->particles_->n_)
-{
-    contact_convection_.resize(this->contact_particles_.size());
-    contact_T_infinity_.resize(this->all_diffusions_.size());
-
-    for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
-    {
-        for (size_t k = 0; k != this->contact_particles_.size(); ++k)
-        {
-            contact_n_.push_back(&(this->contact_particles_[k]->n_));
-            contact_convection_[k] = this->contact_particles_[k]->template registerSharedVariable<Real>("Convection");
-            contact_T_infinity_[m] = this->contact_particles_[k]->template registerGlobalVariable<Real>("T_infinity");
-        }
-    }
-}
-//=================================================================================================//
-template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-void DiffusionRelaxationRobin<ParticlesType, ContactParticlesType, KernelGradientType>
-    :: getDiffusionChangeRateRobin(size_t particle_i, size_t particle_j
-                                 , Real surface_area_ij_Robin, size_t k)
-{
-    for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
-    {
-        Real phi_ij = *contact_T_infinity_[k] - (*this->diffusion_species_[m])[particle_i];
-        (*this->diffusion_dt_[m])[particle_i] += (*contact_convection_[k])[particle_j] * phi_ij * surface_area_ij_Robin;
-    }
-}
-//=================================================================================================//
-template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-void DiffusionRelaxationRobin<ParticlesType, ContactParticlesType, KernelGradientType>
-    :: interaction(size_t index_i, Real dt)
-{
-    for (size_t k = 0; k < this->contact_configuration_.size(); ++k)
-    {
-        StdLargeVec<Vecd> &n_k = *(contact_n_[k]);
-        Neighborhood &contact_neighborhood = (*this->contact_configuration_[k])[index_i];
-        for (size_t n = 0; n != contact_neighborhood.current_size_; ++n)
-        {
-            size_t index_j = contact_neighborhood.j_[n];
-            Real dW_ijV_j_ = contact_neighborhood.dW_ijV_j_[n];
-            Vecd &e_ij = contact_neighborhood.e_ij_[n];
-
-            const Vecd &grad_ijV_j = this->contact_kernel_gradients_[k](index_i, index_j, dW_ijV_j_, e_ij);
-            Vecd n_ij = n_[index_i] - n_k[index_j];
-            Real area_ij_Robin = grad_ijV_j.dot(n_ij);
-            getDiffusionChangeRateRobin(index_i, index_j, area_ij_Robin, k);
-        }
-    }
-}
-//=================================================================================================//
-template <class DiffusionType, class ParticlesType, class ContactParticlesType, class KernelGradientType>
-DiffusionRelaxationMutimaterialContact<DiffusionType, ParticlesType, ContactParticlesType, KernelGradientType>::
-    DiffusionRelaxationMutimaterialContact(BaseContactRelation &contact_relation)
-    : BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>(contact_relation)
-{
-    all_contact_diffusions_.resize(this->contact_particles_.size());
-    contact_thermal_diffusivities_.resize(this->contact_particles_.size());
-    contact_gradient_species_.resize(this->contact_particles_.size());
-    
-    for (size_t k = 0; k != this->contact_particles_.size(); ++k)
-    {
-        all_contact_diffusions_[k] = this->contact_particles_[k]->diffusion_reaction_material_.AllDiffusions();
+        StdVec<std::string> &all_species_names = this->particles_->AllSpeciesNames();
+        contact_gradient_species_names_.resize(this->contact_particles_.size());
 
         for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
         {
-            std::string contact_species_names_k_m = this->contact_gradient_species_names_[k][m];
-            auto all_species_map_k = this->contact_particles_[k]->AllSpeciesIndexMap();
-            size_t contact_species_index_k_m = all_species_map_k[contact_species_names_k_m];
-            StdVec<StdLargeVec<Real>> &all_contact_species_k = this->contact_particles_[k]->all_species_;
-            contact_gradient_species_[k].push_back(&all_contact_species_k[contact_species_index_k_m]);
-
-            contact_thermal_diffusivities_[k].push_back( ThermalDiffusivity<DiffusionType>(
-                DynamicCast<DiffusionType>(this, *this->all_diffusions_[m]), 
-                DynamicCast<DiffusionType>(this,  *all_contact_diffusions_[k][m]) ));
+            size_t l = this->all_diffusions_[m]->gradient_species_index_;
+            std::string &inner_species_name_m = all_species_names[l];
+            for (size_t k = 0; k != this->contact_particles_.size(); ++k)
+            {
+                auto all_species_map_k = this->contact_particles_[k]->AllSpeciesIndexMap();
+                if (all_species_map_k.find(inner_species_name_m) != all_species_map_k.end())
+                {
+                    contact_gradient_species_names_[k].push_back(inner_species_name_m);
+                }
+                else
+                {
+                    std::cout << "\n Error: inner species '" << inner_species_name_m
+                            << "' is not found in contact particles" << std::endl;
+                    std::cout << __FILE__ << ':' << __LINE__ << std::endl;
+                    exit(1);
+                }
+            }
         }
-    }
-} // fluid_(DynamicCast<Fluid>(this, particles_->getBaseMaterial())),
-//=================================================================================================//
-template <class DiffusionType, class ParticlesType, class ContactParticlesType, class KernelGradientType>
-void DiffusionRelaxationMutimaterialContact<DiffusionType, ParticlesType, ContactParticlesType, KernelGradientType>::
-    getDiffusionChangeRateMultimaterialContact(size_t particle_i, size_t particle_j, Vecd &e_ij,Real surface_area_ij,  size_t contact_k)
-{
-    for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
-    {
-        Real diff_coeff_ij = contact_thermal_diffusivities_[contact_k][m].getInterParticleDiffusivity(particle_i, particle_i, e_ij);
-        Real phi_ij = (*this->gradient_species_[m])[particle_i] - (*contact_gradient_species_[contact_k][m])[particle_j];
-        (*this->diffusion_dt_[m])[particle_i] += diff_coeff_ij * phi_ij * surface_area_ij;
-    }
-}
-//=================================================================================================//
-template <class DiffusionType, class ParticlesType, class ContactParticlesType, class KernelGradientType>
-void DiffusionRelaxationMutimaterialContact<DiffusionType, ParticlesType, ContactParticlesType, KernelGradientType>::
-    interaction(size_t index_i, Real dt)
-{
-    for (size_t k = 0; k < this->contact_configuration_.size(); ++k)
-    {
-        Neighborhood &contact_neighborhood = (*this->contact_configuration_[k])[index_i];
-        for (size_t n = 0; n != contact_neighborhood.current_size_; ++n)
+
+        for (size_t k = 0; k != this->contact_particles_.size(); ++k)
         {
-            size_t index_j = contact_neighborhood.j_[n];
-            Real r_ij_ = contact_neighborhood.r_ij_[n];
-            Real dW_ijV_j_ = contact_neighborhood.dW_ijV_j_[n];
-            Vecd &e_ij = contact_neighborhood.e_ij_[n];
-
-            const Vecd &grad_ijV_j = this->contact_kernel_gradients_[k](index_i, index_j, dW_ijV_j_, e_ij);
-            Real area_ij = 2.0 * grad_ijV_j.dot(e_ij) / r_ij_;
-            getDiffusionChangeRateMultimaterialContact(index_i, index_j, e_ij, area_ij, k);
+            contact_kernel_gradients_.push_back(KernelGradientType(this->particles_, this->contact_particles_[k]));
         }
     }
-}
-//=================================================================================================//
-template <class ParticlesType>
-InitializationRK<ParticlesType>::InitializationRK(SPHBody &sph_body, StdVec<StdLargeVec<Real>> &diffusion_species_s)
-    : BaseDiffusionRelaxation<ParticlesType>(sph_body)
-    , diffusion_species_s_(diffusion_species_s) 
-{}
-//=================================================================================================//
-template <class ParticlesType>
-void InitializationRK<ParticlesType>::update(size_t index_i, Real dt)
-{
-    for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
+    //=================================================================================================//
+    template <class DiffusionType, class ParticlesType, class ContactParticlesType, class KernelGradientType>
+    DiffusionRelaxationContact<DiffusionType, ParticlesType, ContactParticlesType, KernelGradientType>::
+        DiffusionRelaxationContact(BaseContactRelation &contact_relation)
+        : BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>(contact_relation)
     {
-        diffusion_species_s_[m][index_i] = (*this->diffusion_species_[m])[index_i];
-    }
-}
-//=================================================================================================//
-template <class FirstStageType>
-void SecondStageRK2<FirstStageType>::update(size_t index_i, Real dt)
-{
-    FirstStageType::update(index_i, dt);
-    for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
+        all_contact_diffusions_.resize(this->contact_particles_.size());
+        contact_thermal_diffusivities_.resize(this->contact_particles_.size());
+        contact_gradient_species_.resize(this->contact_particles_.size());
+        
+        for (size_t k = 0; k != this->contact_particles_.size(); ++k)
+        {
+            all_contact_diffusions_[k] = this->contact_particles_[k]->diffusion_reaction_material_.AllDiffusions();
+
+            for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
+            {
+                std::string contact_species_names_k_m = this->contact_gradient_species_names_[k][m];
+                auto all_species_map_k = this->contact_particles_[k]->AllSpeciesIndexMap();
+                size_t contact_species_index_k_m = all_species_map_k[contact_species_names_k_m];
+                StdVec<StdLargeVec<Real>> &all_contact_species_k = this->contact_particles_[k]->all_species_;
+                contact_gradient_species_[k].push_back(&all_contact_species_k[contact_species_index_k_m]);
+
+                contact_thermal_diffusivities_[k].push_back( ContactDiffusivity<DiffusionType>(
+                    DynamicCast<DiffusionType>(this, *this->all_diffusions_[m]), 
+                    DynamicCast<DiffusionType>(this,  *all_contact_diffusions_[k][m]) ));
+            }
+        }
+    } 
+    //=================================================================================================//
+    template <class DiffusionType, class ParticlesType, class ContactParticlesType, class KernelGradientType>
+    void DiffusionRelaxationContact<DiffusionType, ParticlesType, ContactParticlesType, KernelGradientType>::
+        getDiffusionChangeRateMultimaterialContact(size_t particle_i, size_t particle_j, Vecd &e_ij,Real surface_area_ij,  size_t contact_k)
     {
-        (*this->diffusion_species_[m])[index_i] = 0.5 * diffusion_species_s_[m][index_i] +
-                                                  0.5 * (*this->diffusion_species_[m])[index_i];
+        for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
+        {
+            Real diff_coeff_ij = contact_thermal_diffusivities_[contact_k][m].getInterParticleDiffusivity(particle_i, particle_i, e_ij);
+            Real phi_ij = (*this->gradient_species_[m])[particle_i] - (*contact_gradient_species_[contact_k][m])[particle_j];
+            (*this->diffusion_dt_[m])[particle_i] += diff_coeff_ij * phi_ij * surface_area_ij;
+        }
     }
-}
-//=================================================================================================//
-template <class FirstStageType>
-template <typename... ContactArgsType>
-DiffusionRelaxationRK2<FirstStageType>:: DiffusionRelaxationRK2(typename FirstStageType::BodyRelationType &body_relation
-                                                              , ContactArgsType &&...contact_args)
-    : BaseDynamics<void>(body_relation.getSPHBody())
-    , rk2_initialization_(body_relation.getSPHBody(), diffusion_species_s_)
-    , rk2_1st_stage_(body_relation, std::forward<ContactArgsType>(contact_args)...)
-    , rk2_2nd_stage_(body_relation, diffusion_species_s_, std::forward<ContactArgsType>(contact_args)...)
-    , all_diffusions_(rk2_1st_stage_.AllDiffusions())
-{
-    diffusion_species_s_.resize(all_diffusions_.size());
-    StdVec<std::string> &all_species_names = rk2_1st_stage_.getParticles()->AllSpeciesNames();
-    for (size_t i = 0; i != all_diffusions_.size(); ++i)
+    //=================================================================================================//
+    template <class DiffusionType, class ParticlesType, class ContactParticlesType, class KernelGradientType>
+    void DiffusionRelaxationContact<DiffusionType, ParticlesType, ContactParticlesType, KernelGradientType>::
+        interaction(size_t index_i, Real dt)
     {
-        size_t diffusion_species_index = all_diffusions_[i]->diffusion_species_index_;
-        std::string &diffusion_species_name = all_species_names[diffusion_species_index];
-        rk2_1st_stage_.getParticles()->registerVariable(diffusion_species_s_[i], diffusion_species_name + "Intermediate");
+        for (size_t k = 0; k < this->contact_configuration_.size(); ++k)
+        {
+            Neighborhood &contact_neighborhood = (*this->contact_configuration_[k])[index_i];
+            for (size_t n = 0; n != contact_neighborhood.current_size_; ++n)
+            {
+                size_t index_j = contact_neighborhood.j_[n];
+                Real r_ij_ = contact_neighborhood.r_ij_[n];
+                Real dW_ijV_j_ = contact_neighborhood.dW_ijV_j_[n];
+                Vecd &e_ij = contact_neighborhood.e_ij_[n];
+
+                const Vecd &grad_ijV_j = this->contact_kernel_gradients_[k](index_i, index_j, dW_ijV_j_, e_ij);
+                Real area_ij = 2.0 * grad_ijV_j.dot(e_ij) / r_ij_;
+                getDiffusionChangeRateMultimaterialContact(index_i, index_j, e_ij, area_ij, k);
+            }
+        }
     }
-}
+    //=================================================================================================//
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
+    DiffusionRelaxationDirichlet<ParticlesType, ContactParticlesType, KernelGradientType>
+        :: DiffusionRelaxationDirichlet(BaseContactRelation &contact_relation)
+        : BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>
+    (contact_relation)
+    {
+        contact_gradient_species_.resize(this->contact_particles_.size());
+
+        for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
+        {
+            for (size_t k = 0; k != this->contact_particles_.size(); ++k)
+            {
+                std::string contact_species_names_k_m = this->contact_gradient_species_names_[k][m];
+                auto all_species_map_k = this->contact_particles_[k]->AllSpeciesIndexMap();
+                size_t contact_species_index_k_m = all_species_map_k[contact_species_names_k_m];
+                StdVec<StdLargeVec<Real>> &all_contact_species_k = this->contact_particles_[k]->all_species_;
+                contact_gradient_species_[k].push_back(&all_contact_species_k[contact_species_index_k_m]);
+            }
+        }
+    }
+    //=================================================================================================//
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
+    void DiffusionRelaxationDirichlet<ParticlesType, ContactParticlesType, KernelGradientType>
+        :: getDiffusionChangeRateDirichlet(size_t particle_i, size_t particle_j, Vecd &e_ij, Real surface_area_ij, size_t k)
+    {
+        for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
+        {
+            Real diff_coeff_ij =
+                this->all_diffusions_[m]->getInterParticleDiffusionCoeff(particle_i, particle_i, e_ij);
+            Real phi_ij = (*this->gradient_species_[m])[particle_i] - (*contact_gradient_species_[k][m])[particle_j];
+            (*this->diffusion_dt_[m])[particle_i] += diff_coeff_ij * phi_ij * surface_area_ij;
+        }
+    }
+    //=================================================================================================//
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
+    void DiffusionRelaxationDirichlet<ParticlesType, ContactParticlesType, KernelGradientType>
+        :: interaction(size_t index_i, Real dt)
+    {
+        for (size_t k = 0; k < this->contact_configuration_.size(); ++k)
+        {
+            Neighborhood &contact_neighborhood = (*this->contact_configuration_[k])[index_i];
+            for (size_t n = 0; n != contact_neighborhood.current_size_; ++n)
+            {
+                size_t index_j = contact_neighborhood.j_[n];
+                Real r_ij_ = contact_neighborhood.r_ij_[n];
+                Real dW_ijV_j_ = contact_neighborhood.dW_ijV_j_[n];
+                Vecd &e_ij = contact_neighborhood.e_ij_[n];
+
+                const Vecd &grad_ijV_j = this->contact_kernel_gradients_[k](index_i, index_j, dW_ijV_j_, e_ij);
+                Real area_ij = 2.0 * grad_ijV_j.dot(e_ij) / r_ij_;
+                getDiffusionChangeRateDirichlet(index_i, index_j, e_ij, area_ij, k);
+            }
+        }
+    }
+    //=================================================================================================//
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
+    DiffusionRelaxationNeumann<ParticlesType, ContactParticlesType, KernelGradientType>
+        :: DiffusionRelaxationNeumann(BaseContactRelation &contact_relation)
+        : BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>(contact_relation)
+        , n_(this->particles_->n_)
+    {
+        contact_heat_flux_.resize(this->contact_particles_.size());
+        for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
+        {
+            for (size_t k = 0; k != this->contact_particles_.size(); ++k)
+            {
+                contact_n_.push_back(&(this->contact_particles_[k]->n_));
+                contact_heat_flux_[k] = this->contact_particles_[k]->template registerSharedVariable<Real>("HeatFlux");
+            }
+        }
+    }
+    //=================================================================================================//
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
+    void DiffusionRelaxationNeumann<ParticlesType, ContactParticlesType, KernelGradientType>
+        :: getDiffusionChangeRateNeumann(size_t particle_i, size_t particle_j, Real surface_area_ij_Neumann, size_t k)
+    {
+        for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
+        {
+            (*this->diffusion_dt_[m])[particle_i] += surface_area_ij_Neumann * (*contact_heat_flux_[k])[particle_j];
+        }
+    }
+    //=================================================================================================//
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
+    void DiffusionRelaxationNeumann<ParticlesType, ContactParticlesType, KernelGradientType>
+        :: interaction(size_t index_i, Real dt)
+    {
+        for (size_t k = 0; k < this->contact_configuration_.size(); ++k)
+        {
+            StdLargeVec<Vecd> &n_k = *(contact_n_[k]);
+            Neighborhood &contact_neighborhood = (*this->contact_configuration_[k])[index_i];
+
+            for (size_t n = 0; n != contact_neighborhood.current_size_; ++n)
+            {
+                size_t index_j = contact_neighborhood.j_[n];
+                Real dW_ijV_j_ = contact_neighborhood.dW_ijV_j_[n];
+                Vecd &e_ij = contact_neighborhood.e_ij_[n];
+
+                const Vecd &grad_ijV_j = this->contact_kernel_gradients_[k](index_i, index_j, dW_ijV_j_, e_ij);
+                Vecd n_ij = n_[index_i] - n_k[index_j];
+                Real area_ij_Neumann = grad_ijV_j.dot(n_ij);
+                getDiffusionChangeRateNeumann(index_i, index_j, area_ij_Neumann, k);
+            }
+        }
+    }
+    //=================================================================================================//
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
+    DiffusionRelaxationRobin<ParticlesType, ContactParticlesType, KernelGradientType>
+        :: DiffusionRelaxationRobin(BaseContactRelation &contact_relation)
+        : BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>(contact_relation)
+        , n_(this->particles_->n_)
+    {
+        contact_convection_.resize(this->contact_particles_.size());
+        contact_T_infinity_.resize(this->all_diffusions_.size());
+
+        for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
+        {
+            for (size_t k = 0; k != this->contact_particles_.size(); ++k)
+            {
+                contact_n_.push_back(&(this->contact_particles_[k]->n_));
+                contact_convection_[k] = this->contact_particles_[k]->template registerSharedVariable<Real>("Convection");
+                contact_T_infinity_[m] = this->contact_particles_[k]->template registerGlobalVariable<Real>("T_infinity");
+            }
+        }
+    }
+    //=================================================================================================//
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
+    void DiffusionRelaxationRobin<ParticlesType, ContactParticlesType, KernelGradientType>
+        :: getDiffusionChangeRateRobin(size_t particle_i, size_t particle_j
+                                    , Real surface_area_ij_Robin, size_t k)
+    {
+        for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
+        {
+            Real phi_ij = *contact_T_infinity_[k] - (*this->diffusion_species_[m])[particle_i];
+            (*this->diffusion_dt_[m])[particle_i] += (*contact_convection_[k])[particle_j] * phi_ij * surface_area_ij_Robin;
+        }
+    }
+    //=================================================================================================//
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
+    void DiffusionRelaxationRobin<ParticlesType, ContactParticlesType, KernelGradientType>
+        :: interaction(size_t index_i, Real dt)
+    {
+        for (size_t k = 0; k < this->contact_configuration_.size(); ++k)
+        {
+            StdLargeVec<Vecd> &n_k = *(contact_n_[k]);
+            Neighborhood &contact_neighborhood = (*this->contact_configuration_[k])[index_i];
+            for (size_t n = 0; n != contact_neighborhood.current_size_; ++n)
+            {
+                size_t index_j = contact_neighborhood.j_[n];
+                Real dW_ijV_j_ = contact_neighborhood.dW_ijV_j_[n];
+                Vecd &e_ij = contact_neighborhood.e_ij_[n];
+
+                const Vecd &grad_ijV_j = this->contact_kernel_gradients_[k](index_i, index_j, dW_ijV_j_, e_ij);
+                Vecd n_ij = n_[index_i] - n_k[index_j];
+                Real area_ij_Robin = grad_ijV_j.dot(n_ij);
+                getDiffusionChangeRateRobin(index_i, index_j, area_ij_Robin, k);
+            }
+        }
+    }
+    //=================================================================================================//
+    template <class ParticlesType>
+    InitializationRK<ParticlesType>::InitializationRK(SPHBody &sph_body, StdVec<StdLargeVec<Real>> &diffusion_species_s)
+        : BaseDiffusionRelaxation<ParticlesType>(sph_body)
+        , diffusion_species_s_(diffusion_species_s) 
+    {}
+    //=================================================================================================//
+    template <class ParticlesType>
+    void InitializationRK<ParticlesType>::update(size_t index_i, Real dt)
+    {
+        for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
+        {
+            diffusion_species_s_[m][index_i] = (*this->diffusion_species_[m])[index_i];
+        }
+    }
+    //=================================================================================================//
+    template <class FirstStageType>
+    void SecondStageRK2<FirstStageType>::update(size_t index_i, Real dt)
+    {
+        FirstStageType::update(index_i, dt);
+        for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
+        {
+            (*this->diffusion_species_[m])[index_i] = 0.5 * diffusion_species_s_[m][index_i] +
+                                                    0.5 * (*this->diffusion_species_[m])[index_i];
+        }
+    }
+    //=================================================================================================//
+    template <class FirstStageType>
+    template <typename... ContactArgsType>
+    DiffusionRelaxationRK2<FirstStageType>:: DiffusionRelaxationRK2(typename FirstStageType::BodyRelationType &body_relation
+                                                                , ContactArgsType &&...contact_args)
+        : BaseDynamics<void>(body_relation.getSPHBody())
+        , rk2_initialization_(body_relation.getSPHBody(), diffusion_species_s_)
+        , rk2_1st_stage_(body_relation, std::forward<ContactArgsType>(contact_args)...)
+        , rk2_2nd_stage_(body_relation, diffusion_species_s_, std::forward<ContactArgsType>(contact_args)...)
+        , all_diffusions_(rk2_1st_stage_.AllDiffusions())
+    {
+        diffusion_species_s_.resize(all_diffusions_.size());
+        StdVec<std::string> &all_species_names = rk2_1st_stage_.getParticles()->AllSpeciesNames();
+        for (size_t i = 0; i != all_diffusions_.size(); ++i)
+        {
+            size_t diffusion_species_index = all_diffusions_[i]->diffusion_species_index_;
+            std::string &diffusion_species_name = all_species_names[diffusion_species_index];
+            rk2_1st_stage_.getParticles()->registerVariable(diffusion_species_s_[i], diffusion_species_name + "Intermediate");
+        }
+    }
+    //=================================================================================================//
+    template <class FirstStageType>
+    void DiffusionRelaxationRK2<FirstStageType>::exec(Real dt)
+    {
+        rk2_initialization_.exec();
+        rk2_1st_stage_.exec(dt);
+        rk2_2nd_stage_.exec(dt);
+    }
 //=================================================================================================//
-template <class FirstStageType>
-void DiffusionRelaxationRK2<FirstStageType>::exec(Real dt)
-{
-    rk2_initialization_.exec();
-    rk2_1st_stage_.exec(dt);
-    rk2_2nd_stage_.exec(dt);
-}
-//=================================================================================================//
-} // namespace SPH
-#endif // DIFFUSION_DYNAMICS_HPP
+}       // namespace SPH
+#endif  // DIFFUSION_DYNAMICS_HPP

--- a/src/shared/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics.hpp
+++ b/src/shared/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics.hpp
@@ -113,10 +113,10 @@ namespace SPH
         }
     }
     //=================================================================================================//
-    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-    BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType, template<class> class BaseDiffusionRelaxationType>
+    BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
         :: BaseDiffusionRelaxationContact(BaseContactRelation &contact_relation)
-        : BaseDiffusionRelaxation<ParticlesType>(contact_relation.getSPHBody())
+        : BaseDiffusionRelaxationType<ParticlesType>(contact_relation.getSPHBody())
         , DataDelegateContact<ParticlesType, ContactParticlesType, DataDelegateEmptyBase>(contact_relation)
     {
         StdVec<std::string> &all_species_names = this->particles_->AllSpeciesNames();
@@ -149,10 +149,10 @@ namespace SPH
         }
     }
     //=================================================================================================//
-    template <class DiffusionType, class ParticlesType, class ContactParticlesType, class KernelGradientType>
-    DiffusionRelaxationContact<DiffusionType, ParticlesType, ContactParticlesType, KernelGradientType>::
-        DiffusionRelaxationContact(BaseContactRelation &contact_relation)
-        : BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>(contact_relation)
+    template <class DiffusionType, class ParticlesType, class ContactParticlesType, class KernelGradientType, template<class> class BaseDiffusionRelaxationType>
+    DiffusionRelaxationContact<DiffusionType, ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
+        :: DiffusionRelaxationContact(BaseContactRelation &contact_relation)
+        : BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>(contact_relation)
     {
         all_contact_diffusions_.resize(this->contact_particles_.size());
         contact_thermal_diffusivities_.resize(this->contact_particles_.size());
@@ -177,9 +177,9 @@ namespace SPH
         }
     } 
     //=================================================================================================//
-    template <class DiffusionType, class ParticlesType, class ContactParticlesType, class KernelGradientType>
-    void DiffusionRelaxationContact<DiffusionType, ParticlesType, ContactParticlesType, KernelGradientType>::
-        getDiffusionChangeRateMultimaterialContact(size_t particle_i, size_t particle_j, Vecd &e_ij,Real surface_area_ij,  size_t contact_k)
+    template <class DiffusionType, class ParticlesType, class ContactParticlesType, class KernelGradientType, template<class> class BaseDiffusionRelaxationType>
+    void DiffusionRelaxationContact<DiffusionType, ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
+        :: getDiffusionChangeRateMultimaterialContact(size_t particle_i, size_t particle_j, Vecd &e_ij,Real surface_area_ij,  size_t contact_k)
     {
         for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
         {
@@ -189,9 +189,9 @@ namespace SPH
         }
     }
     //=================================================================================================//
-    template <class DiffusionType, class ParticlesType, class ContactParticlesType, class KernelGradientType>
-    void DiffusionRelaxationContact<DiffusionType, ParticlesType, ContactParticlesType, KernelGradientType>::
-        interaction(size_t index_i, Real dt)
+    template <class DiffusionType, class ParticlesType, class ContactParticlesType, class KernelGradientType, template<class> class BaseDiffusionRelaxationType>
+    void DiffusionRelaxationContact<DiffusionType, ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
+        :: interaction(size_t index_i, Real dt)
     {
         for (size_t k = 0; k < this->contact_configuration_.size(); ++k)
         {
@@ -210,10 +210,10 @@ namespace SPH
         }
     }
     //=================================================================================================//
-    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-    DiffusionRelaxationDirichlet<ParticlesType, ContactParticlesType, KernelGradientType>
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType, template<class> class BaseDiffusionRelaxationType>
+    DiffusionRelaxationDirichlet<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
         :: DiffusionRelaxationDirichlet(BaseContactRelation &contact_relation)
-        : BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>
+        : BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
     (contact_relation)
     {
         contact_gradient_species_.resize(this->contact_particles_.size());
@@ -231,8 +231,8 @@ namespace SPH
         }
     }
     //=================================================================================================//
-    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-    void DiffusionRelaxationDirichlet<ParticlesType, ContactParticlesType, KernelGradientType>
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType, template<class> class BaseDiffusionRelaxationType>
+    void DiffusionRelaxationDirichlet<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
         :: getDiffusionChangeRateDirichlet(size_t particle_i, size_t particle_j, Vecd &e_ij, Real surface_area_ij, size_t k)
     {
         for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
@@ -244,8 +244,8 @@ namespace SPH
         }
     }
     //=================================================================================================//
-    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-    void DiffusionRelaxationDirichlet<ParticlesType, ContactParticlesType, KernelGradientType>
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType, template<class> class BaseDiffusionRelaxationType>
+    void DiffusionRelaxationDirichlet<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
         :: interaction(size_t index_i, Real dt)
     {
         for (size_t k = 0; k < this->contact_configuration_.size(); ++k)
@@ -265,10 +265,10 @@ namespace SPH
         }
     }
     //=================================================================================================//
-    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-    DiffusionRelaxationNeumann<ParticlesType, ContactParticlesType, KernelGradientType>
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType, template<class> class BaseDiffusionRelaxationType>
+    DiffusionRelaxationNeumann<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
         :: DiffusionRelaxationNeumann(BaseContactRelation &contact_relation)
-        : BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>(contact_relation)
+        : BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>(contact_relation)
         , n_(this->particles_->n_)
     {
         contact_heat_flux_.resize(this->contact_particles_.size());
@@ -282,8 +282,8 @@ namespace SPH
         }
     }
     //=================================================================================================//
-    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-    void DiffusionRelaxationNeumann<ParticlesType, ContactParticlesType, KernelGradientType>
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType, template<class> class BaseDiffusionRelaxationType>
+    void DiffusionRelaxationNeumann<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
         :: getDiffusionChangeRateNeumann(size_t particle_i, size_t particle_j, Real surface_area_ij_Neumann, size_t k)
     {
         for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
@@ -292,8 +292,8 @@ namespace SPH
         }
     }
     //=================================================================================================//
-    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-    void DiffusionRelaxationNeumann<ParticlesType, ContactParticlesType, KernelGradientType>
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType, template<class> class BaseDiffusionRelaxationType>
+    void DiffusionRelaxationNeumann<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
         :: interaction(size_t index_i, Real dt)
     {
         for (size_t k = 0; k < this->contact_configuration_.size(); ++k)
@@ -315,10 +315,10 @@ namespace SPH
         }
     }
     //=================================================================================================//
-    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-    DiffusionRelaxationRobin<ParticlesType, ContactParticlesType, KernelGradientType>
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType, template<class> class BaseDiffusionRelaxationType>
+    DiffusionRelaxationRobin<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
         :: DiffusionRelaxationRobin(BaseContactRelation &contact_relation)
-        : BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType>(contact_relation)
+        : BaseDiffusionRelaxationContact<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>(contact_relation)
         , n_(this->particles_->n_)
     {
         contact_convection_.resize(this->contact_particles_.size());
@@ -335,8 +335,8 @@ namespace SPH
         }
     }
     //=================================================================================================//
-    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-    void DiffusionRelaxationRobin<ParticlesType, ContactParticlesType, KernelGradientType>
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType, template<class> class BaseDiffusionRelaxationType>
+    void DiffusionRelaxationRobin<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
         :: getDiffusionChangeRateRobin(size_t particle_i, size_t particle_j
                                     , Real surface_area_ij_Robin, size_t k)
     {
@@ -347,8 +347,8 @@ namespace SPH
         }
     }
     //=================================================================================================//
-    template <class ParticlesType, class ContactParticlesType, class KernelGradientType>
-    void DiffusionRelaxationRobin<ParticlesType, ContactParticlesType, KernelGradientType>
+    template <class ParticlesType, class ContactParticlesType, class KernelGradientType, template<class> class BaseDiffusionRelaxationType>
+    void DiffusionRelaxationRobin<ParticlesType, ContactParticlesType, KernelGradientType, BaseDiffusionRelaxationType>
         :: interaction(size_t index_i, Real dt)
     {
         for (size_t k = 0; k < this->contact_configuration_.size(); ++k)

--- a/src/shared/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics.hpp
+++ b/src/shared/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics.hpp
@@ -60,22 +60,6 @@ namespace SPH
         }
     }
     //=================================================================================================//
-    template <class ParticlesType>
-    BaseThermalDiffusionRelaxation<ParticlesType>::BaseThermalDiffusionRelaxation(SPHBody &sph_body)
-        : BaseDiffusionRelaxation<ParticlesType>(sph_body)
-        , rho_(this->particles_->rho_)
-    {}
-    //=================================================================================================//
-    template <class ParticlesType>
-    void BaseThermalDiffusionRelaxation<ParticlesType>::update(size_t index_i, Real dt)
-    {
-        Real rho_reciprocal = 1.0 / rho_[index_i]; 
-        for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
-        {
-            (*this->diffusion_species_[m])[index_i] += dt * rho_reciprocal * (*this->diffusion_dt_[m])[index_i];
-        }
-    }
-    //=================================================================================================//
     template <class ParticlesType, class KernelGradientType>
     DiffusionRelaxationInner<ParticlesType, KernelGradientType>::DiffusionRelaxationInner(BaseInnerRelation &inner_relation)
         : BaseDiffusionRelaxation<ParticlesType>(inner_relation.getSPHBody())
@@ -111,6 +95,21 @@ namespace SPH
             const Vecd &grad_ijV_j = this->kernel_gradient_(index_i, index_j, dW_ijV_j_, e_ij);
             Real area_ij = 2.0 * grad_ijV_j.dot(e_ij) / r_ij_;
             getDiffusionChangeRate(index_i, index_j, e_ij, area_ij);
+        }
+    }
+    //=================================================================================================//
+    template <class ParticlesType, class KernelGradientType>
+    ThermalDiffusionRelaxationInner<ParticlesType, KernelGradientType>::ThermalDiffusionRelaxationInner(BaseInnerRelation &inner_relation)
+        : DiffusionRelaxationInner<ParticlesType, KernelGradientType>(inner_relation)
+        , rho_(this->particles_->rho_)
+    {}
+    //=================================================================================================//
+    template <class ParticlesType, class KernelGradientType>
+    void ThermalDiffusionRelaxationInner<ParticlesType, KernelGradientType>::update(size_t index_i, Real dt)
+    {
+        for (size_t m = 0; m < this->all_diffusions_.size(); ++m)
+        {
+            (*this->diffusion_species_[m])[index_i] += dt * (*this->diffusion_dt_[m])[index_i] / rho_[index_i];
         }
     }
     //=================================================================================================//

--- a/tests/user_examples/test_2d_VP_problem1_same_sink_nonop/VP_problem1_same_sink_nonop.cpp
+++ b/tests/user_examples/test_2d_VP_problem1_same_sink_nonop/VP_problem1_same_sink_nonop.cpp
@@ -82,7 +82,7 @@ class DiffusionMaterial : public DiffusionReaction<Solid>
 public:
 	DiffusionMaterial() : DiffusionReaction<Solid>({ "Phi" }, SharedPtr<NoReaction>())
 	{
-		initializeAnDiffusion<LocalIsotropicDiffusion>("Phi", "Phi", diffusion_coeff);
+		initializeAnDiffusion<LocalIsotropicThermalDiffusion>("Phi", "Phi", diffusion_coeff);
 	}
 };
 

--- a/tests/user_examples/test_2d_VP_problem1_same_sink_opt/VP_problem1_same_sink_opt.cpp
+++ b/tests/user_examples/test_2d_VP_problem1_same_sink_opt/VP_problem1_same_sink_opt.cpp
@@ -82,7 +82,7 @@ class DiffusionMaterial : public DiffusionReaction<Solid>
 public:
 	DiffusionMaterial() : DiffusionReaction<Solid>({ "Phi" }, SharedPtr<NoReaction>())
 	{
-		initializeAnDiffusion<LocalIsotropicDiffusion>("Phi", "Phi", diffusion_coeff);
+		initializeAnDiffusion<LocalIsotropicThermalDiffusion>("Phi", "Phi", diffusion_coeff);
 	}
 };
 

--- a/tests/user_examples/test_2d_VP_problem4_heat_flux_nonop/VP_problem4_heat_flux_nonop.cpp
+++ b/tests/user_examples/test_2d_VP_problem4_heat_flux_nonop/VP_problem4_heat_flux_nonop.cpp
@@ -94,7 +94,7 @@ class DiffusionMaterial : public DiffusionReaction<Solid>
 public:
 	DiffusionMaterial() : DiffusionReaction<Solid>({ "Phi" }, SharedPtr<NoReaction>())
 	{
-		initializeAnDiffusion<LocalIsotropicDiffusion>("Phi", "Phi", diffusion_coeff);
+		initializeAnDiffusion<LocalIsotropicThermalDiffusion>("Phi", "Phi", diffusion_coeff);
 	}
 };
 

--- a/tests/user_examples/test_2d_VP_problem4_heat_flux_opt/VP_problem4_heat_flux_opt.cpp
+++ b/tests/user_examples/test_2d_VP_problem4_heat_flux_opt/VP_problem4_heat_flux_opt.cpp
@@ -95,7 +95,7 @@ class DiffusionMaterial : public DiffusionReaction<Solid>
 public:
 	DiffusionMaterial() : DiffusionReaction<Solid>({ "Phi" }, SharedPtr<NoReaction>())
 	{
-		initializeAnDiffusion<LocalIsotropicDiffusion>("Phi", "Phi", diffusion_coeff);
+		initializeAnDiffusion<LocalIsotropicThermalDiffusion>("Phi", "Phi", diffusion_coeff);
 	}
 };
 


### PR DESCRIPTION
1, introduce thermal diffusion material, whose constant parameter should be density, capacity and conductivity, and thermal diffusivity is the thermal conductivity divided by density and specific heat capacity. 
2, thermal diffusion dynamics is add, as its accurate SPH approximation is  rho * cp * (dT/dt) = 2 * sum (2.0 k1 * k2 / (k1 + k2)) * grad w * V, which consider the variation of density and exhibits better performance when different conductivity involved. 
3, contact dynamics is added for different conductivity. 