### PR TITLE
BasePaericles function ParticleMass() not neccessary after new definition of discrete variable mass

### DIFF
--- a/src/for_3D_build/particles/beam_particles.h
+++ b/src/for_3D_build/particles/beam_particles.h
@@ -75,8 +75,6 @@ class BarParticles : public ShellParticles
     //----------------------------------------------------------------------
     /** get particle volume. */
     virtual Real ParticleVolume(size_t index_i) override { return Vol_[index_i] * thickness_[index_i] * width_[index_i]; }
-    /** get particle mass. */
-    virtual Real ParticleMass(size_t index_i) override { return mass_[index_i] * width_[index_i]; }
     /** Initialize variable for shell particles. */
     virtual void initializeOtherVariables() override;
     virtual BarParticles *ThisObjectPtr() override { return this; };

--- a/src/shared/particle_dynamics/solid_dynamics/fluid_structure_interaction.h
+++ b/src/shared/particle_dynamics/solid_dynamics/fluid_structure_interaction.h
@@ -137,7 +137,7 @@ class BasePressureForceAccelerationFromFluid : public BaseForceFromFluid
                 size_t index_j = contact_neighborhood.j_[n];
                 Vecd e_ij = contact_neighborhood.e_ij_[n];
                 Real r_ij = contact_neighborhood.r_ij_[n];
-                Real face_wall_external_acceleration = (force_prior_k[index_j] / mass_k[index_j] - force_ave_[index_i] / particles_->ParticleMass(index_i)).dot(e_ij);
+                Real face_wall_external_acceleration = (force_prior_k[index_j] / mass_k[index_j] - force_ave_[index_i] / particles_->mass_[index_i]).dot(e_ij);
                 Real p_in_wall = p_k[index_j] + rho_n_k[index_j] * r_ij * SMAX(Real(0), face_wall_external_acceleration);
                 Real u_jump = 2.0 * (vel_k[index_j] - vel_ave_[index_i]).dot(n_[index_i]);
                 force += (riemann_solvers_k.DissipativePJump(u_jump) * n_[index_i] - (p_in_wall + p_k[index_j]) * e_ij) * Vol_[index_i] * contact_neighborhood.dW_ijV_j_[n];

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -190,7 +190,6 @@ class BaseParticles
     //		Relation relate volume, surface and linear particles
     //----------------------------------------------------------------------
     virtual Real ParticleVolume(size_t index) { return Vol_[index]; }
-    virtual Real ParticleMass(size_t index) { return mass_[index]; }
     virtual Real ParticleSpacing(size_t index) { return std::pow(Vol_[index], 1.0 / Real(Dimensions)); }
 
   protected:

--- a/src/shared/particles/solid_particles.h
+++ b/src/shared/particles/solid_particles.h
@@ -188,9 +188,6 @@ class ShellParticles : public ElasticSolidParticles
 
     /** get particle volume. */
     virtual Real ParticleVolume(size_t index_i) override { return Vol_[index_i] * thickness_[index_i]; }
-    /** get particle mass. */
-    virtual Real ParticleMass(size_t index_i) override { return mass_[index_i]; }
-    /** Initialize variable for shell particles. */
     virtual void initializeOtherVariables() override;
     /** Return this pointer. */
     virtual ShellParticles *ThisObjectPtr() override { return this; };

--- a/tests/3d_examples/test_3d_shell_stability_half_sphere/test_3d_shell_stability_half_sphere.cpp
+++ b/tests/3d_examples/test_3d_shell_stability_half_sphere/test_3d_shell_stability_half_sphere.cpp
@@ -135,7 +135,7 @@ void sphere_compression(int dp_ratio, Real pressure, Real gravity_z)
 
     // starting the actual simulation
     SPHSystem system(bb_system, dp);
-    system.setIOEnvironment(false);  
+    system.setIOEnvironment(false);
     SolidBody shell_body(system, shell_shape);
     shell_body.defineParticlesWithMaterial<ShellParticles>(material.get());
     shell_body.generateParticles<ShellSphereParticleGenerator>(obj_vertices, center, particle_area, thickness);
@@ -161,7 +161,7 @@ void sphere_compression(int dp_ratio, Real pressure, Real gravity_z)
         for (size_t i = 0; i < shell_particles->force_prior_.size(); ++i)
         {
             // opposite to normals
-            shell_particles->force_prior_[i] -= shell_particles->mass_[i] * pressure_MPa * shell_particles->Vol_[i] / shell_particles->ParticleMass(i) * shell_particles->n_[i];
+            shell_particles->force_prior_[i] -= pressure_MPa * shell_particles->Vol_[i] * shell_particles->n_[i];
         }
     };
 


### PR DESCRIPTION
ParticleMass() is deleted.