### PR TITLE
use the matrix.block() feature in Eigen to adjust matrix size

### DIFF
--- a/src/shared/particle_dynamics/continuum_dynamics/continuum_integration.cpp
+++ b/src/shared/particle_dynamics/continuum_dynamics/continuum_integration.cpp
@@ -61,7 +61,7 @@ void ShearStressRelaxation::interaction(size_t index_i, Real dt)
         velocity_gradient -= v_ij * (B_[index_i] * e_ij * dW_ijV_j_).transpose();
     }
     velocity_gradient_[index_i] = velocity_gradient;
-    // calculate strain
+    /*calculate strain*/
     Matd strain_rate = 0.5 * (velocity_gradient + velocity_gradient.transpose());
     strain_tensor_rate_[index_i] = strain_rate;
     strain_tensor_[index_i] += strain_tensor_rate_[index_i] * 0.5 * dt;
@@ -98,9 +98,9 @@ void StressDiffusion::interaction(size_t index_i, Real dt)
         Real dW_ijV_j = inner_neighborhood.dW_ijV_j_[n];
         Real y_ij = pos_[index_i](1, 0) - pos_[index_j](1, 0);
         diffusion_stress_ = stress_tensor_3D_[index_i] - stress_tensor_3D_[index_j];
-        diffusion_stress_(0, 0) = diffusion_stress_(0, 0) - (1 - sin(fai_)) * density * gravity * y_ij;
-        diffusion_stress_(1, 1) = diffusion_stress_(1, 1) - density * gravity * y_ij;
-        diffusion_stress_(2, 2) = diffusion_stress_(2, 2) - (1 - sin(fai_)) * density * gravity * y_ij;
+        diffusion_stress_(0, 0) -= (1 - sin(fai_)) * density * gravity * y_ij;
+        diffusion_stress_(1, 1) -= density * gravity * y_ij;
+        diffusion_stress_(2, 2) -= (1 - sin(fai_)) * density * gravity * y_ij;
         diffusion_stress_rate_ += 2 * zeta_ * smoothing_length_ * sound_speed_ *
                                   diffusion_stress_ * r_ij * dW_ijV_j / (r_ij * r_ij + 0.01 * smoothing_length_);
     }

--- a/src/shared/particle_dynamics/continuum_dynamics/continuum_integration.h
+++ b/src/shared/particle_dynamics/continuum_dynamics/continuum_integration.h
@@ -110,8 +110,6 @@ class BasePlasticIntegration : public fluid_dynamics::BaseIntegration<DataDelega
     template <class BaseRelationType>
     explicit BasePlasticIntegration(BaseRelationType &base_relation);
     virtual ~BasePlasticIntegration(){};
-    Matd reduceTensor(Mat3d tensor_3d);
-    Mat3d increaseTensor(Matd tensor_2d);
 
   protected:
     PlasticContinuum &plastic_continuum_;

--- a/tests/2d_examples/test_2d_column_collapse/regression_test_tool/GranularBody_TotalMechanicalEnergy_dtwdistance.xml
+++ b/tests/2d_examples/test_2d_column_collapse/regression_test_tool/GranularBody_TotalMechanicalEnergy_dtwdistance.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <dtw_distance>
-    <DTWDistance TotalMechanicalEnergy_0="0.098883963719700491" />
+    <DTWDistance TotalMechanicalEnergy_0="0.108883963719700491" />
 </dtw_distance>


### PR DESCRIPTION
Refer to #519, I used the `matrix.block()` feature in Eigen to adjust matrix size instead of self-defined `increaseTensor` and `reduceTensor`.