### PR TITLE
[SYCL] Event-driven kernel execution

### DIFF
--- a/src/for_2D_build/meshes/cell_linked_list.hpp
+++ b/src/for_2D_build/meshes/cell_linked_list.hpp
@@ -45,7 +45,7 @@ void CellLinkedList::searchNeighborsByParticles(
 }
 //=================================================================================================//
 template <class DynamicsRange, typename GetSearchDepth, typename GetNeighborRelation>
-ExecutionEvent CellLinkedListKernel::searchNeighborsByParticles(
+execution::ExecutionEvent CellLinkedListKernel::searchNeighborsByParticles(
     DynamicsRange &dynamics_range, NeighborhoodDevice *particle_configuration,
     GetSearchDepth &get_search_depth, GetNeighborRelation& get_neighbor_relation,
     execution::ExecutionEvent dependency_event)

--- a/src/shared/bodies/base_body.h
+++ b/src/shared/bodies/base_body.h
@@ -243,19 +243,19 @@ class RealBody : public SPHBody
     bool getUseSplitCellLists() { return use_split_cell_lists_; };
     SplitCellLists &getSplitCellLists() { return split_cell_lists_; };
     template<class ExecutionPolicy = execution::ParallelPolicy>
-    void updateCellLinkedList(ExecutionPolicy execution_policy = execution::par)
+    execution::ExecutionEvent updateCellLinkedList(ExecutionPolicy execution_policy = execution::par)
     {
-        getCellLinkedList(execution_policy).UpdateCellLists(*base_particles_);
-        base_particles_->total_ghost_particles_ = 0;
+        return getCellLinkedList(execution_policy).UpdateCellLists(*base_particles_)
+            .then([=]() { base_particles_->total_ghost_particles_ = 0; });
     }
     template<class ExecutionPolicy = execution::ParallelPolicy>
-    void updateCellLinkedListWithParticleSort(size_t particle_sort_period, ExecutionPolicy execution_policy = execution::par)
+    execution::ExecutionEvent updateCellLinkedListWithParticleSort(size_t particle_sort_period, ExecutionPolicy execution_policy = execution::par)
     {
         if (iteration_count_ % particle_sort_period == 0)
                 base_particles_->sortParticles(getCellLinkedList(execution_policy), execution_policy);
 
         iteration_count_++;
-        updateCellLinkedList(execution_policy);
+        return updateCellLinkedList(execution_policy);
     }
 };
 } // namespace SPH

--- a/src/shared/body_relations/base_body_relation.h
+++ b/src/shared/body_relations/base_body_relation.h
@@ -116,7 +116,7 @@ class SPHRelation
     void subscribeToBody() { sph_body_.body_relations_.push_back(this); };
     virtual void resizeConfiguration() = 0;
     virtual void updateConfiguration() = 0;
-    virtual void updateDeviceConfiguration() {}
+    virtual execution::ExecutionEvent updateDeviceConfiguration() { return {}; }
 };
 
 /**
@@ -127,7 +127,7 @@ class BaseInnerRelation : public SPHRelation
 {
   protected:
     virtual void resetNeighborhoodCurrentSize();
-    virtual void resetNeighborhoodDeviceCurrentSize();
+    virtual execution::ExecutionEvent resetNeighborhoodDeviceCurrentSize();
 
   public:
     RealBody *real_body_;
@@ -152,7 +152,7 @@ class BaseContactRelation : public SPHRelation
 {
   protected:
     virtual void resetNeighborhoodCurrentSize();
-    virtual void resetNeighborhoodDeviceCurrentSize();
+    virtual execution::ExecutionEvent resetNeighborhoodDeviceCurrentSize();
 
   private:
     bool device_configuration_allocated_;

--- a/src/shared/body_relations/complex_body_relation.cpp
+++ b/src/shared/body_relations/complex_body_relation.cpp
@@ -67,10 +67,10 @@ void ComplexRelation::updateConfiguration()
     contact_relation_.updateConfiguration();
 }
 //=================================================================================================//
-void ComplexRelation::updateDeviceConfiguration()
+execution::ExecutionEvent ComplexRelation::updateDeviceConfiguration()
 {
-    inner_relation_.updateDeviceConfiguration();
-    contact_relation_.updateDeviceConfiguration();
+    return std::move(inner_relation_.updateDeviceConfiguration()
+                         .add(contact_relation_.updateDeviceConfiguration()));
 }
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/body_relations/complex_body_relation.h
+++ b/src/shared/body_relations/complex_body_relation.h
@@ -64,7 +64,7 @@ class ComplexRelation : public SPHRelation
 
     virtual void resizeConfiguration() override;
     virtual void updateConfiguration() override;
-    virtual void updateDeviceConfiguration() override;
+    virtual execution::ExecutionEvent updateDeviceConfiguration() override;
 };
 } // namespace SPH
 #endif // COMPLEX_BODY_RELATION_H

--- a/src/shared/body_relations/contact_body_relation.cpp
+++ b/src/shared/body_relations/contact_body_relation.cpp
@@ -27,15 +27,17 @@ void ContactRelation::updateConfiguration()
     }
 }
 //=================================================================================================//
-void ContactRelation::updateDeviceConfiguration()
+execution::ExecutionEvent ContactRelation::updateDeviceConfiguration()
 {
-    resetNeighborhoodDeviceCurrentSize();
+    auto reset_event = resetNeighborhoodDeviceCurrentSize();
+    execution::ExecutionEvent update_events;
     for (size_t k = 0; k != contact_bodies_.size(); ++k)
     {
-        target_cell_linked_lists_[k]->getDeviceProxy().getKernel()->searchNeighborsByParticles(
+        update_events.add(target_cell_linked_lists_[k]->getDeviceProxy().getKernel()->searchNeighborsByParticles(
             sph_body_, contact_configuration_device_[k].data(),
-            *get_search_depths_[k], *get_contact_neighbors_[k]);
+            *get_search_depths_[k], *get_contact_neighbors_[k], reset_event));
     }
+    return std::move(update_events);
 }
 //=================================================================================================//
 SurfaceContactRelation::SurfaceContactRelation(SPHBody &sph_body, RealBodyVector contact_bodies)

--- a/src/shared/body_relations/contact_body_relation.h
+++ b/src/shared/body_relations/contact_body_relation.h
@@ -81,7 +81,7 @@ class ContactRelation : public ContactRelationCrossResolution
     ContactRelation(SPHBody &sph_body, RealBodyVector contact_bodies);
     virtual ~ContactRelation(){};
     virtual void updateConfiguration() override;
-    virtual void updateDeviceConfiguration() override;
+    virtual execution::ExecutionEvent updateDeviceConfiguration() override;
 
   protected:
     StdVec<NeighborBuilderContact *> get_contact_neighbors_;

--- a/src/shared/body_relations/inner_body_relation.cpp
+++ b/src/shared/body_relations/inner_body_relation.cpp
@@ -18,12 +18,12 @@ void InnerRelation::updateConfiguration()
         get_single_search_depth_, get_inner_neighbor_);
 }
 //=================================================================================================//
-void InnerRelation::updateDeviceConfiguration()
+execution::ExecutionEvent InnerRelation::updateDeviceConfiguration()
 {
-    resetNeighborhoodDeviceCurrentSize();
-    cell_linked_list_.getDeviceProxy().getKernel()->searchNeighborsByParticles(
+    auto reset_event = resetNeighborhoodDeviceCurrentSize();
+    return cell_linked_list_.getDeviceProxy().getKernel()->searchNeighborsByParticles(
         sph_body_, inner_configuration_device_->data(),
-        get_single_search_depth_, get_inner_neighbor_);
+        get_single_search_depth_, get_inner_neighbor_, std::move(reset_event));
 }
 //=================================================================================================//
 AdaptiveInnerRelation::

--- a/src/shared/body_relations/inner_body_relation.h
+++ b/src/shared/body_relations/inner_body_relation.h
@@ -49,7 +49,7 @@ class InnerRelation : public BaseInnerRelation
     virtual ~InnerRelation(){};
 
     virtual void updateConfiguration() override;
-    virtual void updateDeviceConfiguration() override;
+    virtual execution::ExecutionEvent updateDeviceConfiguration() override;
 };
 
 /**

--- a/src/shared/common/vector_functions.h
+++ b/src/shared/common/vector_functions.h
@@ -138,6 +138,10 @@ inline execution::ExecutionEvent copyDataToDevice(const Vec2d* host, DeviceVec2d
     return transformAndCopyDataToDevice(host, device, size, [](auto vec) { return hostToDeviceVecd(vec); });
 }
 
+inline execution::ExecutionEvent copyDataToDevice(const Vec3d* host, DeviceVec3d* device, std::size_t size) {
+    return transformAndCopyDataToDevice(host, device, size, [](auto vec) { return hostToDeviceVecd(vec); });
+}
+
 inline execution::ExecutionEvent copyDataToDevice(const Real* host, DeviceReal* device, std::size_t size) {
     return transformAndCopyDataToDevice(host, device, size, [](Real val) { return static_cast<DeviceReal>(val); });
 }
@@ -164,6 +168,10 @@ execution::ExecutionEvent transformAndCopyDataFromDevice(HostType* host, const D
 
 
 inline execution::ExecutionEvent copyDataFromDevice(Vec2d* host, const DeviceVec2d* device, std::size_t size) {
+    return transformAndCopyDataFromDevice(host, device, size, [](auto vec) { return deviceToHostVecd(vec); });
+}
+
+inline execution::ExecutionEvent copyDataFromDevice(Vec3d* host, const DeviceVec3d* device, std::size_t size) {
     return transformAndCopyDataFromDevice(host, device, size, [](auto vec) { return deviceToHostVecd(vec); });
 }
 

--- a/src/shared/io_system/io_base.cpp
+++ b/src/shared/io_system/io_base.cpp
@@ -71,11 +71,18 @@ void BodyStatesRecording::writeToFile(size_t iteration_step)
     writeWithFileName(padValueWithZeros(iteration_step));
 };
 //=============================================================================================//
-execution::ExecutionEvent BodyStatesRecording::copyDeviceData() const {
+execution::ExecutionEvent BodyStatesRecording::copyDeviceData() const
+{
     execution::ExecutionEvent copy_events;
-    for(auto* body : bodies_)
+    for (auto *body : bodies_)
         if (body->checkNewlyUpdated())
-            copy_events.add(body->getBaseParticles().copyFromDeviceMemory());
+        {
+            auto &particles = body->getBaseParticles();
+            auto size = particles.total_real_particles_;
+            copy_events.add(copyDataFromDevice(particles.unsorted_id_.data(), particles.unsorted_id_device_, size));
+            copy_events.add(copyDataFromDevice(particles.pos_.data(), particles.getDeviceVariableByName<DeviceVecd>("Position"), size));
+            copy_events.add(copyDataFromDevice(particles.vel_.data(), particles.getDeviceVariableByName<DeviceVecd>("Velocity"), size));
+        }
     return std::move(copy_events);
 }
 //=============================================================================================//

--- a/src/shared/io_system/io_base.cpp
+++ b/src/shared/io_system/io_base.cpp
@@ -71,10 +71,12 @@ void BodyStatesRecording::writeToFile(size_t iteration_step)
     writeWithFileName(padValueWithZeros(iteration_step));
 };
 //=============================================================================================//
-void BodyStatesRecording::copyDeviceData() const {
+execution::ExecutionEvent BodyStatesRecording::copyDeviceData() const {
+    execution::ExecutionEvent copy_events;
     for(auto* body : bodies_)
         if (body->checkNewlyUpdated())
-            body->getBaseParticles().copyFromDeviceMemory();
+            copy_events.add(body->getBaseParticles().copyFromDeviceMemory());
+    return std::move(copy_events);
 }
 //=============================================================================================//
 RestartIO::RestartIO(IOEnvironment &io_environment, SPHBodyVector bodies)

--- a/src/shared/io_system/io_base.h
+++ b/src/shared/io_system/io_base.h
@@ -107,7 +107,7 @@ class BodyStatesRecording : public BaseIO
     /** write with filename indicated by physical time */
     void writeToFile();
     virtual void writeToFile(size_t iteration_step) override;
-    virtual void copyDeviceData() const;
+    virtual execution::ExecutionEvent copyDeviceData() const;
 
   protected:
     SPHBodyVector bodies_;

--- a/src/shared/io_system/io_observation.h
+++ b/src/shared/io_system/io_observation.h
@@ -67,7 +67,7 @@ class ObservedQuantityRecording : public BodyStatesRecording,
         if constexpr (std::is_same_v<ExecutionPolicy, ParallelSYCLDevicePolicy>) {
             auto* device_data = this->getParticles()->
                                 template getDeviceVariableByName<typename DataTypeEquivalence<VariableType>::device_type>(quantity_name_);
-            copyDataFromDevice(this->interpolated_quantities_->data(), device_data, this->getParticles()->total_real_particles_);
+            copyDataFromDevice(this->interpolated_quantities_->data(), device_data, this->getParticles()->total_real_particles_).wait();
         }
 
         /** Output for .dat file. */
@@ -93,7 +93,7 @@ class ObservedQuantityRecording : public BodyStatesRecording,
         if constexpr (std::is_same_v<ExecutionPolicy, ParallelSYCLDevicePolicy>) {
             auto* device_data = this->getParticles()->
                                 template getDeviceVariableByName<typename DataTypeEquivalence<VariableType>::device_type>(quantity_name_);
-            copyDataFromDevice(this->interpolated_quantities_->data(), device_data, this->getParticles()->total_real_particles_);
+            copyDataFromDevice(this->interpolated_quantities_->data(), device_data, this->getParticles()->total_real_particles_).wait();
         }
 
         std::ofstream out_file(filefullpath_output_.c_str(), std::ios::app);

--- a/src/shared/meshes/cell_linked_list.h
+++ b/src/shared/meshes/cell_linked_list.h
@@ -67,7 +67,7 @@ class BaseCellLinkedList : public BaseMeshField
     /** access concrete cell linked list levels*/
     virtual StdVec<CellLinkedList *> CellLinkedListLevels() = 0;
     /** update the cell lists */
-    virtual void UpdateCellLists(BaseParticles &base_particles) = 0;
+    virtual execution::ExecutionEvent UpdateCellLists(BaseParticles &base_particles) = 0;
     /** Insert a cell-linked_list entry to the concurrent index list. */
     virtual void insertParticleIndex(size_t particle_index, const Vecd &particle_position) = 0;
     /** Insert a cell-linked_list entry of the index and particle position pair. */
@@ -88,12 +88,13 @@ class CellLinkedListKernel {
     CellLinkedListKernel(BaseParticles& particles, const DeviceVecd &meshLowerBound, DeviceReal gridSpacing,
                          const DeviceArrayi &allGridPoints, const DeviceArrayi &allCells);
 
-    void clearCellLists();
-    void UpdateCellLists(BaseParticles &base_particles);
+    execution::ExecutionEvent clearCellLists();
+    execution::ExecutionEvent UpdateCellLists(BaseParticles &base_particles);
 
     template <class DynamicsRange, typename GetSearchDepth, typename GetNeighborRelation>
-    void searchNeighborsByParticles(DynamicsRange &dynamics_range, NeighborhoodDevice *particle_configuration,
-                                    GetSearchDepth &get_search_depth, GetNeighborRelation &get_neighbor_relation);
+    execution::ExecutionEvent searchNeighborsByParticles(DynamicsRange &dynamics_range, NeighborhoodDevice *particle_configuration,
+                                    GetSearchDepth &get_search_depth, GetNeighborRelation &get_neighbor_relation,
+                                                         execution::ExecutionEvent dependency_event = {});
 
     size_t* computingSequence(BaseParticles &baseParticles);
 
@@ -152,7 +153,7 @@ class CellLinkedList : public BaseCellLinkedList, public Mesh,
 
     void clearCellLists();
     void UpdateCellListData(BaseParticles &base_particles);
-    virtual void UpdateCellLists(BaseParticles &base_particles) override;
+    virtual execution::ExecutionEvent UpdateCellLists(BaseParticles &base_particles) override;
     void insertParticleIndex(size_t particle_index, const Vecd &particle_position) override;
     void InsertListDataEntry(size_t particle_index, const Vecd &particle_position, Real volumetric) override;
     virtual ListData findNearestListDataEntry(const Vecd &position) override;
@@ -187,7 +188,7 @@ class MultilevelCellLinkedList : public MultilevelMesh<BaseCellLinkedList, CellL
                              size_t total_levels, RealBody &real_body, SPHAdaptation &sph_adaptation);
     virtual ~MultilevelCellLinkedList(){};
 
-    virtual void UpdateCellLists(BaseParticles &base_particles) override;
+    virtual execution::ExecutionEvent UpdateCellLists(BaseParticles &base_particles) override;
     void insertParticleIndex(size_t particle_index, const Vecd &particle_position) override;
     void InsertListDataEntry(size_t particle_index, const Vecd &particle_position, Real volumetric) override;
     virtual ListData findNearestListDataEntry(const Vecd &position) override { return ListData(0, Vecd::Zero(), 0); };

--- a/src/shared/particle_dynamics/execution_unit/execution_event.cpp
+++ b/src/shared/particle_dynamics/execution_unit/execution_event.cpp
@@ -1,0 +1,43 @@
+#include "execution_event.h"
+#include "execution_queue.hpp"
+
+namespace SPH::execution
+{
+ExecutionEvent::ExecutionEvent(const sycl::event &event) : event_list_{event} {}
+ExecutionEvent::ExecutionEvent(const std::vector<sycl::event> &event) : event_list_{event} {}
+ExecutionEvent &ExecutionEvent::operator=(sycl::event event)
+{
+    event_list_.emplace_back(std::move(event));
+    return *this;
+}
+void ExecutionEvent::wait()
+{
+    sycl::event::wait(event_list_);
+    event_list_.clear();
+}
+const std::vector<sycl::event> &ExecutionEvent::getEventList() const
+{
+    return event_list_;
+}
+ExecutionEvent &ExecutionEvent::add(sycl::event event)
+{
+    event_list_.emplace_back(std::move(event));
+    return *this;
+}
+ExecutionEvent &ExecutionEvent::add(const SPH::execution::ExecutionEvent &event)
+{
+    auto new_events = event.getEventList();
+    event_list_.insert(event_list_.end(), new_events.begin(), new_events.end());
+    return *this;
+}
+ExecutionEvent &ExecutionEvent::then(std::function<void()> &&func)
+{
+    executionQueue.getQueue()
+        .submit([&](sycl::handler &cgh)
+                {
+                    cgh.depends_on(getEventList());
+                    cgh.host_task(std::move(func)); });
+    return *this;
+}
+
+} // namespace SPH::execution

--- a/src/shared/particle_dynamics/execution_unit/execution_event.h
+++ b/src/shared/particle_dynamics/execution_unit/execution_event.h
@@ -26,7 +26,8 @@ class ExecutionEvent
     ExecutionEvent &add(const ExecutionEvent &event);
 
     void wait();
-    ExecutionEvent &then(std::function<void()> &&func);
+    ExecutionEvent &then(std::function<void()> &&func,
+                         std::optional<std::reference_wrapper<ExecutionEvent>> host_event = {});
 
   private:
     std::vector<sycl::event> event_list_;

--- a/src/shared/particle_dynamics/execution_unit/execution_event.h
+++ b/src/shared/particle_dynamics/execution_unit/execution_event.h
@@ -1,0 +1,39 @@
+#ifndef SPHINXSYS_EXECUTIONEVENT_HPP
+#define SPHINXSYS_EXECUTIONEVENT_HPP
+
+#include "execution_policy.h"
+#include <any>
+#include <sycl/sycl.hpp>
+#include <utility>
+
+namespace SPH::execution
+{
+class ExecutionEvent
+{
+  public:
+    ExecutionEvent() = default;
+    ExecutionEvent(const sycl::event &event);
+    ExecutionEvent(const std::vector<sycl::event> &event);
+
+    ExecutionEvent(const ExecutionEvent &executionEvent) = default;
+    ExecutionEvent(ExecutionEvent &&executionEvent) = default;
+
+    ExecutionEvent &operator=(const ExecutionEvent &event) = default;
+    ExecutionEvent &operator=(ExecutionEvent &&event) = default;
+
+    ExecutionEvent &operator=(sycl::event event);
+
+    const std::vector<sycl::event> &getEventList() const;
+
+    ExecutionEvent &add(sycl::event event);
+    ExecutionEvent &add(const ExecutionEvent &event);
+
+    void wait();
+    ExecutionEvent &then(std::function<void()> &&func);
+
+  private:
+    std::vector<sycl::event> event_list_;
+};
+} // namespace SPH::execution
+
+#endif // SPHINXSYS_EXECUTIONEVENT_HPP

--- a/src/shared/particle_dynamics/execution_unit/execution_event.h
+++ b/src/shared/particle_dynamics/execution_unit/execution_event.h
@@ -1,10 +1,7 @@
 #ifndef SPHINXSYS_EXECUTIONEVENT_HPP
 #define SPHINXSYS_EXECUTIONEVENT_HPP
 
-#include "execution_policy.h"
-#include <any>
 #include <sycl/sycl.hpp>
-#include <utility>
 
 namespace SPH::execution
 {

--- a/src/shared/particle_neighborhood/neighborhood.cpp
+++ b/src/shared/particle_neighborhood/neighborhood.cpp
@@ -23,13 +23,13 @@ void Neighborhood::removeANeighbor(size_t neighbor_n)
 }
 
 Neighborhood& Neighborhood::operator=(const NeighborhoodDevice &device) {
-    copyDataFromDevice(&current_size_, device.current_size_, 1);
-    copyDataFromDevice(j_.data(), device.j_, current_size_);
-    copyDataFromDevice(W_ij_.data(), device.W_ij_, current_size_);
-    copyDataFromDevice(dW_ijV_j_.data(), device.dW_ijV_j_, current_size_);
-    copyDataFromDevice(r_ij_.data(), device.r_ij_, current_size_);
-    copyDataFromDevice(e_ij_.data(), device.e_ij_, current_size_);
-
+    copyDataFromDevice(&current_size_, device.current_size_, 1)
+        .add(copyDataFromDevice(j_.data(), device.j_, current_size_))
+        .add(copyDataFromDevice(W_ij_.data(), device.W_ij_, current_size_))
+        .add(copyDataFromDevice(dW_ijV_j_.data(), device.dW_ijV_j_, current_size_))
+        .add(copyDataFromDevice(r_ij_.data(), device.r_ij_, current_size_))
+        .add(copyDataFromDevice(e_ij_.data(), device.e_ij_, current_size_))
+        .wait();
     return *this;
 }
 
@@ -54,14 +54,13 @@ NeighborhoodDevice& NeighborhoodDevice::operator=(const Neighborhood &host) {
     if(allocated_size_ < host.current_size_)
         throw std::runtime_error("NeighborhoodDevice allocation size (" + std::to_string(allocated_size_) +
                                  ") is smaller than host Neighborhood size (" + std::to_string(host.current_size_) + ")");
-    copyDataToDevice(host.j_.data(), j_, host.current_size_);
-    copyDataToDevice(host.W_ij_.data(), W_ij_, host.current_size_);
-    copyDataToDevice(host.dW_ijV_j_.data(), dW_ijV_j_, host.current_size_);
-    copyDataToDevice(host.r_ij_.data(), r_ij_, host.current_size_);
-    copyDataToDevice(host.e_ij_.data(), e_ij_, host.current_size_);
-
-    copyDataToDevice(&host.current_size_, current_size_, 1);
-
+    copyDataToDevice(host.j_.data(), j_, host.current_size_)
+        .add(copyDataToDevice(host.W_ij_.data(), W_ij_, host.current_size_))
+        .add(copyDataToDevice(host.dW_ijV_j_.data(), dW_ijV_j_, host.current_size_))
+        .add(copyDataToDevice(host.r_ij_.data(), r_ij_, host.current_size_))
+        .add(copyDataToDevice(host.e_ij_.data(), e_ij_, host.current_size_))
+        .add(copyDataToDevice(&host.current_size_, current_size_, 1))
+        .wait();
     return *this;
 }
 

--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -381,30 +381,34 @@ void BaseParticles::readFromXmlForReloadParticle(std::string &filefullpath)
         registerDeviceVariable<DeviceReal>("Volume", total_real_particles_, Vol_.data());
     }
 
-    void BaseParticles::copyToDeviceMemory() {
-        copyDataToDevice(unsorted_id_.data(), unsorted_id_device_, total_real_particles_);
-        copyDataToDevice(sorted_id_.data(), sorted_id_device_, total_real_particles_);
-        copyDataToDevice(sequence_.data(), sequence_device_, total_real_particles_);
-        copyDataToDevice(pos_.data(), getDeviceVariableByName<DeviceVecd>("Position"), total_real_particles_);
-        copyDataToDevice(vel_.data(), getDeviceVariableByName<DeviceVecd>("Velocity"), total_real_particles_);
-        copyDataToDevice(acc_.data(), getDeviceVariableByName<DeviceVecd>("Acceleration"), total_real_particles_);
-        copyDataToDevice(acc_prior_.data(), getDeviceVariableByName<DeviceVecd>("AccelerationPrior"), total_real_particles_);
-        copyDataToDevice(rho_.data(), getDeviceVariableByName<DeviceReal>("Density"), total_real_particles_);
-        copyDataToDevice(mass_.data(), getDeviceVariableByName<DeviceReal>("Mass"), total_real_particles_);
-        copyDataToDevice(Vol_.data(), getDeviceVariableByName<DeviceReal>("Volume"), total_real_particles_);
+    execution::ExecutionEvent BaseParticles::copyToDeviceMemory() {
+        execution::ExecutionEvent copy_events;
+        copy_events.add(copyDataToDevice(unsorted_id_.data(), unsorted_id_device_, total_real_particles_));
+        copy_events.add(copyDataToDevice(sorted_id_.data(), sorted_id_device_, total_real_particles_));
+        copy_events.add(copyDataToDevice(sequence_.data(), sequence_device_, total_real_particles_));
+        copy_events.add(copyDataToDevice(pos_.data(), getDeviceVariableByName<DeviceVecd>("Position"), total_real_particles_));
+        copy_events.add(copyDataToDevice(vel_.data(), getDeviceVariableByName<DeviceVecd>("Velocity"), total_real_particles_));
+        copy_events.add(copyDataToDevice(acc_.data(), getDeviceVariableByName<DeviceVecd>("Acceleration"), total_real_particles_));
+        copy_events.add(copyDataToDevice(acc_prior_.data(), getDeviceVariableByName<DeviceVecd>("AccelerationPrior"), total_real_particles_));
+        copy_events.add(copyDataToDevice(rho_.data(), getDeviceVariableByName<DeviceReal>("Density"), total_real_particles_));
+        copy_events.add(copyDataToDevice(mass_.data(), getDeviceVariableByName<DeviceReal>("Mass"), total_real_particles_));
+        copy_events.add(copyDataToDevice(Vol_.data(), getDeviceVariableByName<DeviceReal>("Volume"), total_real_particles_));
+        return std::move(copy_events);
     }
 
-    void BaseParticles::copyFromDeviceMemory() {
-        copyDataFromDevice(unsorted_id_.data(), unsorted_id_device_, total_real_particles_);
-        copyDataFromDevice(sorted_id_.data(), sorted_id_device_, total_real_particles_);
-        copyDataFromDevice(sequence_.data(), sequence_device_, total_real_particles_);
-        copyDataFromDevice(pos_.data(), getDeviceVariableByName<DeviceVecd>("Position"), total_real_particles_);
-        copyDataFromDevice(vel_.data(), getDeviceVariableByName<DeviceVecd>("Velocity"), total_real_particles_);
-        copyDataFromDevice(acc_.data(), getDeviceVariableByName<DeviceVecd>("Acceleration"), total_real_particles_);
-        copyDataFromDevice(acc_prior_.data(), getDeviceVariableByName<DeviceVecd>("AccelerationPrior"), total_real_particles_);
-        copyDataFromDevice(rho_.data(), getDeviceVariableByName<DeviceReal>("Density"), total_real_particles_);
-        copyDataFromDevice(mass_.data(), getDeviceVariableByName<DeviceReal>("Mass"), total_real_particles_);
-        copyDataFromDevice(Vol_.data(), getDeviceVariableByName<DeviceReal>("Volume"), total_real_particles_);
+    execution::ExecutionEvent BaseParticles::copyFromDeviceMemory() {
+        execution::ExecutionEvent copy_events;
+        copy_events.add(copyDataFromDevice(unsorted_id_.data(), unsorted_id_device_, total_real_particles_));
+        copy_events.add(copyDataFromDevice(sorted_id_.data(), sorted_id_device_, total_real_particles_));
+        copy_events.add(copyDataFromDevice(sequence_.data(), sequence_device_, total_real_particles_));
+        copy_events.add(copyDataFromDevice(pos_.data(), getDeviceVariableByName<DeviceVecd>("Position"), total_real_particles_));
+        copy_events.add(copyDataFromDevice(vel_.data(), getDeviceVariableByName<DeviceVecd>("Velocity"), total_real_particles_));
+        copy_events.add(copyDataFromDevice(acc_.data(), getDeviceVariableByName<DeviceVecd>("Acceleration"), total_real_particles_));
+        copy_events.add(copyDataFromDevice(acc_prior_.data(), getDeviceVariableByName<DeviceVecd>("AccelerationPrior"), total_real_particles_));
+        copy_events.add(copyDataFromDevice(rho_.data(), getDeviceVariableByName<DeviceReal>("Density"), total_real_particles_));
+        copy_events.add(copyDataFromDevice(mass_.data(), getDeviceVariableByName<DeviceReal>("Mass"), total_real_particles_));
+        copy_events.add(copyDataFromDevice(Vol_.data(), getDeviceVariableByName<DeviceReal>("Volume"), total_real_particles_));
+        return std::move(copy_events);
     }
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -218,8 +218,8 @@ class BaseParticles
     virtual Real ParticleMass(size_t index) { return mass_[index]; }
 
     virtual void registerDeviceMemory();
-    virtual void copyToDeviceMemory();
-    virtual void copyFromDeviceMemory();
+    virtual execution::ExecutionEvent copyToDeviceMemory();
+    virtual execution::ExecutionEvent copyFromDeviceMemory();
 
   protected:
     SPHBody &sph_body_;

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -220,6 +220,8 @@ class BaseParticles
     virtual void registerDeviceMemory();
     virtual execution::ExecutionEvent copyToDeviceMemory();
     virtual execution::ExecutionEvent copyFromDeviceMemory();
+    virtual execution::ExecutionEvent copyVariablesFromDevice(ParticleVariables &);
+    virtual execution::ExecutionEvent copyRestartVariablesFromDevice();
 
   protected:
     SPHBody &sph_body_;

--- a/src/shared/particles/base_particles.hpp
+++ b/src/shared/particles/base_particles.hpp
@@ -322,8 +322,6 @@ void BaseParticles::writeParticlesToVtk(StreamType &output_stream)
         StdLargeVec<Real> &variable_data = *(std::get<type_index_Real>(all_particle_data_)[variable->IndexInContainer()]);
         DeviceVariable<DataTypeEquivalence<Real>::device_type> *device_variable =
             findVariableByName<DataTypeEquivalence<Real>::device_type>(all_device_variables_, variable->Name());
-        if(device_variable)
-            copyDataFromDevice(variable_data.data(), device_variable->VariableAddress(), total_real_particles_);
         output_stream << "    <DataArray Name=\"" << variable->Name() << "\" type=\"Float32\" Format=\"ascii\">\n";
         output_stream << "    ";
         for (size_t i = 0; i != total_real_particles; ++i)
@@ -341,8 +339,6 @@ void BaseParticles::writeParticlesToVtk(StreamType &output_stream)
         StdLargeVec<Vecd> &variable_data = *(std::get<type_index_Vecd>(all_particle_data_)[variable->IndexInContainer()]);
         DeviceVariable<DataTypeEquivalence<Vecd>::device_type> *device_variable =
             findVariableByName<DataTypeEquivalence<Vecd>::device_type>(all_device_variables_, variable->Name());
-        if(device_variable)
-            copyDataFromDevice(variable_data.data(), device_variable->VariableAddress(), total_real_particles_);
         output_stream << "    <DataArray Name=\"" << variable->Name() << "\" type=\"Float32\"  NumberOfComponents=\"3\" Format=\"ascii\">\n";
         output_stream << "    ";
         for (size_t i = 0; i != total_real_particles; ++i)

--- a/src/shared/particles/solid_particles.cpp
+++ b/src/shared/particles/solid_particles.cpp
@@ -30,16 +30,18 @@ void SolidParticles::registerDeviceMemory() {
         registerDeviceVariable<DeviceVecd>("InitialNormal", total_real_particles_, n0_.data());
 }
 
-void SolidParticles::copyToDeviceMemory() {
-    BaseParticles::copyToDeviceMemory();
-    copyDataToDevice(n_.data(), getDeviceVariableByName<DeviceVecd>("Normal"), total_real_particles_);
-    copyDataToDevice(n0_.data(), getDeviceVariableByName<DeviceVecd>("InitialNormal"), total_real_particles_);
+execution::ExecutionEvent SolidParticles::copyToDeviceMemory() {
+    auto copy_events = BaseParticles::copyToDeviceMemory();
+    copy_events.add(copyDataToDevice(n_.data(), getDeviceVariableByName<DeviceVecd>("Normal"), total_real_particles_));
+    copy_events.add(copyDataToDevice(n0_.data(), getDeviceVariableByName<DeviceVecd>("InitialNormal"), total_real_particles_));
+    return std::move(copy_events);
 }
 
-void SolidParticles::copyFromDeviceMemory() {
-    BaseParticles::copyFromDeviceMemory();
-    copyDataFromDevice(n_.data(), getDeviceVariableByName<DeviceVecd>("Normal"), total_real_particles_);
-    copyDataFromDevice(n0_.data(), getDeviceVariableByName<DeviceVecd>("InitialNormal"), total_real_particles_);
+execution::ExecutionEvent SolidParticles::copyFromDeviceMemory() {
+    auto copy_events = BaseParticles::copyFromDeviceMemory();
+    copy_events.add(copyDataFromDevice(n_.data(), getDeviceVariableByName<DeviceVecd>("Normal"), total_real_particles_));
+    copy_events.add(copyDataFromDevice(n0_.data(), getDeviceVariableByName<DeviceVecd>("InitialNormal"), total_real_particles_));
+    return std::move(copy_events);
 }
 
 //=============================================================================================//

--- a/src/shared/particles/solid_particles.h
+++ b/src/shared/particles/solid_particles.h
@@ -68,8 +68,8 @@ class SolidParticles : public BaseParticles
     virtual SolidParticles *ThisObjectPtr() override { return this; };
 
     void registerDeviceMemory() override;
-    void copyToDeviceMemory() override;
-    void copyFromDeviceMemory() override;
+    execution::ExecutionEvent copyToDeviceMemory() override;
+    execution::ExecutionEvent copyFromDeviceMemory() override;
 };
 
 /**

--- a/src/shared/sphinxsys_system/sph_system.cpp
+++ b/src/shared/sphinxsys_system/sph_system.cpp
@@ -22,10 +22,12 @@ void SPHSystem::initializeSystemCellLinkedLists()
     }
 }
 //=================================================================================================//
-void SPHSystem::initializeSystemCellLinkedLists(execution::ParallelSYCLDevicePolicy execution_policy)
+execution::ExecutionEvent SPHSystem::initializeSystemCellLinkedLists(execution::ParallelSYCLDevicePolicy execution_policy)
 {
+    execution::ExecutionEvent update_events;
     for (auto &body : real_bodies_)
-        DynamicCast<RealBody>(this, body)->updateCellLinkedList(execution_policy);
+        update_events.add(DynamicCast<RealBody>(this, body)->updateCellLinkedList(execution_policy));
+    return std::move(update_events);
 }
 //=================================================================================================//
 void SPHSystem::initializeSystemConfigurations()
@@ -39,11 +41,13 @@ void SPHSystem::initializeSystemConfigurations()
     }
 }
 //=================================================================================================//
-void SPHSystem::initializeSystemDeviceConfigurations()
+execution::ExecutionEvent SPHSystem::initializeSystemDeviceConfigurations()
 {
+    execution::ExecutionEvent update_events;
     for (auto &body : sph_bodies_)
         for (auto & body_relation : body->body_relations_)
-            body_relation->updateDeviceConfiguration();
+            update_events.add(body_relation->updateDeviceConfiguration());
+    return update_events;
 }
 //=================================================================================================//
 Real SPHSystem::getSmallestTimeStepAmongSolidBodies(Real CFL)

--- a/src/shared/sphinxsys_system/sph_system.h
+++ b/src/shared/sphinxsys_system/sph_system.h
@@ -85,10 +85,10 @@ class SPHSystem
     SolidBodyVector solid_bodies_;     /**< The bodies with inner particle configuration and acoustic time steps . */
     /** Initialize cell linked list for the SPH system. */
     void initializeSystemCellLinkedLists();
-    void initializeSystemCellLinkedLists(execution::ParallelSYCLDevicePolicy);
+    execution::ExecutionEvent initializeSystemCellLinkedLists(execution::ParallelSYCLDevicePolicy);
     /** Initialize particle configuration for the SPH system. */
     void initializeSystemConfigurations();
-    void initializeSystemDeviceConfigurations();
+    execution::ExecutionEvent initializeSystemDeviceConfigurations();
     /** get the min time step from all bodies. */
     Real getSmallestTimeStepAmongSolidBodies(Real CFL = 0.6);
     /** Command line handle for Ctest. */

--- a/src/shared/variables/base_variable.h
+++ b/src/shared/variables/base_variable.h
@@ -68,7 +68,7 @@ public:
             : BaseVariable(name), device_addr_(allocateDeviceData<DeviceDataType>(size)), size_(size)
     {
         if constexpr(std::negation_v<std::is_same<HostDataType, void>>)
-            copyDataToDevice(host_value, device_addr_, size);
+            copyDataToDevice(host_value, device_addr_, size).wait();
     }
     virtual ~DeviceVariable()
     {

--- a/tests/2d_examples/test_2d_dambreak_sycl/dambreak_sycl.cpp
+++ b/tests/2d_examples/test_2d_dambreak_sycl/dambreak_sycl.cpp
@@ -101,7 +101,7 @@ int main(int ac, char *av[])
     ReduceDynamics<fluid_dynamics::AdvectionTimeStepSize, ParallelSYCLDevicePolicy> fluid_advection_time_step(water_block, U_max);
     ReduceDynamics<fluid_dynamics::AcousticTimeStepSize, ParallelSYCLDevicePolicy> fluid_acoustic_time_step(water_block);
 
-    water_block.getBaseParticles().copyToDeviceMemory();
+    water_block.getBaseParticles().copyToDeviceMemory().wait();
     executionQueue.setWorkGroupSize(16);
 
     //----------------------------------------------------------------------
@@ -122,7 +122,7 @@ int main(int ac, char *av[])
     auto system_configuration_update_event = sph_system.initializeSystemDeviceConfigurations();
 
     wall_boundary_normal_direction.exec();
-    wall_boundary.getBaseParticles().copyToDeviceMemory();
+    wall_boundary.getBaseParticles().copyToDeviceMemory().wait();
     //----------------------------------------------------------------------
     //	Load restart file if necessary.
     //----------------------------------------------------------------------


### PR DESCRIPTION
# Changes

- A new class, `ExecutionEvent`, offers the possibility to launch multiple GPU and CPU tasks asynchronously by defining the dependencies that exist between them.

# Details

So far, computations have been offloaded to SYCL device by submitting a kernel to a queue and waiting for it to finish.
However, some methods are executed at a given moment but their result will not be relevant until much later. This is the case for system configurations update and writing output files, in the latter case their results are never required by the following iterations.
SYCL provides an event class that can be used to postpone kernel synchronization: it is possible to submit a kernel, then continue with other computations not dependent on such execution, and finally wait for the event to complete when the result is actually necessary.
Additionally, SYCL offers a command group directive, `host_task`, that executes a function on a new CPU thread. The function in this case is not tied to the same restrictions applied to the kernels submitted to the device, instead any C++ code can be run as an host task.
`ExecutionEvent` combines those two features, offering methods to build a list of dependencies coming from SYCL kernels, and the possibility to set an host task to be run asynchronously when all the device events have been completed.

An example would be `body_state_recording`, that first needs to copy data from device to host, and then it can write output files with CPU:
```c++
ExecutionEvent async_body_states_copy_event = body_states_recording.copyDeviceData();
// ... other computations hiding the transfer runtime
async_body_states_copy_event.then([&] { body_states_recording.writeToFile(); }).wait();
```

It is worth noting that the task expressed by the lambda function passed to `.then()` will be executed on a different thread than the rest of the code, which means that, while the files are being processed, the rest  of the simulations carries on with the remaining iterations. Effectively, the main CPU thread will be responsible for submitting kernels to the device, while the threads managed by SYCL will execute the major computational effort that, so far, slowed-down computations.

# Benchmarks

> Refer to #454 and #448 for reference runtime on CPU

_SYCL with 500'000 particles_ 
```
Total wall time for computation: 2964.484684851 seconds.
interval_computing_time_step =1410.974875226
interval_computing_fluid_pressure_relaxation = 1048.459943614
interval_updating_configuration = 260.050099024
interval_writing_files = 228.746797083
```

_SYCL with 80'000 particles_
```
Total wall time for computation: 258.931707035 seconds.
interval_computing_time_step =83.856230888
interval_computing_fluid_pressure_relaxation = 99.339878925
interval_updating_configuration = 40.913803999
interval_writing_files = 30.766704951
```

Which corresponds to 5.7x and 4.4x speed-up respectively compared to multi-threaded TBB

> *Note:* `interval_updating_configuration` and `interval_writing_files` show a shorter time interval because they now share computational resources with other steps, such as time-step computations, that is now running simultaneously with configuration update, hence slowing down time-step calculation, but improving the overall performance.