### PR TITLE
[SYCL] Improved SYCL particle sorting

### DIFF
--- a/src/shared/particle_neighborhood/neighborhood.cpp
+++ b/src/shared/particle_neighborhood/neighborhood.cpp
@@ -34,7 +34,7 @@ Neighborhood& Neighborhood::operator=(const NeighborhoodDevice &device) {
 }
 
 NeighborhoodDevice::NeighborhoodDevice() : current_size_(allocateDeviceData<size_t>(1)),
-                                           allocated_size_(Dimensions == 2 ? 28 : 68),
+                                           allocated_size_(Dimensions == 2 ? 28 : 82),
                                            j_(allocateDeviceData<size_t>(allocated_size_)),
                                            W_ij_(allocateDeviceData<DeviceReal>(allocated_size_)),
                                            dW_ijV_j_(allocateDeviceData<DeviceReal>(allocated_size_)),


### PR DESCRIPTION
# Changes
- Improved performance of SYCL particle sorting by executing global buckets scan in a separate kernel
- Reduce memory allocation by reusing data buffers whenever sorting size is unchanged from the last use. For this purpose, sorting methods relative to SYCL have been moved inside a new class `DeviceRadixSort`

# Performance
This implementation is now comparable to Intel's oneDPL execution for `size_t`/`uint64_t` keys, making it considerable faster than previous implementation (depending on the sorted data size)

![benchmark](https://github.com/Xiangyu-Hu/SPHinXsys/assets/43089212/7f88c102-9202-4e35-92bc-a579c0432b18)

# Other changes
- Allocation size of `NeighborhoodDevice` for the 3d case has been increased, since the previous value was not sufficient for larger simulations