### PR TITLE
[CI] Build shared libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Generate buildsystem using float (No test)
         run: |
           cmake -G Ninja \
+            -D BUILD_SHARED_LIBS=ON\
             -D CMAKE_BUILD_TYPE=Release \
             -D CMAKE_TOOLCHAIN_FILE="${{github.workspace}}/vcpkg/scripts/buildsystems/vcpkg.cmake" \
             -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
@@ -134,6 +135,7 @@ jobs:
       - name: Generate buildsystem using double
         run: |
           cmake -G Ninja \
+            -D BUILD_SHARED_LIBS=ON\
             -D CMAKE_BUILD_TYPE=Release \
             -D CMAKE_TOOLCHAIN_FILE="${{github.workspace}}/vcpkg/scripts/buildsystems/vcpkg.cmake" \
             -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
@@ -438,6 +440,7 @@ jobs:
       - name: Generate buildsystem
         run: |
           cmake -G Ninja \
+            -D BUILD_SHARED_LIBS=ON\
             -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER=clang++ \
             -D CMAKE_BUILD_TYPE=Release \
             -D CMAKE_TOOLCHAIN_FILE="${{github.workspace}}/vcpkg/scripts/buildsystems/vcpkg.cmake" \


### PR DESCRIPTION
Generate shared libraries instead of static one. The objective is to reduce disk size consumed on the GitHub runners by the CI. Currently as static library, the binary code is duplicated many times across all example binaries. Building as shared library should solve that. 