### PR TITLE
[SYCL] Particle sorting and homogenized ND range kernels

### DIFF
--- a/src/for_2D_build/meshes/base_mesh_supplementary.cpp
+++ b/src/for_2D_build/meshes/base_mesh_supplementary.cpp
@@ -19,5 +19,10 @@ size_t BaseMesh::transferMeshIndexToMortonOrder(const Array2i &mesh_index)
 {
     return MortonCode(mesh_index[0]) | (MortonCode(mesh_index[1]) << 1);
 }
+//=============================================================================================//
+size_t BaseMesh::transferMeshIndexToMortonOrder(const DeviceArray2i &mesh_index)
+{
+    return MortonCode(mesh_index[0]) | (MortonCode(mesh_index[1]) << 1);
+}
 } // namespace SPH
 //=============================================================================================//

--- a/src/for_2D_build/meshes/cell_linked_list.hpp
+++ b/src/for_2D_build/meshes/cell_linked_list.hpp
@@ -52,30 +52,34 @@ void CellLinkedListKernel::searchNeighborsByParticles(
     auto *pos = dynamics_range.getBaseParticles().template getDeviceVariableByName<DeviceVec2d>("Position");
     auto get_neighbor_relation_kernel = *get_neighbor_relation.getDeviceProxy().getKernel();
     const int search_depth = get_search_depth(0);
+    const auto loop_range = dynamics_range.LoopRange();
     executionQueue.getQueue()
         .submit(
             [&, index_list=index_list_, index_head_list=index_head_list_, list_data_pos=list_data_pos_,
              list_data_Vol=list_data_Vol_, mesh_lower_bound=mesh_lower_bound_,
              grid_spacing=grid_spacing_, all_grid_points=all_grid_points_, all_cells=all_cells_](sycl::handler &cgh) {
-                cgh.parallel_for(dynamics_range.LoopRange(), [=](sycl::item<1> it) {
-                                     const size_t index_i = it.get_id(0);
-                                     const auto& pos_i = pos[index_i];
-                                     auto &neighborhood = particle_configuration[index_i];
-                                     const auto target_cell_index = CellIndexFromPosition(pos_i, mesh_lower_bound,
-                                                                             grid_spacing, all_grid_points);
-                                     mesh_for_each(
-                                         sycl::max(DeviceArray2i{0}, DeviceArray2i{target_cell_index - search_depth}),
-                                         sycl::min(all_cells, DeviceArray2i{target_cell_index + search_depth + 1}),
-                                         [&](int l, int m) {
-                                             const auto linear_cell_index = transferCellIndexTo1D({l,m}, all_cells);
-                                             size_t index_j = index_head_list[linear_cell_index];
-                                             // Cell list ends when index_j == 0, if index_j is already zero then cell is empty.
-                                             while(index_j--) {  // abbreviates while(index_j != 0) { index_j -= 1; ... }
-                                                 get_neighbor_relation_kernel(neighborhood, pos_i, index_i, index_j, list_data_pos[index_j],
-                                                                              list_data_Vol[index_j]);
-                                                 index_j = index_list[index_j];
-                                             }
-                                         });
+                cgh.parallel_for(executionQueue.getUniformNdRange(loop_range), [=](sycl::nd_item<1> it) {
+                                     const size_t index_i = it.get_global_id(0);
+                                     if(index_i < loop_range)
+                                     {
+                                         const auto& pos_i = pos[index_i];
+                                         auto &neighborhood = particle_configuration[index_i];
+                                         const auto target_cell_index = CellIndexFromPosition(pos_i, mesh_lower_bound,
+                                                                                 grid_spacing, all_grid_points);
+                                         mesh_for_each(
+                                             sycl::max(DeviceArray2i{0}, DeviceArray2i{target_cell_index - search_depth}),
+                                             sycl::min(all_cells, DeviceArray2i{target_cell_index + search_depth + 1}),
+                                             [&](int l, int m) {
+                                                 const auto linear_cell_index = transferCellIndexTo1D({l,m}, all_cells);
+                                                 size_t index_j = index_head_list[linear_cell_index];
+                                                 // Cell list ends when index_j == 0, if index_j is already zero then cell is empty.
+                                                 while(index_j--) {  // abbreviates while(index_j != 0) { index_j -= 1; ... }
+                                                     get_neighbor_relation_kernel(neighborhood, pos_i, index_i, index_j, list_data_pos[index_j],
+                                                                                  list_data_Vol[index_j]);
+                                                     index_j = index_list[index_j];
+                                                 }
+                                             });
+                                     }
                                  });
             }).wait_and_throw();
 }

--- a/src/shared/bodies/base_body.h
+++ b/src/shared/bodies/base_body.h
@@ -252,13 +252,7 @@ class RealBody : public SPHBody
     void updateCellLinkedListWithParticleSort(size_t particle_sort_period, ExecutionPolicy execution_policy = execution::par)
     {
         if (iteration_count_ % particle_sort_period == 0)
-        {
-            if constexpr (std::is_same_v<ExecutionPolicy, execution::ParallelSYCLDevicePolicy>)
-                base_particles_->copyFromDeviceMemory();
-            base_particles_->sortParticles(getCellLinkedList(), execution_policy);
-            if constexpr (std::is_same_v<ExecutionPolicy, execution::ParallelSYCLDevicePolicy>)
-                base_particles_->copyToDeviceMemory();
-        }
+                base_particles_->sortParticles(getCellLinkedList(execution_policy), execution_policy);
 
         iteration_count_++;
         updateCellLinkedList(execution_policy);

--- a/src/shared/common/base_data_package.h
+++ b/src/shared/common/base_data_package.h
@@ -141,6 +141,40 @@ struct DataAssembleOperation
         integer_operation(std::forward<OperationArgs>(operation_args)...);
     }
 };
+
+template <template <typename VariableType> typename OperationType>
+struct DeviceDataAssembleOperation
+{
+    template <class VariablesAssemble>
+    explicit DeviceDataAssembleOperation(VariablesAssemble &&assemble)
+        : scalar_operation(std::forward<VariablesAssemble>(assemble)),
+          vector2d_operation(std::forward<VariablesAssemble>(assemble)),
+          vector3d_operation(std::forward<VariablesAssemble>(assemble)) {}
+
+    DeviceDataAssembleOperation() = default;
+
+    template <typename... OperationArgs>
+    void init(OperationArgs &&...operation_args)
+    {
+        scalar_operation.init(std::forward<OperationArgs>(operation_args)...);
+        vector2d_operation.init(std::forward<OperationArgs>(operation_args)...);
+        vector3d_operation.init(std::forward<OperationArgs>(operation_args)...);
+    }
+
+    template <typename... OperationArgs>
+    std::vector<sycl::event> operator()(OperationArgs &&...operation_args) const
+    {
+        return {
+            scalar_operation(std::forward<OperationArgs>(operation_args)...),
+            vector2d_operation(std::forward<OperationArgs>(operation_args)...),
+            vector3d_operation(std::forward<OperationArgs>(operation_args)...)};
+    }
+
+  private:
+    OperationType<DeviceReal> scalar_operation;
+    OperationType<DeviceVec2d> vector2d_operation;
+    OperationType<DeviceVec3d> vector3d_operation;
+};
 } // namespace SPH
 
 #endif // BASE_DATA_PACKAGE_H

--- a/src/shared/common/base_data_type.h
+++ b/src/shared/common/base_data_type.h
@@ -100,7 +100,7 @@ using DeviceArray3i = sycl::int3;
 
 template<typename Type, class Enable = void>
 struct DataTypeEquivalence {
-    static constexpr bool exists = false;
+    static constexpr bool type_defined = false;
     static_assert("Type non recognized as host or device type.");
 };
 
@@ -109,42 +109,42 @@ using enable_if_is_either_t = std::enable_if_t<std::disjunction_v<std::is_same<C
 
 template<class TypeReal>
 struct DataTypeEquivalence<TypeReal, enable_if_is_either_t<TypeReal, Real, DeviceReal>> {
-    static constexpr bool exists = true;
-    using host_t = Real;
-    using device_t = DeviceReal;
+    static constexpr bool type_defined = true;
+    using host_type = Real;
+    using device_type = DeviceReal;
 };
 
 template<class TypeVec2d>
 struct DataTypeEquivalence<TypeVec2d, enable_if_is_either_t<TypeVec2d, Vec2d, DeviceVec2d>> {
-    static constexpr bool exists = true;
-    using host_t = Vec2d;
-    using device_t = DeviceVec2d;
+    static constexpr bool type_defined = true;
+    using host_type = Vec2d;
+    using device_type = DeviceVec2d;
 };
 
 template<class TypeVec3d>
 struct DataTypeEquivalence<TypeVec3d, enable_if_is_either_t<TypeVec3d, Vec3d, DeviceVec3d>> {
-    static constexpr bool exists = true;
-    using host_t = Vec3d;
-    using device_t = DeviceVec3d;
+    static constexpr bool type_defined = true;
+    using host_type = Vec3d;
+    using device_type = DeviceVec3d;
 };
 
 template<class TypeArray2i>
 struct DataTypeEquivalence<TypeArray2i, enable_if_is_either_t<TypeArray2i, Array2i , DeviceArray2i >> {
-    static constexpr bool exists = true;
-    using host_t = Array2i;
-    using device_t = DeviceArray2i;
+    static constexpr bool type_defined = true;
+    using host_type = Array2i;
+    using device_type = DeviceArray2i;
 };
 
 template<class TypeArray3i>
 struct DataTypeEquivalence<TypeArray3i, enable_if_is_either_t<TypeArray3i, Array3i , DeviceArray3i>> {
-    static constexpr bool exists = true;
-    using host_t = Array3i;
-    using device_t = DeviceArray3i;
+    static constexpr bool type_defined = true;
+    using host_type = Array3i;
+    using device_type = DeviceArray3i;
 };
 
 template<class CheckType, class HostOrDeviceType>
-using enable_both_host_device_t = enable_if_is_either_t<CheckType, typename DataTypeEquivalence<HostOrDeviceType>::host_t,
-                                                         typename DataTypeEquivalence<HostOrDeviceType>::device_t>;
+using enable_both_host_device_t = enable_if_is_either_t<CheckType, typename DataTypeEquivalence<HostOrDeviceType>::host_type,
+                                                         typename DataTypeEquivalence<HostOrDeviceType>::device_type>;
 
 /** Unified initialize to zero for all data type. */
 /**
@@ -207,7 +207,7 @@ struct DataTypeIndex<int>
 
 template<typename DeviceType>
 using is_device_type_different_from_host =
-    std::conditional_t<std::is_same_v<DeviceType, typename DataTypeEquivalence<DeviceType>::host_t>, std::false_type, std::true_type>;
+    std::conditional_t<std::is_same_v<DeviceType, typename DataTypeEquivalence<DeviceType>::host_type>, std::false_type, std::true_type>;
 
 template <>
 struct DataTypeIndex<DeviceReal, is_device_type_different_from_host<DeviceReal>>

--- a/src/shared/common/base_data_type.h
+++ b/src/shared/common/base_data_type.h
@@ -100,6 +100,7 @@ using DeviceArray3i = sycl::int3;
 
 template<typename Type, class Enable = void>
 struct DataTypeEquivalence {
+    static constexpr bool exists = false;
     static_assert("Type non recognized as host or device type.");
 };
 
@@ -108,30 +109,35 @@ using enable_if_is_either_t = std::enable_if_t<std::disjunction_v<std::is_same<C
 
 template<class TypeReal>
 struct DataTypeEquivalence<TypeReal, enable_if_is_either_t<TypeReal, Real, DeviceReal>> {
+    static constexpr bool exists = true;
     using host_t = Real;
     using device_t = DeviceReal;
 };
 
 template<class TypeVec2d>
 struct DataTypeEquivalence<TypeVec2d, enable_if_is_either_t<TypeVec2d, Vec2d, DeviceVec2d>> {
+    static constexpr bool exists = true;
     using host_t = Vec2d;
     using device_t = DeviceVec2d;
 };
 
 template<class TypeVec3d>
 struct DataTypeEquivalence<TypeVec3d, enable_if_is_either_t<TypeVec3d, Vec3d, DeviceVec3d>> {
+    static constexpr bool exists = true;
     using host_t = Vec3d;
     using device_t = DeviceVec3d;
 };
 
 template<class TypeArray2i>
 struct DataTypeEquivalence<TypeArray2i, enable_if_is_either_t<TypeArray2i, Array2i , DeviceArray2i >> {
+    static constexpr bool exists = true;
     using host_t = Array2i;
     using device_t = DeviceArray2i;
 };
 
 template<class TypeArray3i>
 struct DataTypeEquivalence<TypeArray3i, enable_if_is_either_t<TypeArray3i, Array3i , DeviceArray3i>> {
+    static constexpr bool exists = true;
     using host_t = Array3i;
     using device_t = DeviceArray3i;
 };

--- a/src/shared/io_system/io_observation.h
+++ b/src/shared/io_system/io_observation.h
@@ -66,7 +66,7 @@ class ObservedQuantityRecording : public BodyStatesRecording,
         /** Copy data from device when executing with device policy */
         if constexpr (std::is_same_v<ExecutionPolicy, ParallelSYCLDevicePolicy>) {
             auto* device_data = this->getParticles()->
-                                template getDeviceVariableByName<typename DataTypeEquivalence<VariableType>::device_t>(quantity_name_);
+                                template getDeviceVariableByName<typename DataTypeEquivalence<VariableType>::device_type>(quantity_name_);
             copyDataFromDevice(this->interpolated_quantities_->data(), device_data, this->getParticles()->total_real_particles_);
         }
 
@@ -92,7 +92,7 @@ class ObservedQuantityRecording : public BodyStatesRecording,
         /** Copy data from device when executing with device policy */
         if constexpr (std::is_same_v<ExecutionPolicy, ParallelSYCLDevicePolicy>) {
             auto* device_data = this->getParticles()->
-                                template getDeviceVariableByName<typename DataTypeEquivalence<VariableType>::device_t>(quantity_name_);
+                                template getDeviceVariableByName<typename DataTypeEquivalence<VariableType>::device_type>(quantity_name_);
             copyDataFromDevice(this->interpolated_quantities_->data(), device_data, this->getParticles()->total_real_particles_);
         }
 

--- a/src/shared/meshes/base_mesh.h
+++ b/src/shared/meshes/base_mesh.h
@@ -93,9 +93,10 @@ class BaseMesh
      * https://stackoverflow.com/questions/18529057/
      * produce-interleaving-bit-patterns-morton-keys-for-32-bit-64-bit-and-128bit
      */
-    size_t MortonCode(const size_t &i);
+    SYCL_EXTERNAL static size_t MortonCode(const size_t &i);
     /** Converts mesh index into a Morton order. */
-    size_t transferMeshIndexToMortonOrder(const Arrayi &mesh_index);
+    static size_t transferMeshIndexToMortonOrder(const Arrayi &mesh_index);
+    SYCL_EXTERNAL static size_t transferMeshIndexToMortonOrder(const DeviceArrayi &mesh_index);
 };
 
 /**

--- a/src/shared/meshes/cell_linked_list.h
+++ b/src/shared/meshes/cell_linked_list.h
@@ -75,7 +75,7 @@ class BaseCellLinkedList : public BaseMeshField
     /** find the nearest list data entry */
     virtual ListData findNearestListDataEntry(const Vecd &position) = 0;
     /** computing the sequence which indicate the order of sorted particle data */
-    virtual StdLargeVec<size_t> &computingSequence(BaseParticles &base_particles) = 0;
+    virtual size_t* computingSequence(BaseParticles &base_particles) = 0;
     /** Tag body part by cell, call by body part */
     virtual void tagBodyPartByCell(ConcurrentCellLists &cell_lists, std::function<bool(Vecd, Real)> &check_included) = 0;
     /** Tag domain bounding cells in an axis direction, called by domain bounding classes */
@@ -95,13 +95,15 @@ class CellLinkedListKernel {
     void searchNeighborsByParticles(DynamicsRange &dynamics_range, NeighborhoodDevice *particle_configuration,
                                     GetSearchDepth &get_search_depth, GetNeighborRelation &get_neighbor_relation);
 
+    size_t* computingSequence(BaseParticles &baseParticles);
+
     static inline DeviceArrayi CellIndexFromPosition(const DeviceVecd &position, const DeviceVecd& mesh_lower_bound,
                                                      const DeviceReal &grid_spacing, const DeviceArrayi &all_grid_points)
     {
         return sycl::min(
             sycl::max(
                 sycl::floor((position - mesh_lower_bound) / grid_spacing)
-                    .convert<int>(), DeviceArrayi{0}),
+                    .convert<int, sycl::rounding_mode::rtz>(), DeviceArrayi{0}),
             all_grid_points - DeviceArrayi{2});
     }
 
@@ -154,17 +156,7 @@ class CellLinkedList : public BaseCellLinkedList, public Mesh,
     void insertParticleIndex(size_t particle_index, const Vecd &particle_position) override;
     void InsertListDataEntry(size_t particle_index, const Vecd &particle_position, Real volumetric) override;
     virtual ListData findNearestListDataEntry(const Vecd &position) override;
-    virtual StdLargeVec<size_t> &computingSequence(BaseParticles &base_particles) override;
-    template<class ExecutionPolicy>
-    StdLargeVec<size_t> &computingSequence(BaseParticles &base_particles, ExecutionPolicy)
-    {
-        /*StdLargeVec<Vecd> &pos = base_particles.pos_;
-        StdLargeVec<size_t> &sequence = base_particles.sequence_;
-        size_t total_real_particles = base_particles.total_real_particles_;
-        particle_for(execution_policy, total_real_particles, [&](size_t i, auto&& kernel)
-            { sequence[i] = transferMeshIndexToMortonOrder(CellIndexFromPosition(pos[i])); }, ExecutionSelector<BaseMesh, ExecutionPolicy>(this));
-        return sequence;*/
-    }
+    virtual size_t* computingSequence(BaseParticles &base_particles) override;
     virtual void tagBodyPartByCell(ConcurrentCellLists &cell_lists, std::function<bool(Vecd, Real)> &check_included) override;
     virtual void tagBoundingCells(StdVec<CellLists> &cell_data_lists, BoundingBox &bounding_bounds, int axis) override;
     virtual void writeMeshFieldToPlt(std::ofstream &output_file) override;
@@ -199,7 +191,7 @@ class MultilevelCellLinkedList : public MultilevelMesh<BaseCellLinkedList, CellL
     void insertParticleIndex(size_t particle_index, const Vecd &particle_position) override;
     void InsertListDataEntry(size_t particle_index, const Vecd &particle_position, Real volumetric) override;
     virtual ListData findNearestListDataEntry(const Vecd &position) override { return ListData(0, Vecd::Zero(), 0); };
-    virtual StdLargeVec<size_t> &computingSequence(BaseParticles &base_particles) override;
+    virtual size_t* computingSequence(BaseParticles &base_particles) override;
     virtual void tagBodyPartByCell(ConcurrentCellLists &cell_lists, std::function<bool(Vecd, Real)> &check_included) override;
     virtual void tagBoundingCells(StdVec<CellLists> &cell_data_lists, BoundingBox &bounding_bounds, int axis) override{};
     virtual StdVec<CellLinkedList *> CellLinkedListLevels() override { return getMeshLevels(); };

--- a/src/shared/particle_dynamics/execution_unit/execution_queue.hpp
+++ b/src/shared/particle_dynamics/execution_unit/execution_queue.hpp
@@ -32,7 +32,7 @@ namespace SPH::execution {
             return {global_size % local_size ? (global_size / local_size + 1) * local_size : global_size , local_size};
         }
 
-        inline sycl::nd_range<1> getUniformNdRange(size_t global_size) {
+        inline sycl::nd_range<1> getUniformNdRange(size_t global_size) const {
             // sycl::nd_range is trivially-copyable, no std::move required
             return getUniformNdRange(global_size, work_group_size);
         }

--- a/src/shared/particle_dynamics/execution_unit/execution_queue.hpp
+++ b/src/shared/particle_dynamics/execution_unit/execution_queue.hpp
@@ -28,6 +28,15 @@ namespace SPH::execution {
             work_group_size = workGroupSize;
         }
 
+        static inline sycl::nd_range<1> getUniformNdRange(size_t global_size, size_t local_size) {
+            return {global_size % local_size ? (global_size / local_size + 1) * local_size : global_size , local_size};
+        }
+
+        inline sycl::nd_range<1> getUniformNdRange(size_t global_size) {
+            // sycl::nd_range is trivially-copyable, no std::move required
+            return getUniformNdRange(global_size, work_group_size);
+        }
+
     private:
         ExecutionQueue() : work_group_size(32), sycl_queue() {}
 

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.h
@@ -393,7 +393,9 @@ class BaseIntegrationKernel {
         pos_(particles->getDeviceVariableByName<DeviceVecd>("Position")),
         vel_(particles->getDeviceVariableByName<DeviceVecd>("Velocity")),
         acc_(particles->getDeviceVariableByName<DeviceVecd>("Acceleration")),
-        acc_prior_(particles->getDeviceVariableByName<DeviceVecd>("AccelerationPrior")) {}
+        acc_prior_(particles->getDeviceVariableByName<DeviceVecd>("AccelerationPrior")) {
+        particles->registerSortableVariable<Real>("Pressure");
+    }
         
   protected:
     FluidT fluid_;

--- a/src/shared/particle_dynamics/general_dynamics/general_interpolation.h
+++ b/src/shared/particle_dynamics/general_dynamics/general_interpolation.h
@@ -130,7 +130,7 @@ class BaseInterpolation : public LocalDynamics, public InterpolationContactData
 template <typename DataType>
 class BaseInterpolation<DataType, true> : public LocalDynamics, public InterpolationContactData,
                                           public DeviceExecutable<BaseInterpolation<DataType, true>,
-                                              BaseInterpolationKernel<typename DataTypeEquivalence<DataType>::device_t>>
+                                              BaseInterpolationKernel<typename DataTypeEquivalence<DataType>::device_type>>
 {
   public:
     StdLargeVec<DataType> *interpolated_quantities_;
@@ -138,14 +138,14 @@ class BaseInterpolation<DataType, true> : public LocalDynamics, public Interpola
     explicit BaseInterpolation(BaseContactRelation &contact_relation, const std::string &variable_name)
         : LocalDynamics(contact_relation.getSPHBody()), InterpolationContactData(contact_relation),
           DeviceExecutable<BaseInterpolation<DataType, true>,
-                           BaseInterpolationKernel<typename DataTypeEquivalence<DataType>::device_t>>(
+                           BaseInterpolationKernel<typename DataTypeEquivalence<DataType>::device_type>>(
               this, this->contact_configuration_device_ ? this->contact_configuration_device_->data() : nullptr,
               this->contact_configuration_device_ ? this->contact_configuration_device_->size() : 0,
-              particles_->registerDeviceVariable<typename DataTypeEquivalence<DataType>::device_t>(
+              particles_->registerDeviceVariable<typename DataTypeEquivalence<DataType>::device_type>(
                           variable_name, particles_->total_real_particles_)),
           interpolated_quantities_(nullptr)
     {
-            using DataTypeDevice = typename DataTypeEquivalence<DataType>::device_t;
+            using DataTypeDevice = typename DataTypeEquivalence<DataType>::device_type;
 
             contact_Vol_device_ = makeSharedDevice<StdSharedVec<DeviceReal*>>(this->contact_particles_.size(),
                                                                                execution::executionQueue.getQueue());
@@ -169,7 +169,7 @@ class BaseInterpolation<DataType, true> : public LocalDynamics, public Interpola
 
   protected:
     SharedPtr<StdSharedVec<DeviceReal*>> contact_Vol_device_;
-    SharedPtr<StdSharedVec<typename DataTypeEquivalence<DataType>::device_t*>> contact_data_device_;
+    SharedPtr<StdSharedVec<typename DataTypeEquivalence<DataType>::device_type*>> contact_data_device_;
 };
 
 /**

--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -369,6 +369,9 @@ void BaseParticles::readFromXmlForReloadParticle(std::string &filefullpath)
 }
 
     void BaseParticles::registerDeviceMemory() {
+        unsorted_id_device_ = allocateDeviceData<size_t>(total_real_particles_);
+        sorted_id_device_ = allocateDeviceData<size_t>(total_real_particles_);
+        sequence_device_ = allocateDeviceData<size_t>(total_real_particles_);
         registerDeviceVariable<DeviceVecd>("Position", total_real_particles_, pos_.data());
         registerDeviceVariable<DeviceVecd>("Velocity", total_real_particles_, vel_.data());
         registerDeviceVariable<DeviceVecd>("Acceleration", total_real_particles_, acc_.data());
@@ -379,6 +382,9 @@ void BaseParticles::readFromXmlForReloadParticle(std::string &filefullpath)
     }
 
     void BaseParticles::copyToDeviceMemory() {
+        copyDataToDevice(unsorted_id_.data(), unsorted_id_device_, total_real_particles_);
+        copyDataToDevice(sorted_id_.data(), sorted_id_device_, total_real_particles_);
+        copyDataToDevice(sequence_.data(), sequence_device_, total_real_particles_);
         copyDataToDevice(pos_.data(), getDeviceVariableByName<DeviceVecd>("Position"), total_real_particles_);
         copyDataToDevice(vel_.data(), getDeviceVariableByName<DeviceVecd>("Velocity"), total_real_particles_);
         copyDataToDevice(acc_.data(), getDeviceVariableByName<DeviceVecd>("Acceleration"), total_real_particles_);
@@ -389,6 +395,9 @@ void BaseParticles::readFromXmlForReloadParticle(std::string &filefullpath)
     }
 
     void BaseParticles::copyFromDeviceMemory() {
+        copyDataFromDevice(unsorted_id_.data(), unsorted_id_device_, total_real_particles_);
+        copyDataFromDevice(sorted_id_.data(), sorted_id_device_, total_real_particles_);
+        copyDataFromDevice(sequence_.data(), sequence_device_, total_real_particles_);
         copyDataFromDevice(pos_.data(), getDeviceVariableByName<DeviceVecd>("Position"), total_real_particles_);
         copyDataFromDevice(vel_.data(), getDeviceVariableByName<DeviceVecd>("Velocity"), total_real_particles_);
         copyDataFromDevice(acc_.data(), getDeviceVariableByName<DeviceVecd>("Acceleration"), total_real_particles_);

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -93,7 +93,11 @@ class BaseParticles
 
   public:
     explicit BaseParticles(SPHBody &sph_body, BaseMaterial *base_material);
-    virtual ~BaseParticles(){};
+    virtual ~BaseParticles(){
+        freeDeviceData(unsorted_id_device_);
+        freeDeviceData(sorted_id_device_);
+        freeDeviceData(sequence_device_);
+    };
 
     StdLargeVec<Vecd> pos_;       /**< Position */
     StdLargeVec<Vecd> vel_;       /**< Velocity */
@@ -184,6 +188,10 @@ class BaseParticles
     ParticleData sortable_data_;
     ParticleVariables sortable_variables_;
     ParticleSorting particle_sorting_;
+    size_t* unsorted_id_device_;      /**< copy of unsorted ids stored inside device. */
+    size_t* sorted_id_device_;        /**< copy of sorted ids stored inside device. */
+    size_t* sequence_device_;         /**< the sequence referred for sorting within device execution. */
+    DeviceVariables sortable_device_variables_;
 
     template <typename DataType>
     void registerSortableVariable(const std::string &variable_name);

--- a/src/shared/particles/base_particles.hpp
+++ b/src/shared/particles/base_particles.hpp
@@ -206,9 +206,9 @@ void BaseParticles::registerSortableVariable(const std::string &variable_name)
     }
 
     // add device variable if already registered
-    if constexpr(DataTypeEquivalence<DataType>::exists)
+    if constexpr(DataTypeEquivalence<DataType>::type_defined)
     {
-        using DeviceDataType = typename DataTypeEquivalence<DataType>::device_t;
+        using DeviceDataType = typename DataTypeEquivalence<DataType>::device_type;
         auto *device_variable = findVariableByName<DeviceDataType>(all_device_variables_, variable_name);
         if(device_variable && !findVariableByName<DeviceDataType>(sortable_device_variables_, variable_name))
                 std::get<DataTypeIndex<DeviceDataType>::value>(sortable_device_variables_).push_back(device_variable);
@@ -320,8 +320,8 @@ void BaseParticles::writeParticlesToVtk(StreamType &output_stream)
     for (DiscreteVariable<Real> *variable : std::get<type_index_Real>(variables_to_write_))
     {
         StdLargeVec<Real> &variable_data = *(std::get<type_index_Real>(all_particle_data_)[variable->IndexInContainer()]);
-        DeviceVariable<DataTypeEquivalence<Real>::device_t> *device_variable =
-            findVariableByName<DataTypeEquivalence<Real>::device_t>(all_device_variables_, variable->Name());
+        DeviceVariable<DataTypeEquivalence<Real>::device_type> *device_variable =
+            findVariableByName<DataTypeEquivalence<Real>::device_type>(all_device_variables_, variable->Name());
         if(device_variable)
             copyDataFromDevice(variable_data.data(), device_variable->VariableAddress(), total_real_particles_);
         output_stream << "    <DataArray Name=\"" << variable->Name() << "\" type=\"Float32\" Format=\"ascii\">\n";
@@ -339,8 +339,8 @@ void BaseParticles::writeParticlesToVtk(StreamType &output_stream)
     for (DiscreteVariable<Vecd> *variable : std::get<type_index_Vecd>(variables_to_write_))
     {
         StdLargeVec<Vecd> &variable_data = *(std::get<type_index_Vecd>(all_particle_data_)[variable->IndexInContainer()]);
-        DeviceVariable<DataTypeEquivalence<Vecd>::device_t> *device_variable =
-            findVariableByName<DataTypeEquivalence<Vecd>::device_t>(all_device_variables_, variable->Name());
+        DeviceVariable<DataTypeEquivalence<Vecd>::device_type> *device_variable =
+            findVariableByName<DataTypeEquivalence<Vecd>::device_type>(all_device_variables_, variable->Name());
         if(device_variable)
             copyDataFromDevice(variable_data.data(), device_variable->VariableAddress(), total_real_particles_);
         output_stream << "    <DataArray Name=\"" << variable->Name() << "\" type=\"Float32\"  NumberOfComponents=\"3\" Format=\"ascii\">\n";

--- a/src/shared/particles/particle_sorting.cpp
+++ b/src/shared/particles/particle_sorting.cpp
@@ -23,9 +23,25 @@ void SwapSortableParticleData::operator()(size_t *a, size_t *b)
     swap_particle_data_value_(sortable_data_, index_a, index_b);
 }
 //=================================================================================================//
+MoveSortableParticleDeviceData::MoveSortableParticleDeviceData(BaseParticles &base_particles)
+    : base_particles_(base_particles), initialized_swap_variables_(false) {}
+//=================================================================================================//
+void MoveSortableParticleDeviceData::operator()(size_t *index_permutation, size_t size)
+{
+    if (!initialized_swap_variables_)
+    {
+        swap_particle_device_data_value_.init(base_particles_.sortable_device_variables_);
+        swap_unsorted_id_.init(base_particles_.unsorted_id_device_, base_particles_.total_real_particles_);
+        initialized_swap_variables_ = true;
+    }
+    auto swap_events = swap_particle_device_data_value_(index_permutation, size);
+    swap_events.emplace_back(swap_unsorted_id_(index_permutation, size));
+    sycl::event::wait(swap_events);
+}
+//=================================================================================================//
 ParticleSorting::ParticleSorting(BaseParticles &base_particles)
-    : base_particles_(base_particles),
-      swap_sortable_particle_data_(base_particles), compare_(),
+    : base_particles_(base_particles), index_sorting_device_variables_(nullptr),
+      swap_sortable_particle_data_(base_particles), move_sortable_particle_device_data_(base_particles), compare_(),
       quick_sort_particle_range_(base_particles_.sequence_.data(), 0, compare_, swap_sortable_particle_data_),
       quick_sort_particle_body_() {}
 //=================================================================================================//
@@ -52,6 +68,63 @@ void ParticleSorting::updateSortedId()
             }
         },
         ap);
+}
+//=================================================================================================//
+void ParticleSorting::updateSortedDeviceId() const
+{
+    size_t *unsorted_id_device = base_particles_.unsorted_id_device_;
+    size_t *sorted_id_device = base_particles_.sorted_id_device_;
+    size_t total_real_particles = base_particles_.total_real_particles_;
+    execution::executionQueue.getQueue()
+        .parallel_for(execution::executionQueue.getUniformNdRange(total_real_particles),
+                      [=](sycl::nd_item<1> item)
+                      {
+                          size_t i = item.get_global_id();
+                          if (i < total_real_particles)
+                              sorted_id_device[unsorted_id_device[i]] = i;
+                      })
+        .wait();
+}
+//=================================================================================================//
+template <>
+void ParticleSorting::sortingParticleData(size_t *begin, size_t size, execution::ParallelSYCLDevicePolicy execution_policy)
+{
+    if (!index_sorting_device_variables_)
+        index_sorting_device_variables_ = allocateDeviceData<size_t>(size);
+
+    sort_by_key(begin, index_sorting_device_variables_, size, execution::executionQueue.getQueue(), 256, 4, [](size_t *data, size_t idx)
+    { return idx; }).wait();
+
+    move_sortable_particle_device_data_(index_sorting_device_variables_, size);
+
+    updateSortedDeviceId();
+}
+//=================================================================================================//
+size_t split_count(bool bit, sycl::nd_item<1> &item)
+{
+    const auto group_range = item.get_local_range().size();
+    const size_t id = item.get_local_id();
+
+    // Count 1s held by lower-numbered work-items and current work-item
+    size_t true_before = sycl::inclusive_scan_over_group(item.get_group(), static_cast<size_t>(bit),
+                                                         sycl::plus<size_t>{}); // prefix sum over group
+
+    // Total number of 0s
+    size_t false_totals = sycl::group_broadcast(item.get_group(), group_range - true_before,
+                                                group_range - 1);
+
+    // Return work-item's rank
+    return bit ? true_before - 1 + false_totals : id - true_before;
+}
+//=================================================================================================//
+size_t get_digit(size_t key, size_t d, size_t radix_bits)
+{
+    return (key >> d * radix_bits) & ((1ul << radix_bits) - 1);
+}
+//=================================================================================================//
+size_t get_bit(size_t key, size_t b)
+{
+    return (key >> b) & 1;
 }
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/particles/particle_sorting.h
+++ b/src/shared/particles/particle_sorting.h
@@ -30,6 +30,8 @@
 #define PARTICLE_SORTING_H
 
 #include "base_data_package.h"
+#include "execution_policy.h"
+#include "execution_queue.hpp"
 #include "sph_data_containers.h"
 
 /** this is a reformulation of tbb parallel_sort for particle data */
@@ -196,6 +198,172 @@ struct QuickSortParticleBody
  */
 namespace SPH
 {
+
+/** Get the number of bits corresponding to the d-th digit of key,
+ * with each digit composed of a number of bits equal to radix_bits */
+inline size_t get_digit(size_t key, size_t d, size_t radix_bits);
+
+/** Get the b-th bit of key */
+inline size_t get_bit(size_t key, size_t b);
+
+/** Group operation to compute rank, i.e. sorted position, of each work-item based on one bit.
+ * All work-items with bit = 0 will be on the first half of the ranking, while work-items with
+ * bit = 1 will be placed on the second half. */
+SYCL_EXTERNAL size_t split_count(bool bit, sycl::nd_item<1> &item);
+
+template <class T>
+T find_max_element(const T *data, size_t size, T identity)
+{
+    T result = identity;
+    auto &sycl_queue = execution::executionQueue.getQueue();
+    {
+        sycl::buffer<T> buffer_result(&result, 1);
+        sycl_queue.submit([&](sycl::handler &cgh)
+                          {
+                              auto reduction_operator = sycl::reduction(buffer_result, cgh, sycl::maximum<>());
+                              cgh.parallel_for(execution::executionQueue.getUniformNdRange(size), reduction_operator,
+                                               [=](sycl::nd_item<1> item, auto& reduction) {
+                                                   if(item.get_global_id() < size)
+                                                       reduction.combine(data[item.get_global_linear_id()]);
+                                               }); })
+            .wait_and_throw();
+    }
+    return result;
+}
+
+template <class T, class DataInitializer>
+sycl::event sort_by_key(
+    size_t *keys, T *data, size_t data_size, sycl::queue &queue,
+    size_t workgroup_size = 256, size_t radix_bits = 4,
+    DataInitializer init_data = [](const T *data, size_t idx) -> T
+    { return data[idx]; })
+{
+    const bool uniform_case_masking = data_size % workgroup_size; // Workload needs to be homogenized
+    size_t uniform_global_size = uniform_case_masking ? (data_size / workgroup_size + 1) * workgroup_size : data_size;
+    const sycl::nd_range<1> kernel_range{uniform_global_size, workgroup_size};
+    const size_t workgroups = kernel_range.get_group_range().size();
+
+    const size_t radix = 1ul << radix_bits; // radix = 2^b
+    // Largest key, increased by 1 if the workgroup is not homogeneous with the data vector,
+    // the new maximum will be used for those work-items out of data range, that will then be excluded once sorted
+    const size_t max_key = find_max_element(keys, data_size, 0ul) + (uniform_case_masking ? 1 : 0);
+    const size_t bits_max_key = std::floor(std::log2(max_key)) + 1.0;                                    // bits needed to represent max_key
+    const size_t length = max_key ? bits_max_key / radix_bits + (bits_max_key % radix_bits ? 1 : 0) : 1; // max number of radix digits
+
+    // Each entry contains global number of digits with the same value
+    // Column-major, so buckets offsets can be computed by just applying a scan over it
+    auto global_buckets = sycl::buffer<size_t, 2>({radix, workgroups});
+    // Each entry contains global number of digits with the same and lower values
+    auto global_buckets_offsets = sycl::buffer<size_t, 2>({radix, workgroups});
+    auto local_buckets_offsets_buffer = sycl::buffer<size_t, 2>({workgroups, radix}); // save state of local accessor
+
+    using SortablePair = std::pair<size_t, T>;
+    auto data_swap_buffer = sycl::buffer<SortablePair>(data_size); // temporary memory for swapping
+
+    sycl::event sort_event{};
+    for (int digit = 0; digit < length; ++digit)
+    {
+
+        auto buckets_event = queue.submit([&](sycl::handler &cgh)
+                                          {
+                        cgh.depends_on(sort_event);
+                         auto data_swap_acc = data_swap_buffer.get_access(cgh, sycl::write_only, sycl::no_init);
+                         auto local_buckets = sycl::local_accessor<size_t>(radix, cgh);
+                         auto local_output = sycl::local_accessor<SortablePair>(kernel_range.get_local_range(), cgh);
+                         auto global_buckets_accessor = global_buckets.get_access(cgh, sycl::read_write, sycl::no_init);
+                         auto local_buckets_offsets_accessor = local_buckets_offsets_buffer.get_access(cgh, sycl::write_only,
+                                                                                                       sycl::no_init);
+
+                         cgh.parallel_for(kernel_range, [=](sycl::nd_item<1> item) {
+                                              const size_t workgroup = item.get_group_linear_id(),
+                                                           global_id = item.get_global_id();
+
+                                              SortablePair number;
+                                              // Initialize key-data pair, with masking in case of non-homogeneous data_size/workgroup_size
+                                              if(global_id < data_size)
+                                                  number = {keys[global_id],
+                                                            // Give possibility to initialize data here to avoid calling
+                                                            // another kernel before sort_by_key in order to initialize it
+                                                            digit ? data[global_id] : init_data(data, global_id)};
+                                              else  // masking extra indexes
+                                                  // Initialize exceeding values to the largest key considered
+                                                  number.first = (1 << bits_max_key) - 1;  // max key for given number of bits
+
+
+                                              // Locally sort digit with split primitive
+                                              auto radix_digit = get_digit(number.first, digit, radix_bits);
+                                              auto rank = split_count(get_bit(radix_digit, 0), item);  // sorting first bit
+                                              local_output[rank] = number;
+                                              for (size_t b = 1; b < radix_bits; ++b) {  // sorting remaining bits
+                                                  item.barrier(sycl::access::fence_space::local_space);
+                                                  number = local_output[item.get_local_id()];
+                                                  radix_digit = get_digit(number.first, digit, radix_bits);
+
+                                                  rank = split_count(get_bit(radix_digit, b), item);
+                                                  local_output[rank] = number;
+                                              }
+
+                                              // Initialize local buckets to zero, since they are uninitialized by default
+                                              for (int r = 0; r < radix; ++r)
+                                                  local_buckets[r] = 0;
+
+                                              item.barrier(sycl::access::fence_space::local_space);
+                                              {
+                                                  sycl::atomic_ref<size_t, sycl::memory_order_relaxed, sycl::memory_scope_work_group,
+                                                                   sycl::access::address_space::local_space> bucket_r{local_buckets[radix_digit]};
+                                                  ++bucket_r;
+                                                  item.barrier(sycl::access::fence_space::local_space);
+                                              }
+
+                                              // Save local buckets to global memory, with one row per work-group (in column-major order)
+                                              for (int r = 0; r < radix; ++r)
+                                                  global_buckets_accessor[r][workgroup] = local_buckets[r];
+
+                                              if(global_id < data_size)
+                                                  data_swap_acc[workgroup_size * workgroup + rank] = number;  // save local sorting back to data
+
+                                              // Compute local buckets offsets
+                                              size_t *begin = local_buckets.get_pointer(), *end = begin + radix,
+                                                     *outBegin = local_buckets_offsets_accessor.get_pointer().get() + workgroup * radix;
+                                              sycl::joint_exclusive_scan(item.get_group(), begin, end, outBegin, sycl::plus<size_t>{});
+                                          }); });
+
+        // Global synchronization to make sure that all locally computed buckets have been copied to global memory
+
+        sort_event = queue.submit([&](sycl::handler &cgh)
+                                  {
+                        cgh.depends_on(buckets_event);
+                         auto data_swap_acc = data_swap_buffer.get_access(cgh, sycl::read_only);
+                         auto global_buckets_accessor = global_buckets.get_access(cgh, sycl::read_only);
+                         auto global_buckets_offsets_accessor = global_buckets_offsets.get_access(cgh, sycl::read_write);
+                         auto local_buckets_offsets_accessor = local_buckets_offsets_buffer.get_access(cgh, sycl::read_only);
+                         cgh.parallel_for(kernel_range, [=](sycl::nd_item<1> item) {
+                                              // Compute global buckets offsets
+                                              size_t *begin = global_buckets_accessor.get_pointer(), *end = begin + global_buckets_accessor.size();
+                                              sycl::joint_exclusive_scan(item.get_group(), begin, end,
+                                                                         global_buckets_offsets_accessor.get_pointer(), sycl::plus<size_t>{});
+
+                                              // Mask only relevant indexes. All max_keys added to homogenize the computations
+                                              // should be owned by work-items with global_id >= data_size
+                                              if(item.get_global_id() < data_size) {
+                                                  // Retrieve position and sorted data from swap memory
+                                                  const size_t rank = item.get_local_id(), workgroup = item.get_group_linear_id();
+                                                  const SortablePair number = data_swap_acc[workgroup_size * workgroup + rank];
+                                                  const size_t radix_digit = get_digit(number.first, digit, radix_bits);
+
+                                                  // Compute sorted position based on global and local buckets
+                                                  const size_t data_offset = global_buckets_offsets_accessor[radix_digit][workgroup] + rank -
+                                                                             local_buckets_offsets_accessor[workgroup][radix_digit];
+
+                                                  // Copy to original data pointers
+                                                  keys[data_offset] = number.first;
+                                                  data[data_offset] = number.second;
+                                              }
+                                          }); });
+    }
+    return sort_event;
+}
+
 class BaseParticles;
 
 template <typename VariableType>
@@ -212,6 +380,65 @@ struct swapParticleDataValue
             std::swap(variable[index_a], variable[index_b]);
         }
     };
+};
+
+template <typename VariableType>
+struct swapParticleDeviceDataValue
+{
+    swapParticleDeviceDataValue() = default;
+
+    /** Initialize swapping for device variables */
+    void init(DeviceVariables &device_variables)
+    {
+        size_variables_ = std::get<DataTypeIndex<VariableType>::value>(device_variables).size();
+        size_single_variable_ = size_variables_ ? std::get<DataTypeIndex<VariableType>::value>(device_variables)[0]->getSize()
+                                                : 0;
+
+        StdVec<DeviceVariable<VariableType> *> variables_ptr = std::get<DataTypeIndex<VariableType>::value>(device_variables);
+        for (size_t i = 0; i != variables_ptr.size(); ++i)
+            variables_.push_back(variables_ptr[i]->VariableAddress());
+
+        tmp_variable_ = allocateDeviceData<VariableType>(size_single_variable_);
+    }
+
+    /** Initialize swapping for extra variable not registered in DeviceVariables */
+    void init(VariableType *single_variable, size_t size_variable)
+    {
+        size_variables_ = 1;
+        size_single_variable_ = size_variable;
+        variables_.push_back(single_variable);
+        tmp_variable_ = allocateDeviceData<VariableType>(size_variable);
+    }
+
+    ~swapParticleDeviceDataValue() { freeDeviceData(tmp_variable_); }
+
+    /** Reorder initialized variables based on a permutation indicating where each element should be placed */
+    sycl::event operator()(const size_t *index_permutation, size_t size) const
+    {
+        if (size_variables_)
+            assert(size == size_single_variable_ && "Provided index permutation has different size than device variables");
+
+        sycl::event sort_event{};
+        for (size_t var = 0; var < size_variables_; ++var)
+        {
+            auto *sortable_device_variable = variables_[var];
+            auto tmp_copy_event = execution::executionQueue.getQueue().copy(sortable_device_variable, tmp_variable_, size, sort_event);
+            sort_event = execution::executionQueue.getQueue().parallel_for(execution::executionQueue.getUniformNdRange(size), tmp_copy_event,
+                                                                           [=, tmp_variable = tmp_variable_](sycl::nd_item<1> item)
+                                                                           {
+                                                                               size_t i = item.get_global_id();
+                                                                               if (i < size)
+                                                                                   sortable_device_variable[i] = tmp_variable[index_permutation[i]];
+                                                                           });
+        }
+        return sort_event;
+    }
+
+  private:
+    size_t size_variables_,                 // number of device variables registered,
+        size_single_variable_;              // size of each variable
+    std::vector<VariableType *> variables_; // variables to be sorted
+    VariableType *tmp_variable_ = nullptr;            // temporary memory to execute sorting in parallel
 };
 
 /**
@@ -248,6 +475,20 @@ class SwapSortableParticleData
     void operator()(size_t *a, size_t *b);
 };
 
+class MoveSortableParticleDeviceData
+{
+  protected:
+    BaseParticles &base_particles_;
+    bool initialized_swap_variables_;
+    DeviceDataAssembleOperation<swapParticleDeviceDataValue> swap_particle_device_data_value_;
+    swapParticleDeviceDataValue<size_t> swap_unsorted_id_;
+
+  public:
+    explicit MoveSortableParticleDeviceData(BaseParticles &base_particles);
+    /** Reorder sortable device variables based on sorting permutation*/
+    void operator()(size_t *index_permutation, size_t size);
+};
+
 /**
  * @class ParticleSorting
  * @brief The class for sorting particle according a given sequence.
@@ -256,9 +497,11 @@ class ParticleSorting
 {
   protected:
     BaseParticles &base_particles_;
+    size_t *index_sorting_device_variables_;
 
     /** using pointer because it is constructed after particles. */
     SwapSortableParticleData swap_sortable_particle_data_;
+    MoveSortableParticleDeviceData move_sortable_particle_device_data_;
     CompareParticleSequence compare_;
     tbb::interface9::QuickSortParticleRange<
         size_t *, CompareParticleSequence, SwapSortableParticleData>
@@ -271,10 +514,20 @@ class ParticleSorting
     // the construction is before particles
     explicit ParticleSorting(BaseParticles &base_particles);
     virtual ~ParticleSorting(){};
+
     /** sorting particle data according to the cell location of particles */
     virtual void sortingParticleData(size_t *begin, size_t size);
+    template <class ExecutionPolicy>
+    inline void sortingParticleData(size_t *begin, size_t size, ExecutionPolicy execution_policy)
+    {
+        this->sortingParticleData(begin, size);
+    }
+    template <>
+    void sortingParticleData(size_t *begin, size_t size, execution::ParallelSYCLDevicePolicy execution_policy);
+
     /** update the reference of sorted data from unsorted data */
     virtual void updateSortedId();
+    void updateSortedDeviceId() const;
 };
 } // namespace SPH
 #endif // PARTICLE_SORTING_H

--- a/src/shared/variables/base_variable.h
+++ b/src/shared/variables/base_variable.h
@@ -65,7 +65,7 @@ class DeviceVariable : public BaseVariable
 public:
     template<class HostDataType = void>
     DeviceVariable(const std::string &name, std::size_t size, const HostDataType *host_value = nullptr)
-            : BaseVariable(name), device_addr_(allocateSharedData<DeviceDataType>(size))
+            : BaseVariable(name), device_addr_(allocateDeviceData<DeviceDataType>(size)), size_(size)
     {
         if constexpr(std::negation_v<std::is_same<HostDataType, void>>)
             copyDataToDevice(host_value, device_addr_, size);
@@ -75,10 +75,12 @@ public:
         freeDeviceData(device_addr_);
     }
 
-    DeviceDataType *VariableAddress() { return device_addr_; };
+    DeviceDataType *VariableAddress() { return device_addr_; }
+    size_t getSize() { return size_; }
 
 private:
     DeviceDataType *device_addr_;
+    size_t size_;
 };
 
 template <typename DataType>


### PR DESCRIPTION
# Main changes

- Particle sorting is now offloaded to GPU, making it possible to run the main simulation steps entirely on SYCL.
    - The sorting algorithm is based on an implementation of [radix sort optimized for accelerators](https://doi.org/10.1109/IPDPS.2009.5161005).
- Kernel executions are now homogenized w.r.t. the set work-group size.
    - This gives more freedom in the choice of the work-group size, which was before required to be a divisor of the number of particles computed, while now the choice can be arbitrary.

## Benchmark

Benchmark of 80'000 particles:
```
Total wall time for computation: 314.42814360 seconds.
interval_computing_time_step =8.077749454
interval_computing_fluid_pressure_relaxation = 96.600376022
interval_updating_configuration = 89.765419521
```

Compared to [previous results](https://github.com/Xiangyu-Hu/SPHinXsys/pull/448) this marks a 1.15x speed-up, and 3.65x speed-up w.r.t. TBB.

Tested with 500'000 particles, results are:

Reference:
```
Total wall time for computation: 17098.949532568 seconds.
interval_computing_time_step =514.735826599
interval_computing_fluid_pressure_relaxation = 9491.617997688
interval_updating_configuration = 5973.237301082
```

SYCL:
```
Total wall time for computation: 3616.444860880 seconds.
interval_computing_time_step =62.580767842
interval_computing_fluid_pressure_relaxation = 1040.480258746
interval_updating_configuration = 1375.825838244
```

Hence, 4.73x speed-up w.r.t. multi-core TBB execution. 