### PR TITLE
Move shell normal update out of relaxation

### DIFF
--- a/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.cpp
+++ b/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.cpp
@@ -11,6 +11,17 @@ ShellDynamicsInitialCondition::ShellDynamicsInitialCondition(SPHBody &sph_body)
       n0_(particles_->n0_), n_(particles_->n_), pseudo_n_(particles_->pseudo_n_),
       pos0_(particles_->pos0_), transformation_matrix_(particles_->transformation_matrix_) {}
 //=================================================================================================//
+UpdateShellNormalDirection::UpdateShellNormalDirection(SPHBody &sph_body)
+    : LocalDynamics(sph_body), ShellDataSimple(sph_body),
+      n_(particles_->n_), F_(particles_->F_),
+      transformation_matrix_(particles_->transformation_matrix_) {}
+//=========================================================================================//
+void UpdateShellNormalDirection::update(size_t index_i, Real dt)
+{
+    /** Calculate the current normal direction of mid-surface. */
+    n_[index_i] = transformation_matrix_[index_i].transpose() * getNormalFromDeformationGradientTensor(F_[index_i]);
+}
+//=================================================================================================//
 ShellAcousticTimeStepSize::ShellAcousticTimeStepSize(SPHBody &sph_body, Real CFL)
     : LocalDynamicsReduce<Real, ReduceMin>(sph_body, Real(MaxRealNumber)),
       ShellDataSimple(sph_body), CFL_(CFL), vel_(particles_->vel_), acc_(particles_->acc_),
@@ -32,8 +43,8 @@ Real ShellAcousticTimeStepSize::reduce(size_t index_i, Real dt)
     Real time_setp_1 = SMIN((Real)sqrt(1.0 / (dangular_vel_dt_[index_i].norm() + TinyReal)),
                             Real(1.0) / (angular_vel_[index_i].norm() + TinyReal));
     Real time_setp_2 = smoothing_length_ * (Real)sqrt(rho0_ * (1.0 - nu_ * nu_) / E0_ /
-                                                (2.0 + (Pi * Pi / 12.0) * (1.0 - nu_) *
-                                                           (1.0 + 1.5 * pow(smoothing_length_ / thickness_[index_i], 2))));
+                                                      (2.0 + (Pi * Pi / 12.0) * (1.0 - nu_) *
+                                                                 (1.0 + 1.5 * pow(smoothing_length_ / thickness_[index_i], 2))));
     return CFL_ * SMIN(time_setp_0, time_setp_1, time_setp_2);
 }
 //=================================================================================================//
@@ -75,7 +86,6 @@ ShellStressRelaxationFirstHalf::
       mid_surface_cauchy_stress_(particles_->mid_surface_cauchy_stress_),
       numerical_damping_scaling_(particles_->numerical_damping_scaling_),
       global_shear_stress_(particles_->global_shear_stress_),
-      n_(particles_->n_),
       rho0_(elastic_solid_.ReferenceDensity()),
       inv_rho0_(1.0 / rho0_),
       smoothing_length_(sph_body_.sph_adaptation_->ReferenceSmoothingLength()),
@@ -121,8 +131,6 @@ void ShellStressRelaxationFirstHalf::initialization(size_t index_i, Real dt)
 
     rho_[index_i] = rho0_ / J;
 
-    /** Calculate the current normal direction of mid-surface. */
-    n_[index_i] = transformation_matrix_[index_i].transpose() * getNormalFromDeformationGradientTensor(F_[index_i]);
     /** Get transformation matrix from global coordinates to current local coordinates. */
     Matd current_transformation_matrix = getTransformationMatrix(pseudo_n_[index_i]);
 
@@ -144,7 +152,7 @@ void ShellStressRelaxationFirstHalf::initialization(size_t index_i, Real dt)
 
         /** correct out-plane numerical damping. */
         Matd cauchy_stress = elastic_solid_.StressCauchy(current_local_almansi_strain, index_i) + current_transformation_matrix * transformation_matrix_[index_i].transpose() * F_gaussian_point *
-                                                                                                                        elastic_solid_.NumericalDampingRightCauchy(F_gaussian_point, dF_gaussian_point_dt, numerical_damping_scaling_[index_i], index_i) * F_gaussian_point.transpose() * transformation_matrix_[index_i] * current_transformation_matrix.transpose() / F_gaussian_point.determinant();
+                                                                                                      elastic_solid_.NumericalDampingRightCauchy(F_gaussian_point, dF_gaussian_point_dt, numerical_damping_scaling_[index_i], index_i) * F_gaussian_point.transpose() * transformation_matrix_[index_i] * current_transformation_matrix.transpose() / F_gaussian_point.determinant();
 
         /** Impose modeling assumptions. */
         cauchy_stress.col(Dimensions - 1) *= shear_correction_factor_;

--- a/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.h
+++ b/src/shared/particle_dynamics/solid_dynamics/thin_structure_dynamics.h
@@ -62,6 +62,24 @@ class ShellDynamicsInitialCondition : public LocalDynamics, public ShellDataSimp
 };
 
 /**
+ * @class UpdateShellNormalDirection
+ * @brief update particle normal directions for shell
+ */
+class UpdateShellNormalDirection : public LocalDynamics, public ShellDataSimple
+{
+  protected:
+    StdLargeVec<Vecd> &n_;
+    StdLargeVec<Matd> &F_;
+    StdLargeVec<Matd> &transformation_matrix_;
+
+  public:
+    explicit UpdateShellNormalDirection(SPHBody &sph_body);
+    virtual ~UpdateShellNormalDirection(){};
+
+    void update(size_t index_i, Real dt = 0.0);
+};
+
+/**
  * @class ShellAcousticTimeStepSize
  * @brief Computing the acoustic time step size for shell
  */
@@ -217,7 +235,7 @@ class ShellStressRelaxationFirstHalf : public BaseShellRelaxation
                                                            transformation_matrix_[index_i].transpose() * F_bending_[index_i] * transformation_matrix_[index_i],
                                                            pseudo_n_variation_j,
                                                            transformation_matrix_[index_j].transpose() * F_bending_[index_j] * transformation_matrix_[index_j]);
-                Real limiter_pseudo_n = SMIN(2.0 * pseudo_n_jump.norm() / ((pseudo_n_variation_i- pseudo_n_variation_j).norm() + Eps), 1.0);
+                Real limiter_pseudo_n = SMIN(2.0 * pseudo_n_jump.norm() / ((pseudo_n_variation_i - pseudo_n_variation_j).norm() + Eps), 1.0);
                 pseudo_normal_acceleration += hourglass_control_factor_ * weight * G0_ * pseudo_n_jump * Dimensions *
                                               inner_neighborhood.dW_ijV_j_[n] * pow(thickness_[index_i], 2) * limiter_pseudo_n;
             }
@@ -239,7 +257,7 @@ class ShellStressRelaxationFirstHalf : public BaseShellRelaxation
   protected:
     ElasticSolid &elastic_solid_;
     StdLargeVec<Matd> &global_stress_, &global_moment_, &mid_surface_cauchy_stress_, &numerical_damping_scaling_;
-    StdLargeVec<Vecd> &global_shear_stress_, &n_;
+    StdLargeVec<Vecd> &global_shear_stress_;
     Real rho0_, inv_rho0_;
     Real smoothing_length_, E0_, G0_, nu_, hourglass_control_factor_;
     bool hourglass_control_;

--- a/tests/3d_examples/test_3d_shell_stability_half_sphere/test_3d_shell_stability_half_sphere.cpp
+++ b/tests/3d_examples/test_3d_shell_stability_half_sphere/test_3d_shell_stability_half_sphere.cpp
@@ -150,6 +150,7 @@ void sphere_compression(int dp_ratio, Real pressure, Real gravity_z)
     ReduceDynamics<thin_structure_dynamics::ShellAcousticTimeStepSize> computing_time_step_size(shell_body);
     Dynamics1Level<thin_structure_dynamics::ShellStressRelaxationFirstHalf> stress_relaxation_first_half(shell_body_inner, 3, true);
     Dynamics1Level<thin_structure_dynamics::ShellStressRelaxationSecondHalf> stress_relaxation_second_half(shell_body_inner);
+    SimpleDynamics<thin_structure_dynamics::UpdateShellNormalDirection> normal_update(shell_body);
 
     // pressure boundary condition
     auto apply_pressure = [&]()
@@ -246,7 +247,10 @@ void sphere_compression(int dp_ratio, Real pressure, Real gravity_z)
 
                 initialize_external_force.exec(dt);
                 if (pressure > TinyReal)
+                {
+                    normal_update.exec();
                     apply_pressure();
+                }
 
                 dt = computing_time_step_size.exec();
                 { // checking for excessive time step reduction

--- a/tests/unit_tests_src/shared/particle_dynamics/solid_dynamics/test_thin_structure_dynamics/test_thin_structure_dynamics.cpp
+++ b/tests/unit_tests_src/shared/particle_dynamics/solid_dynamics/test_thin_structure_dynamics/test_thin_structure_dynamics.cpp
@@ -148,6 +148,7 @@ int main(int ac, char *av[])
         stress_relaxation_first_half(plate_body_inner);
     Dynamics1Level<thin_structure_dynamics::ShellStressRelaxationSecondHalf>
         stress_relaxation_second_half(plate_body_inner);
+    SimpleDynamics<thin_structure_dynamics::UpdateShellNormalDirection> update_normal(plate_body);
     /** Constrain the Boundary. */
     ControledGeometry controled_geometry(plate_body, "ControledGeometry");
     SimpleDynamics<ControledRotation> controled_rotaton(controled_geometry);
@@ -218,6 +219,9 @@ int main(int ac, char *av[])
         rondom_index.push_back((double)rand() / (RAND_MAX)*shell_particles->total_real_particles_);
         von_mises_strain.push_back(shell_particles->getVonMisesStrain(rondom_index[i]));
     }
+
+    update_normal.exec();
+
     pseudo_normal = shell_particles->pseudo_n_;
     normal = shell_particles->n_;
 


### PR DESCRIPTION
A separate class for shell normal update is created since normal direction is not used in stress relaxation