### PR TITLE
[SYCL] Enable double precision and generalized vector operations

### DIFF
--- a/src/shared/common/base_data_type.h
+++ b/src/shared/common/base_data_type.h
@@ -92,7 +92,7 @@ using AlignedBox3d = Eigen::AlignedBox<Real, 3>;
 using Rotation2d = Eigen::Rotation2D<Real>;
 using Rotation3d = Eigen::AngleAxis<Real>;
 /** Device data types. */
-using DeviceReal = float;
+using DeviceReal = Real;
 using DeviceVec2d = sycl::vec<DeviceReal, 2>;
 using DeviceVec3d = sycl::vec<DeviceReal, 3>;
 using DeviceArray2i = sycl::int2;

--- a/src/shared/common/vector_functions.h
+++ b/src/shared/common/vector_functions.h
@@ -105,6 +105,32 @@ template<> inline DeviceVec3d VecdZero() { return { static_cast<DeviceReal>(0.0)
 template<> inline Vec2d VecdZero() { return Vec2d::Zero(); }
 template<> inline Vec3d VecdZero() { return Vec3d::Zero(); }
 
+/* specialization for specific vector operations */
+template<class RealType, int Dimension>
+inline RealType VecdDot(const sycl::vec<RealType,Dimension>& v1, const sycl::vec<RealType,Dimension>& v2) {
+    return sycl::dot(v1, v2);
+}
+template<class RealType, int Dimension>
+inline RealType VecdDot(const Eigen::Matrix<RealType,Dimension,1>& v1, const Eigen::Matrix<RealType,Dimension,1>& v2) {
+    return v1.dot(v2);
+}
+template<class RealType, int Dimension>
+inline RealType VecdNorm(const sycl::vec<RealType,Dimension>& vec) {
+    return sycl::length(vec);
+}
+template<class RealType, int Dimension>
+inline RealType VecdNorm(const Eigen::Matrix<RealType,Dimension,1>& vec) {
+    return vec.norm();
+}
+template<class RealType, int Dimension>
+inline RealType VecdSquareNorm(const sycl::vec<RealType,Dimension>& vec) {
+    return sycl::dot(vec, vec);
+}
+template<class RealType, int Dimension>
+inline RealType VecdSquareNorm(const Eigen::Matrix<RealType,Dimension,1>& vec) {
+    return vec.squaredNorm();
+}
+
 /* SYCL memory transfer utilities */
 template<class T>
 inline T* allocateDeviceData(std::size_t size) {

--- a/src/shared/kernels/kernel_wenland_c2.cpp
+++ b/src/shared/kernels/kernel_wenland_c2.cpp
@@ -92,7 +92,8 @@ DeviceReal DeviceKernelWendlandC2::W(const DeviceReal &r_ij, const DeviceVec3d &
 //=================================================================================================//
 DeviceReal DeviceKernelWendlandC2::W_1D(const DeviceReal q) const
 {
-    return sycl::pow(1.0f - 0.5f * q, 4.0f) * (1.0f + 2.0f * q);
+    return sycl::pow(static_cast<DeviceReal>(1.0) - static_cast<DeviceReal>(0.5) * q,
+                     static_cast<DeviceReal>(4.0)) * (static_cast<DeviceReal>(1.0) + static_cast<DeviceReal>(2.0) * q);
 }
 //=================================================================================================//
 DeviceReal DeviceKernelWendlandC2::W_2D(const DeviceReal q) const
@@ -126,7 +127,7 @@ DeviceReal DeviceKernelWendlandC2::dW(const DeviceReal &r_ij, const DeviceVec3d 
 //=================================================================================================//
 DeviceReal DeviceKernelWendlandC2::dW_1D(const DeviceReal q) const
 {
-    return 0.625f * sycl::pow(q - 2.0f, 3.0f) * q;
+    return 0.625f * sycl::pow(q - static_cast<DeviceReal>(2.0), static_cast<DeviceReal>(3.0)) * q;
 }
 //=================================================================================================//
 DeviceReal DeviceKernelWendlandC2::dW_2D(const DeviceReal q) const
@@ -141,7 +142,8 @@ DeviceReal DeviceKernelWendlandC2::dW_3D(const DeviceReal q) const
 //=================================================================================================//
 DeviceReal DeviceKernelWendlandC2::d2W_1D(const DeviceReal q) const
 {
-    return 1.25f * sycl::pow(q - 2.0f, 2.0f) * (2.0f * q - 1.0f);
+    return 1.25f * sycl::pow(q - static_cast<DeviceReal>(2.0), static_cast<DeviceReal>(2.0))
+           * (static_cast<DeviceReal>(2.0) * q - static_cast<DeviceReal>(1.0));
 }
 //=================================================================================================//
 DeviceReal DeviceKernelWendlandC2::d2W_2D(const DeviceReal q) const

--- a/src/shared/materials/weakly_compressible_fluid.h
+++ b/src/shared/materials/weakly_compressible_fluid.h
@@ -58,9 +58,9 @@ class WeaklyCompressibleFluid : public Fluid
     virtual WeaklyCompressibleFluid *ThisObjectPtr() override { return this; };
 
     DeviceReal getPressure_Device(DeviceReal rho) const {
-        return static_cast<DeviceReal>(p0_) * (rho / static_cast<DeviceReal>(rho0_) - 1.0f);
+        return static_cast<DeviceReal>(p0_) * (rho / static_cast<DeviceReal>(rho0_) - static_cast<DeviceReal>(1.0));
     }
-    DeviceReal getSoundSpeed_Device(DeviceReal p = 0.0f, DeviceReal rho = 1.0f) const {
+    DeviceReal getSoundSpeed_Device(DeviceReal p = 0.0, DeviceReal rho = 1.0) const {
         return static_cast<DeviceReal>(c0_);
     }
 };

--- a/src/shared/particle_dynamics/external_force/external_force.h
+++ b/src/shared/particle_dynamics/external_force/external_force.h
@@ -71,7 +71,7 @@ class Gravity : public ExternalForce
         return global_acceleration_device_;
     }
     DeviceReal getPotential(const DeviceVecd &position) const {
-        return sycl::dot(InducedAcceleration(position), zero_potential_reference_device_ - position);
+        return VecdDot(InducedAcceleration(position), DeviceVecd(zero_potential_reference_device_ - position));
     }
 };
 } // namespace SPH

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.hpp
@@ -161,7 +161,7 @@ InteractionWithWall<BaseIntegrationType>::
         wall_n_.push_back(&(FluidWallData::contact_particles_[k]->n_));
         
         // Device variables
-        wall_inv_rho0_device_.at(k) = 1.0f / static_cast<DeviceReal>(rho0_k);
+        wall_inv_rho0_device_.at(k) = static_cast<DeviceReal>(1.0) / static_cast<DeviceReal>(rho0_k);
         wall_mass_device_.at(k) = this->contact_particles_[k]->template getDeviceVariableByName<DeviceReal>("Mass");;
         wall_vel_ave_device_.at(k) = this->contact_particles_[k]->template getDeviceVariableByName<DeviceVecd>("Velocity");
         wall_acc_ave_device_.at(k) = this->contact_particles_[k]->template getDeviceVariableByName<DeviceVecd>("Acceleration");;
@@ -189,7 +189,7 @@ BaseDensitySummationComplex<DensitySummationInnerType>::
         contact_mass_.at(k) = &(this->contact_particles_[k]->mass_);
 
 	// Device variables
-	contact_inv_rho0_device_.at(k) = 1.0f / static_cast<DeviceReal>(rho0_k);
+	contact_inv_rho0_device_.at(k) = static_cast<DeviceReal>(1.0) / static_cast<DeviceReal>(rho0_k);
         contact_mass_device_.at(k) = this->contact_particles_[k]->template getDeviceVariableByName<DeviceReal>("Mass");
     }
 }

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.hpp
@@ -242,8 +242,7 @@ void BaseIntegration1stHalfWithWall<BaseIntegration1stHalfType>::
             [&](auto index_i){ return computeNonConservativeAcceleration(index_i); },
             [&](auto k){ return this->wall_acc_ave_[k]->data(); },
             [&](auto k, auto index_i) -> Neighborhood&
-               { return (*FluidWallData::contact_configuration_[k])[index_i]; },
-            [](const Vecd& v1, const Vecd& v2){ return v1.dot(v2); });
+               { return (*FluidWallData::contact_configuration_[k])[index_i]; });
 }
 //=================================================================================================//
 template <class BaseIntegration1stHalfType>
@@ -319,8 +318,7 @@ void BaseIntegration2ndHalfWithWall<BaseIntegration2ndHalfType>::
             [&](auto k){ return this->wall_vel_ave_[k]->data(); },
             [&](auto k){ return this->wall_n_[k]->data(); },
             [&](auto k, auto index_i) -> const Neighborhood&
-            { return (*FluidWallData::contact_configuration_[k])[index_i]; },
-            [](const Vecd& v1, const Vecd& v2){ return v1.dot(v2); });
+            { return (*FluidWallData::contact_configuration_[k])[index_i]; });
 }
 //=================================================================================================//
 } // namespace fluid_dynamics

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.cpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.cpp
@@ -68,8 +68,7 @@ AcousticTimeStepSize::AcousticTimeStepSize(SPHBody &sph_body, Real acousticCFL)
 Real AcousticTimeStepSize::reduce(size_t index_i, Real dt)
 {
     return decltype(device_proxy)::Kernel::reduce(index_i, dt, fluid_, p_.data(), rho_.data(), vel_.data(),
-                   [](Fluid& fluid, Real p_i, Real rho_i) { return fluid.getSoundSpeed(p_i, rho_i); },
-                   [](const Vecd& vel) { return vel.norm(); });
+                   [](Fluid& fluid, Real p_i, Real rho_i) { return fluid.getSoundSpeed(p_i, rho_i); });
 }
 //=================================================================================================//
 Real AcousticTimeStepSize::outputResult(Real reduced_value)
@@ -88,8 +87,7 @@ AdvectionTimeStepSizeForImplicitViscosity::
 //=================================================================================================//
 Real AdvectionTimeStepSizeForImplicitViscosity::reduce(size_t index_i, Real dt)
 {
-    return AdvectionTimeStepSizeForImplicitViscosityKernel::reduce(index_i, dt, vel_.data(),
-                                           [](const Vecd& vel) { return vel.squaredNorm(); });
+    return AdvectionTimeStepSizeForImplicitViscosityKernel::reduce(index_i, dt, vel_.data());
 }
 //=================================================================================================//
 Real AdvectionTimeStepSizeForImplicitViscosity::outputResult(Real reduced_value)

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.hpp
@@ -243,8 +243,7 @@ void BaseIntegration2ndHalf<RiemannSolverType>::
     interaction(size_t index_i, Real dt)
 {
     DeviceKernel::interaction(index_i, dt, rho_.data(), drho_dt_.data(), vel_.data(),
-                              acc_.data(), inner_configuration_.data(), riemann_solver_,
-                              [](const Vecd& v1, const Vecd& v2) { return v1.dot(v2); });
+                              acc_.data(), inner_configuration_.data(), riemann_solver_);
 };
 //=================================================================================================//
 } // namespace fluid_dynamics

--- a/src/shared/particle_dynamics/general_dynamics/general_dynamics.cpp
+++ b/src/shared/particle_dynamics/general_dynamics/general_dynamics.cpp
@@ -101,7 +101,7 @@ TotalMechanicalEnergy::TotalMechanicalEnergy(SPHBody &sph_body, SharedPtr<Gravit
 //=================================================================================================//
 Real TotalMechanicalEnergy::reduce(size_t index_i, Real dt)
 {
-    return 0.5 * mass_[index_i] * vel_[index_i].squaredNorm() + mass_[index_i] * gravity_->getPotential(pos_[index_i]);
+    return TotalMechanicalEnergyKernel::reduce(index_i, dt, mass_.data(), vel_.data(), pos_.data(), gravity_);
 }
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/particle_dynamics/general_dynamics/general_dynamics.h
+++ b/src/shared/particle_dynamics/general_dynamics/general_dynamics.h
@@ -317,14 +317,13 @@ public:
         pos_(particles->getDeviceVariableByName<DeviceVecd>("Position")),
         gravity_(gravity) {}
 
-    template<class RealType, class VecType, class SquareNormFunc>
-    static RealType reduce(size_t index_i, Real dt, RealType *mass, VecType* vel, VecType *pos, Gravity* gravity,
-                           SquareNormFunc&& squareNorm) {
-        return 0.5 * mass[index_i] * squareNorm(vel[index_i]) + mass[index_i] * gravity->getPotential(pos[index_i]);
+    template<class RealType, class VecType>
+    static RealType reduce(size_t index_i, Real dt, RealType *mass, VecType* vel, VecType *pos, Gravity* gravity) {
+        return 0.5 * mass[index_i] * VecdSquareNorm(vel[index_i]) + mass[index_i] * gravity->getPotential(pos[index_i]);
     }
 
     DeviceReal reduce(size_t index_i, Real dt = 0.0) const {
-        return reduce(index_i, dt, mass_, vel_, pos_, gravity_, [](const DeviceVecd& vel){ return sycl::dot(vel, vel); });
+        return reduce(index_i, dt, mass_, vel_, pos_, gravity_);
     }
 
 private:

--- a/src/shared/particle_neighborhood/neighborhood.cpp
+++ b/src/shared/particle_neighborhood/neighborhood.cpp
@@ -283,7 +283,7 @@ void NeighborBuilderContactAdaptive::operator()(Neighborhood &neighborhood,
 void NeighborBuilderInnerKernel::operator()(NeighborhoodDevice &neighborhood, const DeviceVecd &pos_i, const size_t index_i, const size_t index_j, const DeviceVecd pos_j, const DeviceReal Vol_j) const
     {
         DeviceVecd displacement = pos_i - pos_j;
-        DeviceReal distance_metric = sycl::dot(displacement, displacement);
+        DeviceReal distance_metric = VecdSquareNorm(displacement);
         if (distance_metric < smoothing_kernel.CutOffRadiusSqr() && index_i != index_j)
         {
             auto current_size_atomic = sycl::atomic_ref<size_t, sycl::memory_order::relaxed,

--- a/src/shared/particle_neighborhood/neighborhood.h
+++ b/src/shared/particle_neighborhood/neighborhood.h
@@ -200,7 +200,7 @@ class NeighborBuilderContactKernel : public NeighborBuilderKernel {
                     const size_t index_j, const DeviceVecd pos_j, const DeviceReal Vol_j) const
     {
         const DeviceVecd displacement = pos_i - pos_j;
-        const DeviceReal distance = sycl::length(displacement);
+        const DeviceReal distance = VecdNorm(displacement);
         if (distance < smoothing_kernel.CutOffRadius())
         {
             auto current_size_atomic = sycl::atomic_ref<size_t, sycl::memory_order::relaxed,


### PR DESCRIPTION
# Changes
- `DeviceReal` can now be set to `double`
    - This change required just some type casting to make sure that the right types could be inferred at compile-time.
- As discussed #448, some helper functions regarding vectors have been added to generalize kernel executions
    - > I have not included a few more changes that would be needed to let `DeviceVecd = Vecd` (i.e. using Eigen matrices as device vectors), since Eigen classes are not device-copyable, hence they cannot be run within kernels without other significant changes to how vectors are stored. I have added the changes needed to enable `DeviceVecd = Vecd` to https://github.com/nR3D/SPHinXsys/tree/sycl-eigen in case they would ever be needed. They mainly involve the definition of other helper classes for vectors, and changes to the declaration of some templates.

# Benchmarks

With 300'000 particles, using double-precision makes the simulation 86.4% slower than with single-precision

Double:
```
Total wall time for computation: 1114.259535746 seconds.
interval_computing_time_step =768.747579194
interval_computing_fluid_pressure_relaxation = 325.318849561
interval_updating_configuration = 3.267941609
interval_writing_files = 10.581363697
```

Float:
```
Total wall time for computation: 597.805587192 seconds.
interval_computing_time_step =319.801477432
interval_computing_fluid_pressure_relaxation = 259.038648931
interval_updating_configuration = 2.944420347
interval_writing_files = 10.566627757
```