### PR TITLE
[SYCL] Support for user-defined variables to write and better event handling of writing tasks

### DIFF
--- a/src/shared/io_system/io_base.h
+++ b/src/shared/io_system/io_base.h
@@ -107,7 +107,7 @@ class BodyStatesRecording : public BaseIO
     /** write with filename indicated by physical time */
     void writeToFile();
     virtual void writeToFile(size_t iteration_step) override;
-    virtual execution::ExecutionEvent copyDeviceData() const;
+    virtual execution::ExecutionEvent copyVariablesToWriteFromDevice() const;
 
   protected:
     SPHBodyVector bodies_;
@@ -140,6 +140,8 @@ class RestartIO : public BaseIO
         readFromFile(restart_step);
         return readRestartTime(restart_step);
     };
+
+    virtual execution::ExecutionEvent copyVariablesToRestartFromDevice() const;
 };
 
 /**

--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -414,9 +414,9 @@ void BaseParticles::readFromXmlForReloadParticle(std::string &filefullpath)
 template <typename DataType>
 struct copyVariablesFromDeviceOperation
 {
-    void operator()(DeviceVariables &device_variables,
-                    ParticleData &particle_data,
-                    ParticleVariables &particle_variables,
+    void operator()(const DeviceVariables &device_variables,
+                    const ParticleData &particle_data,
+                    const ParticleVariables &particle_variables,
                     execution::ExecutionEvent &event) const
     {
         constexpr int type_index = DataTypeIndex<DataType>::value;
@@ -424,7 +424,7 @@ struct copyVariablesFromDeviceOperation
         {
             if constexpr (DataTypeEquivalence<DataType>::type_defined)
             {
-                DeviceVariable<typename DataTypeEquivalence<DataType>::device_type> *device_variable = findVariableByName<typename DataTypeEquivalence<DataType>::device_type>(device_variables, variable->Name());
+                auto *device_variable = findVariableByName<typename DataTypeEquivalence<DataType>::device_type>(device_variables, variable->Name());
                 if (device_variable)
                 {
                     StdLargeVec<DataType> &variable_data = *(std::get<type_index>(particle_data)[variable->IndexInContainer()]);
@@ -435,17 +435,12 @@ struct copyVariablesFromDeviceOperation
     };
 };
 //=================================================================================================//
-execution::ExecutionEvent BaseParticles::copyVariablesFromDevice(ParticleVariables &variables)
+execution::ExecutionEvent BaseParticles::copyVariablesFromDevice(const ParticleVariables &variables) const
 {
     execution::ExecutionEvent copy_events;
     DataAssembleOperation<copyVariablesFromDeviceOperation> copy_operation{};
     copy_operation(all_device_variables_, all_particle_data_, variables, copy_events);
     return std::move(copy_events);
-}
-//=================================================================================================//
-execution::ExecutionEvent BaseParticles::copyRestartVariablesFromDevice()
-{
-    return copyVariablesFromDevice(variables_to_restart_);
 }
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -189,9 +189,9 @@ class BaseParticles
     ParticleData sortable_data_;
     ParticleVariables sortable_variables_;
     ParticleSorting particle_sorting_;
-    size_t* unsorted_id_device_;      /**< copy of unsorted ids stored inside device. */
-    size_t* sorted_id_device_;        /**< copy of sorted ids stored inside device. */
-    size_t* sequence_device_;         /**< the sequence referred for sorting within device execution. */
+    size_t* unsorted_id_device_ = nullptr;      /**< copy of unsorted ids stored inside device. */
+    size_t* sorted_id_device_ = nullptr;        /**< copy of sorted ids stored inside device. */
+    size_t* sequence_device_ = nullptr;         /**< the sequence referred for sorting within device execution. */
     DeviceVariables sortable_device_variables_;
 
     template <typename DataType>

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -170,6 +170,7 @@ class BaseParticles
     void addVariableToList(ParticleVariables &variable_set, const std::string &variable_name);
     template <typename DataType>
     void addVariableToWrite(const std::string &variable_name);
+    inline const ParticleVariables &getVariablesToWrite() const { return variables_to_write_; }
     template <typename DataType>
     void addVariableToRestart(const std::string &variable_name);
     inline const ParticleVariables &getVariablesToRestart() const { return variables_to_restart_; }
@@ -220,8 +221,7 @@ class BaseParticles
     virtual void registerDeviceMemory();
     virtual execution::ExecutionEvent copyToDeviceMemory();
     virtual execution::ExecutionEvent copyFromDeviceMemory();
-    virtual execution::ExecutionEvent copyVariablesFromDevice(ParticleVariables &);
-    virtual execution::ExecutionEvent copyRestartVariablesFromDevice();
+    virtual execution::ExecutionEvent copyVariablesFromDevice(const ParticleVariables &) const;
 
   protected:
     SPHBody &sph_body_;

--- a/src/shared/variables/base_variable.h
+++ b/src/shared/variables/base_variable.h
@@ -98,7 +98,7 @@ class DiscreteVariable : public BaseVariable
 };
 
 template <typename DataType, template <typename VariableDataType> class VariableType>
-VariableType<DataType> *findVariableByName(DataContainerAddressAssemble<VariableType> &assemble,
+VariableType<DataType> *findVariableByName(const DataContainerAddressAssemble<VariableType> &assemble,
                                            const std::string &name)
 {
     constexpr int type_index = DataTypeIndex<DataType>::value;

--- a/tests/2d_examples/test_2d_dambreak_sycl/dambreak_sycl.cpp
+++ b/tests/2d_examples/test_2d_dambreak_sycl/dambreak_sycl.cpp
@@ -208,9 +208,9 @@ int main(int ac, char *av[])
             }
             interval_computing_fluid_pressure_relaxation += TickCount::now() - time_instance;
 
-            /** Update cell linked list */
+            /** Submit for cell linked list update */
             time_instance = TickCount::now();
-            water_block.updateCellLinkedListWithParticleSort(100, execution::par_sycl).wait();
+            auto cell_linked_list_update_event = water_block.updateCellLinkedListWithParticleSort(100, execution::par_sycl);
             interval_updating_configuration += TickCount::now() - time_instance;
 
             /** Screen output */
@@ -220,6 +220,11 @@ int main(int ac, char *av[])
                           << GlobalStaticVariables::physical_time_
                           << "	advection_dt = " << advection_dt << "	acoustic_dt = " << acoustic_dt << "\n";
             }
+
+            /** Wait for cell linked-list update to finish */
+            time_instance = TickCount::now();
+            cell_linked_list_update_event.wait();
+            interval_updating_configuration += TickCount::now() - time_instance;
 
             /** Write body reduced values */
             if (number_of_iterations % observation_sample_interval == 0 && number_of_iterations != sph_system.RestartStep())

--- a/tests/2d_examples/test_2d_dambreak_sycl/dambreak_sycl.cpp
+++ b/tests/2d_examples/test_2d_dambreak_sycl/dambreak_sycl.cpp
@@ -158,7 +158,7 @@ int main(int ac, char *av[])
     //	First output before the main loop.
     //----------------------------------------------------------------------
     ExecutionEvent async_real_bodies_write_event, async_regression_test_event;
-    body_states_recording.copyDeviceData()
+    body_states_recording.copyVariablesToWriteFromDevice()
         .then([&, number_of_iterations]
               { body_states_recording.writeToFile(number_of_iterations); },
               async_real_bodies_write_event);
@@ -240,8 +240,7 @@ int main(int ac, char *av[])
             {
                 time_instance = TickCount::now();
                 async_real_bodies_write_event.wait();
-                water_block.getBaseParticles()
-                    .copyRestartVariablesFromDevice()
+                restart_io.copyVariablesToRestartFromDevice()
                     .then([&, number_of_iterations]
                           { restart_io.writeToFile(number_of_iterations); },
                           async_real_bodies_write_event);
@@ -257,7 +256,7 @@ int main(int ac, char *av[])
         /** Output files */
         time_instance = TickCount::now();
         async_real_bodies_write_event.wait();
-        body_states_recording.copyDeviceData()
+        body_states_recording.copyVariablesToWriteFromDevice()
             .then([&, number_of_iterations]
                   { body_states_recording.writeToFile(number_of_iterations); },
                   async_real_bodies_write_event);

--- a/tests/2d_examples/test_2d_dambreak_sycl/dambreak_sycl.cpp
+++ b/tests/2d_examples/test_2d_dambreak_sycl/dambreak_sycl.cpp
@@ -157,7 +157,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	First output before the main loop.
     //----------------------------------------------------------------------
-    ExecutionEvent async_real_bodies_write_event, async_regression_test_event;
+    ExecutionEvent async_real_bodies_write_event, async_record_quantity_event;
     body_states_recording.copyVariablesToWriteFromDevice()
         .then([&, number_of_iterations]
               { body_states_recording.writeToFile(number_of_iterations); },
@@ -167,7 +167,7 @@ int main(int ac, char *av[])
               {
                   write_water_mechanical_energy.writeToFile(number_of_iterations);
                   write_recorded_water_pressure.writeToFile(number_of_iterations); },
-              async_regression_test_event);
+              async_record_quantity_event);
     //----------------------------------------------------------------------
     //	Main loop starts here.
     //----------------------------------------------------------------------
@@ -210,30 +210,30 @@ int main(int ac, char *av[])
 
             /** Update cell linked list */
             time_instance = TickCount::now();
-            water_block.updateCellLinkedListWithParticleSort(100, execution::par_sycl)
-                .then([&, number_of_iterations, advection_dt, acoustic_dt, physical_time=GlobalStaticVariables::physical_time_]
-                      {
-                          /** Screen output */
-                          if (number_of_iterations % screen_output_interval == 0)
-                          {
-                              std::cout << std::fixed << std::setprecision(9) << "N=" << number_of_iterations << "	Time = "
-                                        << physical_time
-                                        << "	advection_dt = " << advection_dt << "	acoustic_dt = " << acoustic_dt << "\n";
-                          } })
-                .then([&, number_of_iterations, async_regression_test_event]
-                      {
-                          /** Write body reduced values */
-                          if (number_of_iterations % observation_sample_interval == 0 && number_of_iterations != sph_system.RestartStep())
-                          {
-                              time_instance = TickCount::now();
-                              write_water_mechanical_energy.writeToFile(number_of_iterations);
-                              ExecutionEvent(async_regression_test_event).wait();
-                              write_recorded_water_pressure.writeToFile(number_of_iterations);
-                              interval_writing_files += TickCount::now() - time_instance;
-                          } },
-                      async_regression_test_event)
-                .wait();
+            water_block.updateCellLinkedListWithParticleSort(100, execution::par_sycl).wait();
             interval_updating_configuration += TickCount::now() - time_instance;
+
+            /** Screen output */
+            if (number_of_iterations % screen_output_interval == 0)
+            {
+                std::cout << std::fixed << std::setprecision(9) << "N=" << number_of_iterations << "	Time = "
+                          << GlobalStaticVariables::physical_time_
+                          << "	advection_dt = " << advection_dt << "	acoustic_dt = " << acoustic_dt << "\n";
+            }
+
+            /** Write body reduced values */
+            if (number_of_iterations % observation_sample_interval == 0 && number_of_iterations != sph_system.RestartStep())
+            {
+                async_record_quantity_event.wait();
+                ExecutionEvent()
+                    .then([&, number_of_iterations]
+                          {
+                            time_instance = TickCount::now();
+                            write_water_mechanical_energy.writeToFile(number_of_iterations);
+                            write_recorded_water_pressure.writeToFile(number_of_iterations);
+                            interval_writing_files += TickCount::now() - time_instance; },
+                          async_record_quantity_event);
+            }
 
             /** Write restart files */
             if (number_of_iterations % restart_output_interval == 0)


### PR DESCRIPTION
# Changes

- As mentioned in #456, `BodyStatesRecording` will now copy variables contained in `BaseParticles::variables_to_write_`, instead of copying just a default set of variables, thus providing support for user-specified variables. `RestartIO` follows a similar logic by using `BaseParticles::variables_to_restart_`. The method copying restart variables has been moved from `BaseParticles` to `RestartIO`.
- Writing tasks, such as total mechanical energy and pressure recording, are no longer tied to the cell linked list task. They are launched independently once their previous writing has been completed. Additionally, they no longer wait for their previous event by copying it in the lambda to be executed. This improves threads reusing.
- Some computational cost of the cell linked-list update has been hidden by executing the screen output before waiting for the update to finish.

# Benchmarks

SYCL, 80'000 particles
```
Total wall time for computation: 220.081719216 seconds.
interval_computing_time_step =85.569101590
interval_computing_fluid_pressure_relaxation = 99.213271819
interval_updating_configuration = 1.658522652
interval_writing_files = 28.613178912
```

Reference (multi-core TBB), 80'000 particles
```
Total wall time for computation: 1170.825323076 seconds.
interval_computing_time_step =33.417456092
interval_computing_fluid_pressure_relaxation = 630.046776796
interval_updating_configuration = 384.293749674
```

corresponding to a 5.3x speed-up 
