### PR TITLE
[SYCL] Substitute system configuration with direct search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,9 @@ add_subdirectory(modules)
     add_subdirectory(tests)
 endif()]]
 add_subdirectory(tests/2d_examples/test_2d_dambreak)
+add_subdirectory(tests/3d_examples/test_3d_dambreak)
 add_subdirectory(tests/2d_examples/test_2d_dambreak_sycl)
+add_subdirectory(tests/3d_examples/test_3d_dambreak_sycl)
 add_subdirectory(tests/2d_examples/test_2d_sycl_performance)
 
 # ------ Extra scripts to install

--- a/src/for_2D_build/meshes/cell_linked_list.hpp
+++ b/src/for_2D_build/meshes/cell_linked_list.hpp
@@ -44,46 +44,4 @@ void CellLinkedList::searchNeighborsByParticles(
                  });
 }
 //=================================================================================================//
-template <class DynamicsRange, typename GetSearchDepth, typename GetNeighborRelation>
-execution::ExecutionEvent CellLinkedListKernel::searchNeighborsByParticles(
-    DynamicsRange &dynamics_range, NeighborhoodDevice *particle_configuration,
-    GetSearchDepth &get_search_depth, GetNeighborRelation& get_neighbor_relation,
-    execution::ExecutionEvent dependency_event)
-{
-    auto *pos = dynamics_range.getBaseParticles().template getDeviceVariableByName<DeviceVec2d>("Position");
-    auto get_neighbor_relation_kernel = *get_neighbor_relation.device_kernel.get_ptr();
-    const int search_depth = get_search_depth(0);
-    const auto loop_range = dynamics_range.LoopRange();
-    return executionQueue.getQueue()
-        .submit(
-            [&, index_list=index_list_, index_head_list=index_head_list_, list_data_pos=list_data_pos_,
-             list_data_Vol=list_data_Vol_, mesh_lower_bound=mesh_lower_bound_,
-             grid_spacing=grid_spacing_, all_grid_points=all_grid_points_, all_cells=all_cells_](sycl::handler &cgh) {
-                cgh.depends_on(dependency_event.getEventList());
-                cgh.parallel_for(executionQueue.getUniformNdRange(loop_range), [=](sycl::nd_item<1> it) {
-                                     const size_t index_i = it.get_global_id(0);
-                                     if(index_i < loop_range)
-                                     {
-                                         const auto& pos_i = pos[index_i];
-                                         auto &neighborhood = particle_configuration[index_i];
-                                         const auto target_cell_index = CellIndexFromPosition(pos_i, *mesh_lower_bound,
-                                                                                 *grid_spacing, *all_grid_points);
-                                         mesh_for_each(
-                                             VecdMax(DeviceArray2i{0}, DeviceArray2i{target_cell_index - search_depth}),
-                                             VecdMin(*all_cells, DeviceArray2i{target_cell_index + search_depth + 1}),
-                                             [&](int l, int m) {
-                                                 const auto linear_cell_index = transferCellIndexTo1D({l,m}, *all_cells);
-                                                 size_t index_j = index_head_list[linear_cell_index];
-                                                 // Cell list ends when index_j == 0, if index_j is already zero then cell is empty.
-                                                 while(index_j--) {  // abbreviates while(index_j != 0) { index_j -= 1; ... }
-                                                     get_neighbor_relation_kernel(neighborhood, pos_i, index_i, index_j, list_data_pos[index_j],
-                                                                                  list_data_Vol[index_j]);
-                                                     index_j = index_list[index_j];
-                                                 }
-                                             });
-                                     }
-                                 });
-            });
-}
-//=================================================================================================//
 } // namespace SPH

--- a/src/for_2D_build/meshes/mesh_iterators.hpp
+++ b/src/for_2D_build/meshes/mesh_iterators.hpp
@@ -34,6 +34,15 @@ inline Array2i mesh_find_if2d(const CheckOnEach &function)
         }
     return Array2i(upper0, upper1);
 }
+
+//=================================================================================================//
+template <typename LowerArray, typename UpperArray, typename FunctionOnEach>
+void mesh_for_each_array(const LowerArray &lower, const UpperArray &upper, const FunctionOnEach &function)
+{
+    for (int l = lower[0]; l != upper[0]; ++l)
+        for (int m = lower[1]; m != upper[1]; ++m)
+            function(DeviceArray2i{l, m});
+}
 //=================================================================================================//
 template <typename LowerArray, typename UpperArray, typename FunctionOnEach>
 void mesh_for_each(const LowerArray &lower, const UpperArray &upper, const FunctionOnEach &function)

--- a/src/for_3D_build/meshes/cell_linked_list.hpp
+++ b/src/for_3D_build/meshes/cell_linked_list.hpp
@@ -45,46 +45,4 @@ void CellLinkedList::searchNeighborsByParticles(
                  });
 }
 //=================================================================================================//
-template <class DynamicsRange, typename GetSearchDepth, typename GetNeighborRelation>
-execution::ExecutionEvent CellLinkedListKernel::searchNeighborsByParticles(
-    DynamicsRange &dynamics_range, NeighborhoodDevice *particle_configuration,
-    GetSearchDepth &get_search_depth, GetNeighborRelation& get_neighbor_relation,
-    execution::ExecutionEvent dependency_event)
-{
-    auto *pos = dynamics_range.getBaseParticles().template getDeviceVariableByName<DeviceVec3d>("Position");
-    auto get_neighbor_relation_kernel = *get_neighbor_relation.device_kernel.get_ptr();
-    const int search_depth = get_search_depth(0);
-    const auto loop_range = dynamics_range.LoopRange();
-    return executionQueue.getQueue()
-        .submit(
-            [&, index_list=index_list_, index_head_list=index_head_list_, list_data_pos=list_data_pos_,
-             list_data_Vol=list_data_Vol_, mesh_lower_bound=mesh_lower_bound_,
-             grid_spacing=grid_spacing_, all_grid_points=all_grid_points_, all_cells=all_cells_](sycl::handler &cgh) {
-                cgh.depends_on(dependency_event.getEventList());
-                cgh.parallel_for(executionQueue.getUniformNdRange(loop_range), [=](sycl::nd_item<1> it) {
-                                     const size_t index_i = it.get_global_id(0);
-                                     if(index_i < loop_range)
-                                     {
-                                         const auto& pos_i = pos[index_i];
-                                         auto &neighborhood = particle_configuration[index_i];
-                                         const auto target_cell_index = CellIndexFromPosition(pos_i, *mesh_lower_bound,
-                                                                                              *grid_spacing, *all_grid_points);
-                                         mesh_for_each(
-                                             VecdMax(DeviceArray3i{0}, DeviceArray3i{target_cell_index - search_depth}),
-                                             VecdMin(*all_cells, DeviceArray3i{target_cell_index + search_depth + 1}),
-                                             [&](int l, int m, int n) {
-                                                 const auto linear_cell_index = transferCellIndexTo1D({l,m,n}, *all_cells);
-                                                 size_t index_j = index_head_list[linear_cell_index];
-                                                 // Cell list ends when index_j == 0, if index_j is already zero then cell is empty.
-                                                 while(index_j--) {  // abbreviates while(index_j != 0) { index_j -= 1; ... }
-                                                     get_neighbor_relation_kernel(neighborhood, pos_i, index_i, index_j, list_data_pos[index_j],
-                                                                                  list_data_Vol[index_j]);
-                                                     index_j = index_list[index_j];
-                                                 }
-                                             });
-                                     }
-                                 });
-            });
-}
-//=================================================================================================//
 } // namespace SPH

--- a/src/for_3D_build/meshes/mesh_iterators.hpp
+++ b/src/for_3D_build/meshes/mesh_iterators.hpp
@@ -40,6 +40,16 @@ inline Array3i mesh_find_if3d(const CheckOnEach &function)
 }
 //=================================================================================================//
 template <typename LowerArray, typename UpperArray, typename FunctionOnEach>
+void mesh_for_each_array(const LowerArray &lower, const UpperArray &upper,
+                   const FunctionOnEach &function)
+{
+    for (int l = lower[0]; l != upper[0]; ++l)
+        for (int m = lower[1]; m != upper[1]; ++m)
+            for (int n = lower[2]; n != upper[2]; ++n)
+                function(DeviceArray3i{l, m, n});
+}
+//=================================================================================================//
+template <typename LowerArray, typename UpperArray, typename FunctionOnEach>
 void mesh_for_each(const LowerArray &lower, const UpperArray &upper, const FunctionOnEach &function)
 {
     for (int l = lower[0]; l != upper[0]; ++l)

--- a/src/shared/body_relations/base_body_relation.h
+++ b/src/shared/body_relations/base_body_relation.h
@@ -142,6 +142,9 @@ class BaseInnerRelation : public SPHRelation
     void allocateInnerConfigurationDevice();
     void copyInnerConfigurationToDevice();
     void copyInnerConfigurationFromDevice();
+
+    virtual CellLinkedListKernel* getInnerCellLinkedListDevice() const { return nullptr; }
+    virtual NeighborBuilderInnerKernel* getInnerNeighborBuilderDevice() const { return nullptr; }
 };
 
 /**
@@ -190,6 +193,9 @@ class BaseContactRelation : public SPHRelation
             for (int i = 0; i < contact_configuration_.at(k).size(); ++i)
                 contact_configuration_.at(k).at(i) = contact_configuration_device_.at(k).at(i);
     }
+
+    virtual CellLinkedListKernel **getContactCellLinkedListsDevice() const { return nullptr; }
+    virtual NeighborBuilderContactKernel **getContactNeighborBuilderDevice() const { return nullptr; }
 };
 } // namespace SPH
 #endif // BASE_BODY_RELATION_H

--- a/src/shared/body_relations/complex_body_relation.cpp
+++ b/src/shared/body_relations/complex_body_relation.cpp
@@ -67,10 +67,4 @@ void ComplexRelation::updateConfiguration()
     contact_relation_.updateConfiguration();
 }
 //=================================================================================================//
-execution::ExecutionEvent ComplexRelation::updateDeviceConfiguration()
-{
-    return std::move(inner_relation_.updateDeviceConfiguration()
-                         .add(contact_relation_.updateDeviceConfiguration()));
-}
-//=================================================================================================//
 } // namespace SPH

--- a/src/shared/body_relations/complex_body_relation.h
+++ b/src/shared/body_relations/complex_body_relation.h
@@ -64,7 +64,6 @@ class ComplexRelation : public SPHRelation
 
     virtual void resizeConfiguration() override;
     virtual void updateConfiguration() override;
-    virtual execution::ExecutionEvent updateDeviceConfiguration() override;
 };
 } // namespace SPH
 #endif // COMPLEX_BODY_RELATION_H

--- a/src/shared/body_relations/contact_body_relation.cpp
+++ b/src/shared/body_relations/contact_body_relation.cpp
@@ -32,22 +32,11 @@ void ContactRelation::updateConfiguration()
     }
 }
 //=================================================================================================//
-execution::ExecutionEvent ContactRelation::updateDeviceConfiguration()
-{
-    auto reset_event = resetNeighborhoodDeviceCurrentSize();
-    execution::ExecutionEvent update_events;
-    for (size_t k = 0; k != contact_bodies_.size(); ++k)
-    {
-        update_events.add(target_cell_linked_lists_[k]->device_kernel.get_ptr()->searchNeighborsByParticles(
-            sph_body_, contact_configuration_device_[k].data(),
-            *get_search_depths_[k], *get_contact_neighbors_[k], reset_event));
-    }
-    return std::move(update_events);
-}
 CellLinkedListKernel **ContactRelation::getContactCellLinkedListsDevice() const
 {
     return contact_cell_linked_lists_device_;
 }
+//=================================================================================================//
 NeighborBuilderContactKernel **ContactRelation::getContactNeighborBuilderDevice() const
 {
     return contact_neighbor_builder_device_;

--- a/src/shared/body_relations/contact_body_relation.h
+++ b/src/shared/body_relations/contact_body_relation.h
@@ -84,7 +84,6 @@ class ContactRelation : public ContactRelationCrossResolution
         freeDeviceData(contact_neighbor_builder_device_);
     };
     virtual void updateConfiguration() override;
-    virtual execution::ExecutionEvent updateDeviceConfiguration() override;
 
     CellLinkedListKernel **getContactCellLinkedListsDevice() const override;
     NeighborBuilderContactKernel **getContactNeighborBuilderDevice() const override;

--- a/src/shared/body_relations/contact_body_relation.h
+++ b/src/shared/body_relations/contact_body_relation.h
@@ -79,12 +79,21 @@ class ContactRelation : public ContactRelationCrossResolution
 
   public:
     ContactRelation(SPHBody &sph_body, RealBodyVector contact_bodies);
-    virtual ~ContactRelation(){};
+    virtual ~ContactRelation(){
+        freeDeviceData(contact_cell_linked_lists_device_);
+        freeDeviceData(contact_neighbor_builder_device_);
+    };
     virtual void updateConfiguration() override;
     virtual execution::ExecutionEvent updateDeviceConfiguration() override;
 
+    CellLinkedListKernel **getContactCellLinkedListsDevice() const override;
+    NeighborBuilderContactKernel **getContactNeighborBuilderDevice() const override;
+
   protected:
     StdVec<NeighborBuilderContact *> get_contact_neighbors_;
+
+    CellLinkedListKernel **contact_cell_linked_lists_device_;
+    NeighborBuilderContactKernel **contact_neighbor_builder_device_;
 };
 
 /**

--- a/src/shared/body_relations/inner_body_relation.cpp
+++ b/src/shared/body_relations/inner_body_relation.cpp
@@ -20,17 +20,11 @@ void InnerRelation::updateConfiguration()
         get_single_search_depth_, get_inner_neighbor_);
 }
 //=================================================================================================//
-execution::ExecutionEvent InnerRelation::updateDeviceConfiguration()
-{
-    auto reset_event = resetNeighborhoodDeviceCurrentSize();
-    return cell_linked_list_.device_kernel.get_ptr()->searchNeighborsByParticles(
-        sph_body_, inner_configuration_device_->data(),
-        get_single_search_depth_, get_inner_neighbor_, std::move(reset_event));
-}
 CellLinkedListKernel *InnerRelation::getInnerCellLinkedListDevice() const
 {
     return inner_cell_linked_list_device_;
 }
+//=================================================================================================//
 NeighborBuilderInnerKernel *InnerRelation::getInnerNeighborBuilderDevice() const
 {
     return inner_neighbor_builder_device_;

--- a/src/shared/body_relations/inner_body_relation.cpp
+++ b/src/shared/body_relations/inner_body_relation.cpp
@@ -8,7 +8,9 @@ namespace SPH
 //=================================================================================================//
 InnerRelation::InnerRelation(RealBody &real_body)
     : BaseInnerRelation(real_body), get_inner_neighbor_(real_body),
-      cell_linked_list_(DynamicCast<CellLinkedList>(this, real_body.getCellLinkedList())) {}
+      cell_linked_list_(DynamicCast<CellLinkedList>(this, real_body.getCellLinkedList())),
+      inner_cell_linked_list_device_(&real_body.getCellLinkedList(execution::par_sycl)),
+      inner_neighbor_builder_device_(get_inner_neighbor_.device_kernel.get_ptr()) {}
 //=================================================================================================//
 void InnerRelation::updateConfiguration()
 {
@@ -24,6 +26,14 @@ execution::ExecutionEvent InnerRelation::updateDeviceConfiguration()
     return cell_linked_list_.device_kernel.get_ptr()->searchNeighborsByParticles(
         sph_body_, inner_configuration_device_->data(),
         get_single_search_depth_, get_inner_neighbor_, std::move(reset_event));
+}
+CellLinkedListKernel *InnerRelation::getInnerCellLinkedListDevice() const
+{
+    return inner_cell_linked_list_device_;
+}
+NeighborBuilderInnerKernel *InnerRelation::getInnerNeighborBuilderDevice() const
+{
+    return inner_neighbor_builder_device_;
 }
 //=================================================================================================//
 AdaptiveInnerRelation::

--- a/src/shared/body_relations/inner_body_relation.h
+++ b/src/shared/body_relations/inner_body_relation.h
@@ -52,7 +52,6 @@ class InnerRelation : public BaseInnerRelation
     virtual ~InnerRelation(){};
 
     virtual void updateConfiguration() override;
-    virtual execution::ExecutionEvent updateDeviceConfiguration() override;
 
     CellLinkedListKernel *getInnerCellLinkedListDevice() const override;
     NeighborBuilderInnerKernel *getInnerNeighborBuilderDevice() const override;

--- a/src/shared/body_relations/inner_body_relation.h
+++ b/src/shared/body_relations/inner_body_relation.h
@@ -44,12 +44,18 @@ class InnerRelation : public BaseInnerRelation
     NeighborBuilderInner get_inner_neighbor_;
     CellLinkedList &cell_linked_list_;
 
+    CellLinkedListKernel* inner_cell_linked_list_device_;
+    NeighborBuilderInnerKernel* inner_neighbor_builder_device_;
+
   public:
     explicit InnerRelation(RealBody &real_body);
     virtual ~InnerRelation(){};
 
     virtual void updateConfiguration() override;
     virtual execution::ExecutionEvent updateDeviceConfiguration() override;
+
+    CellLinkedListKernel *getInnerCellLinkedListDevice() const override;
+    NeighborBuilderInnerKernel *getInnerNeighborBuilderDevice() const override;
 };
 
 /**

--- a/src/shared/meshes/cell_linked_list.h
+++ b/src/shared/meshes/cell_linked_list.h
@@ -94,11 +94,6 @@ class CellLinkedListKernel {
     execution::ExecutionEvent clearCellLists();
     execution::ExecutionEvent UpdateCellLists(BaseParticles &base_particles);
 
-    template <class DynamicsRange, typename GetSearchDepth, typename GetNeighborRelation>
-    execution::ExecutionEvent searchNeighborsByParticles(DynamicsRange &dynamics_range, NeighborhoodDevice *particle_configuration,
-                                    GetSearchDepth &get_search_depth, GetNeighborRelation &get_neighbor_relation,
-                                                         execution::ExecutionEvent dependency_event = {});
-
     template <typename FunctionOnEach>
     void forEachNeighbor(size_t index_i, const DeviceVecd *self_position,
                          const FunctionOnEach &function) const

--- a/src/shared/meshes/cell_linked_list.h
+++ b/src/shared/meshes/cell_linked_list.h
@@ -34,6 +34,7 @@
 
 #include "base_mesh.h"
 #include "neighborhood.h"
+#include "mesh_iterators.hpp"
 
 namespace SPH
 {
@@ -97,6 +98,35 @@ class CellLinkedListKernel {
     execution::ExecutionEvent searchNeighborsByParticles(DynamicsRange &dynamics_range, NeighborhoodDevice *particle_configuration,
                                     GetSearchDepth &get_search_depth, GetNeighborRelation &get_neighbor_relation,
                                                          execution::ExecutionEvent dependency_event = {});
+
+    template <typename FunctionOnEach>
+    void forEachNeighbor(size_t index_i, const DeviceVecd *self_position,
+                         const FunctionOnEach &function) const
+    {
+        const DeviceVecd pos_i = self_position[index_i];
+        const size_t search_depth = 1;
+        const auto target_cell_index = CellIndexFromPosition(pos_i, *mesh_lower_bound_,
+                                                             *grid_spacing_, *all_grid_points_);
+        mesh_for_each_array(
+            VecdMax(DeviceArrayi{0}, DeviceArrayi{target_cell_index - search_depth}),
+            VecdMin(*all_cells_, DeviceArrayi{target_cell_index + search_depth + 1}),
+            [&](DeviceArrayi&& cell_index) {
+                const auto linear_cell_index = transferCellIndexTo1D(cell_index, *all_cells_);
+                size_t index_j = index_head_list_[linear_cell_index];
+                // Cell list ends when index_j == 0, if index_j is already zero then cell is empty.
+                while(index_j--) {  // abbreviates while(index_j != 0) { index_j -= 1; ... }
+                    function(pos_i, index_j, list_data_pos_[index_j], list_data_Vol_[index_j]);
+                    index_j = index_list_[index_j];
+                }
+            });
+    }
+
+    template <typename FunctionOnEach>
+    void forEachInnerNeighbor(size_t index_i, const FunctionOnEach &function) const
+    {
+        forEachNeighbor(index_i, list_data_pos_, function);
+    }
+
 
     size_t* computingSequence(BaseParticles &baseParticles);
 

--- a/src/shared/meshes/mesh_iterators.h
+++ b/src/shared/meshes/mesh_iterators.h
@@ -92,6 +92,8 @@ inline bool mesh_any_of3d(const CheckOnEach &function)
 
 template <typename LowerArray, typename UpperArray, typename FunctionOnEach>
 void mesh_for_each(const LowerArray &lower, const UpperArray &upper, const FunctionOnEach &function);
+template <typename LowerArray, typename UpperArray, typename  FunctionOnEach>
+SYCL_EXTERNAL void mesh_for_each_array(const LowerArray &lower, const UpperArray &upper, const FunctionOnEach &function);
 template <typename FunctionOnEach>
 Arrayi mesh_find_if(const Arrayi &lower, const Arrayi &upper, const FunctionOnEach &function);
 template <typename FunctionOnEach>

--- a/src/shared/particle_dynamics/base_particle_dynamics.h
+++ b/src/shared/particle_dynamics/base_particle_dynamics.h
@@ -130,14 +130,12 @@ class DataDelegateInner : public BaseDataDelegateType
   public:
     explicit DataDelegateInner(BaseInnerRelation &inner_relation)
         : BaseDataDelegateType(inner_relation.getSPHBody()),
-          inner_configuration_(inner_relation.inner_configuration_),
-          inner_configuration_device_(inner_relation.inner_configuration_device_) {};
+          inner_configuration_(inner_relation.inner_configuration_) {};
     virtual ~DataDelegateInner(){};
 
   protected:
     /** inner configuration of the designated body */
     ParticleConfiguration &inner_configuration_;
-    SharedPtr<StdSharedVec<NeighborhoodDevice>> inner_configuration_device_;
 };
 
 /**
@@ -159,7 +157,6 @@ class DataDelegateContact : public BaseDataDelegateType
     StdVec<ContactParticlesType *> contact_particles_;
     /** Configurations for particle interaction between bodies. */
     StdVec<ParticleConfiguration *> contact_configuration_;
-    SharedPtr<StdSharedVec<NeighborhoodDevice*>> contact_configuration_device_;
 };
 
 /**

--- a/src/shared/particle_dynamics/base_particle_dynamics.h
+++ b/src/shared/particle_dynamics/base_particle_dynamics.h
@@ -191,7 +191,9 @@ class BaseInteractionComplex : public InteractionInnerType, public ContactDataTy
     BaseInteractionComplex(BaseContactRelation &contact_relation,
                            BaseInnerRelation &inner_relation, Args &&...args)
         : InteractionInnerType(inner_relation, std::forward<Args>(args)...),
-          ContactDataType(contact_relation){};
+          ContactDataType(contact_relation),
+          contact_relation_(contact_relation),
+          inner_relation_(inner_relation){};
     template <typename... Args>
     BaseInteractionComplex(ComplexRelation &complex_relation, Args &&...args)
         : BaseInteractionComplex(complex_relation.getContactRelation(),
@@ -204,6 +206,10 @@ class BaseInteractionComplex : public InteractionInnerType, public ContactDataTy
         this->addExtraContactRelation(this->sph_body_, extra_contact_relation);
     };
     virtual ~BaseInteractionComplex(){};
+
+  protected:
+    const BaseContactRelation& contact_relation_;
+    const BaseInnerRelation& inner_relation_;
 };
 } // namespace SPH
 #endif // BASE_PARTICLE_DYNAMICS_H

--- a/src/shared/particle_dynamics/base_particle_dynamics.hpp
+++ b/src/shared/particle_dynamics/base_particle_dynamics.hpp
@@ -21,16 +21,11 @@ DataDelegateContact<ParticlesType, ContactParticlesType, BaseDataDelegateType>::
     : BaseDataDelegateType(body_contact_relation.getSPHBody())
 {
     RealBodyVector contact_sph_bodies = body_contact_relation.contact_bodies_;
-    if(body_contact_relation.isDeviceConfigurationAllocated())
-        contact_configuration_device_ = makeSharedDevice<StdSharedVec<NeighborhoodDevice*>>(contact_sph_bodies.size(),
-                                                                                             execution::executionQueue.getQueue());
     for (size_t i = 0; i != contact_sph_bodies.size(); ++i)
     {
         contact_bodies_.push_back(contact_sph_bodies[i]);
         contact_particles_.push_back(DynamicCast<ContactParticlesType>(this, &contact_sph_bodies[i]->getBaseParticles()));
         contact_configuration_.push_back(&body_contact_relation.contact_configuration_[i]);
-        if(body_contact_relation.isDeviceConfigurationAllocated())
-            contact_configuration_device_->at(i) = body_contact_relation.contact_configuration_device_.at(i).data();
     }
 }
 //=================================================================================================//
@@ -52,26 +47,6 @@ void DataDelegateContact<ParticlesType, ContactParticlesType, BaseDataDelegateTy
         contact_bodies_.push_back(extra_body);
         contact_particles_.push_back(DynamicCast<ContactParticlesType>(this, &extra_body->getBaseParticles()));
     }
-
-    SharedPtr<StdSharedVec<NeighborhoodDevice*>> new_contact_configuration_device;
-    if(contact_configuration_device_)
-    {
-        new_contact_configuration_device = makeSharedDevice<StdSharedVec<NeighborhoodDevice*>>(
-                contact_configuration_device_->size() + extra_contact_relation.contact_bodies_.size(),
-                execution::executionQueue.getQueue());
-        std::copy(contact_configuration_device_->begin(), contact_configuration_device_->end(),
-                  new_contact_configuration_device->begin());
-    }
-    for (size_t i = 0; i != extra_contact_relation.contact_bodies_.size(); ++i)
-    {
-        contact_configuration_.push_back(&extra_contact_relation.contact_configuration_[i]);
-
-        if(contact_configuration_device_)
-            new_contact_configuration_device->at(contact_configuration_device_->size() + i) =
-                extra_contact_relation.contact_configuration_device_.at(i).data();
-    }
-    if(contact_configuration_device_)
-        contact_configuration_device_ = std::move(new_contact_configuration_device);
 }
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/particle_dynamics/execution_unit/device_implementation.hpp
+++ b/src/shared/particle_dynamics/execution_unit/device_implementation.hpp
@@ -15,7 +15,7 @@ class DeviceImplementation
 
     template <class... Args>
     explicit DeviceImplementation(Args &&...device_args)
-        : device_(std::make_shared<Device>(std::forward<Args>(device_args)...)) {}
+        : device_(makeSharedDevice<Device>(std::forward<Args>(device_args)...)) {}
 
     using KernelType = Device;
 

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.h
@@ -76,46 +76,15 @@ class InteractionWithWall : public BaseIntegrationType, public FluidWallData
 class BaseDensitySummationComplexKernel {
   public:
     BaseDensitySummationComplexKernel(DeviceReal *contactInvRho0, DeviceReal **contactMass,
-                                      NeighborhoodDevice **contactConfiguration,
-                                      size_t contactConfigurationSize) :
-                                      contact_inv_rho0_(contactInvRho0),
-                                      contact_mass_(contactMass),
-                                      contact_configuration_(contactConfiguration),
-                                      contact_configuration_size_(contactConfigurationSize) {}
-
-    BaseDensitySummationComplexKernel(DeviceReal *contactInvRho0, DeviceReal **contactMass,
                                       const BaseContactRelation& contact_relation) :
-                                      contact_inv_rho0_(contactInvRho0),
-                                      contact_mass_(contactMass),
+                                      contact_inv_rho0_(contactInvRho0), contact_mass_(contactMass),
                                       particles_position_(contact_relation.base_particles_.getDeviceVariableByName<DeviceVecd>("Position")),
                                       contact_cell_linked_lists_(contact_relation.getContactCellLinkedListsDevice()),
                                       contact_neighbor_builders_(contact_relation.getContactNeighborBuilderDevice()),
                                       contact_bodies_size_(contact_relation.contact_bodies_.size()) {}
 
-    template<class RealType, class ContactMassFunc, class ContactConfigFunc>
-    static RealType ContactSummation(size_t index_i, std::size_t contact_configuration_size,
-                                  const RealType* contact_inv_rho0, ContactMassFunc&& contactMassFunc,
-                                  ContactConfigFunc&& contactConfigFunc)
-    {
-        RealType sigma(0.0);
-        for (size_t k = 0; k < contact_configuration_size; ++k)
-        {
-            const RealType* contact_mass_k = contactMassFunc(k);
-            const auto& contact_inv_rho0_k = contact_inv_rho0[k];
-            const auto& contact_neighborhood = contactConfigFunc(k, index_i);
-            for (size_t n = 0; n != contact_neighborhood.current_size(); ++n)
-                sigma += contact_neighborhood.W_ij_[n] * contact_inv_rho0_k * contact_mass_k[contact_neighborhood.j_[n]];
-            }
-            return sigma;
-    }
-
     DeviceReal ContactSummation(size_t index_i)
     {
-#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
-        return BaseDensitySummationComplexKernel::ContactSummation(index_i, contact_configuration_size_,
-                contact_inv_rho0_, [&](auto k){ return contact_mass_[k]; },
-                [&](auto k, auto index_i) -> NeighborhoodDevice& { return contact_configuration_[k][index_i]; });
-#else
         DeviceReal sigma(0.0);
         for (size_t k = 0; k < contact_bodies_size_; ++k)
         {
@@ -132,14 +101,10 @@ class BaseDensitySummationComplexKernel {
                                                            });
         }
         return sigma;
-#endif
     };
 
   private:
     DeviceReal *contact_inv_rho0_, **contact_mass_;
-    NeighborhoodDevice** contact_configuration_;
-    std::size_t contact_configuration_size_;
-
     DeviceVecd *particles_position_;
     CellLinkedListKernel **contact_cell_linked_lists_;
     NeighborBuilderContactKernel **contact_neighbor_builders_;
@@ -286,15 +251,6 @@ class TransportVelocityCorrectionComplexAdaptive
 template <class BaseIntegration1stHalfType>
 class BaseIntegration1stHalfWithWallKernel : public BaseIntegration1stHalfType {
   public:
-#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
-    template<class ...BaseArgs>
-    BaseIntegration1stHalfWithWallKernel(StdSharedVec<NeighborhoodDevice*> &contact_configuration,
-                                         DeviceVecd** wall_acc_ave, BaseArgs&& ...args) :
-                                         BaseIntegration1stHalfType(std::forward<BaseArgs>(args)...),
-                                         contact_configuration_(contact_configuration),
-                                         wall_acc_ave_(wall_acc_ave) {}
-#endif
-
     template<class ...BaseArgs>
     BaseIntegration1stHalfWithWallKernel(const BaseContactRelation& contact_relation,
                                          DeviceVecd** wall_acc_ave, BaseArgs&& ...args)
@@ -305,46 +261,9 @@ class BaseIntegration1stHalfWithWallKernel : public BaseIntegration1stHalfType {
           contact_neighbor_builders_(contact_relation.getContactNeighborBuilderDevice()),
           particles_position_(contact_relation.base_particles_.getDeviceVariableByName<DeviceVecd>("Position")) {}
 
-    template<class RealType, class VecType, class RiemannSolver, class WallNeighborhoodFunc,
-             class NonConservativeAccFunc, class WallAccAveFunc>
-    static void interaction(size_t index_i, Real dt, RealType *p, RealType *rho, RealType *drho_dt, VecType *acc,
-                            RiemannSolver& riemann_solver, std::size_t contact_configuration_size,
-                            NonConservativeAccFunc&& computeNonConservativeAcceleration,
-                            WallAccAveFunc&& getWallAccAve, WallNeighborhoodFunc&& getWallNeighborhood) {
-        const VecType acc_prior_i = computeNonConservativeAcceleration(index_i);
-        VecType acceleration = VecdZero<VecType>();
-        RealType rho_dissipation{0}, min_external_acc{0};
-        for (size_t k = 0; k < contact_configuration_size; ++k)
-        {
-            const VecType* acc_ave_k = getWallAccAve(k);
-            const auto &wall_neighborhood = getWallNeighborhood(k, index_i);
-            for (size_t n = 0; n < wall_neighborhood.current_size(); ++n)
-            {
-                const auto& index_j = wall_neighborhood.j_[n];
-                const auto& e_ij = wall_neighborhood.e_ij_[n];
-                const auto& dW_ijV_j = wall_neighborhood.dW_ijV_j_[n];
-                const auto& r_ij = wall_neighborhood.r_ij_[n];
-
-                const RealType face_wall_external_acceleration = VecdDot(VecType(acc_prior_i - acc_ave_k[index_j]), VecType(-e_ij));
-                const auto p_in_wall = p[index_i] + rho[index_i] * r_ij * SMAX(min_external_acc, face_wall_external_acceleration);
-                acceleration -= (p[index_i] + p_in_wall) * dW_ijV_j * e_ij;
-                rho_dissipation += riemann_solver.DissipativeUJump(p[index_i] - p_in_wall) * dW_ijV_j;
-            }
-        }
-        acc[index_i] += acceleration / rho[index_i];
-        drho_dt[index_i] += rho_dissipation * rho[index_i];
-    }
-
     void interaction(size_t index_i, Real dt = 0.0) {
         BaseIntegration1stHalfType::interaction(index_i, dt);
 
-#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
-        interaction(index_i, dt, this->p_, this->rho_, this->drho_dt_, this->acc_, this->riemann_solver_,
-                    contact_configuration_.size(), [&](auto index_i){ return this->acc_prior_[index_i]; },
-                    [&](auto k){ return this->wall_acc_ave_[k]; },
-                    [&](auto k, auto index_i) -> const NeighborhoodDevice&
-                        { return this->contact_configuration_[k][index_i]; });
-#else
         const DeviceVecd acc_prior_i = this->acc_prior_[index_i];
         DeviceVecd acceleration = VecdZero<DeviceVecd>();
         DeviceReal rho_dissipation{0}, min_external_acc{0};
@@ -372,14 +291,9 @@ class BaseIntegration1stHalfWithWallKernel : public BaseIntegration1stHalfType {
         }
         this->acc_[index_i] += acceleration / this->rho_[index_i];
         this->drho_dt_[index_i] += rho_dissipation * this->rho_[index_i];
-#endif
     }
   private:
-#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
-    StdSharedVec<NeighborhoodDevice*> &contact_configuration_;
-#endif
     DeviceVecd** wall_acc_ave_;
-
     size_t contact_bodies_size_;
     CellLinkedListKernel **contact_cell_linked_lists_;
     NeighborBuilderContactKernel **contact_neighbor_builders_;
@@ -399,34 +313,18 @@ class BaseIntegration1stHalfWithWall : public InteractionWithWall<BaseIntegratio
     template <typename... Args>
     BaseIntegration1stHalfWithWall(BaseContactRelation& contact_relation, BaseInnerRelation& inner_relation, Args &&...args)
         : InteractionWithWall<BaseIntegration1stHalfType>(contact_relation, inner_relation, std::forward<Args>(args)...),
-#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
-          device_kernel(*this->contact_configuration_device_, this->wall_acc_ave_device_.data(),
-                        BaseIntegration1stHalfType::particles_,
-                        BaseIntegration1stHalfType::inner_configuration_device_ ?
-                            BaseIntegration1stHalfType::inner_configuration_device_->data() : nullptr,
-                        this->riemann_solver_) {}
-#else
           device_kernel(contact_relation, this->wall_acc_ave_device_.data(),
                         inner_relation, BaseIntegration1stHalfType::particles_,
                         this->riemann_solver_) {}
-#endif
 
     template <typename... Args>
     BaseIntegration1stHalfWithWall(ComplexRelation& complex_relation, Args &&...args)
         : InteractionWithWall<BaseIntegration1stHalfType>(complex_relation, std::forward<Args>(args)...),
-#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
-          device_kernel(*this->contact_configuration_device_, this->wall_acc_ave_device_.data(),
-                        BaseIntegration1stHalfType::particles_,
-                        BaseIntegration1stHalfType::inner_configuration_device_ ?
-                            BaseIntegration1stHalfType::inner_configuration_device_->data() : nullptr,
-                        this->riemann_solver_) {}
-#else
           device_kernel(complex_relation.getContactRelation(),
                         this->wall_acc_ave_device_.data(),
                         complex_relation.getInnerRelation(),
                         BaseIntegration1stHalfType::particles_,
                         this->riemann_solver_) {}
-#endif
 
     virtual ~BaseIntegration1stHalfWithWall(){};
 
@@ -495,54 +393,9 @@ class BaseIntegration2ndHalfWithWallKernel : public BaseIntegration2ndHalfType {
           contact_neighbor_builders_(contact_relation.getContactNeighborBuilderDevice()),
           particles_position_(contact_relation.base_particles_.getDeviceVariableByName<DeviceVecd>("Position")) {}
 
-#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
-    template<class ...BaseArgs>
-    BaseIntegration2ndHalfWithWallKernel(StdSharedVec<NeighborhoodDevice*> &contact_configuration,
-                                         DeviceVecd** wall_vel_ave, DeviceVecd** wall_n, BaseArgs&& ...args) :
-            BaseIntegration2ndHalfType(std::forward<BaseArgs>(args)...),
-            contact_configuration_(contact_configuration),
-            wall_vel_ave_(wall_vel_ave), wall_n_(wall_n) {}
-#endif
-
-    template<class RealType, class VecType, class RiemannSolver, class WallNeighborhoodFunc,
-             class WallVelAveFunc, class WallNormalFunc>
-    static void interaction(size_t index_i, Real dt, RealType *rho, RealType *drho_dt, VecType* vel, VecType *acc,
-                            RiemannSolver& riemann_solver, std::size_t contact_configuration_size,
-                            WallVelAveFunc&& getWallVelAve, WallNormalFunc&& getWallNormal,
-                            WallNeighborhoodFunc&& getWallNeighborhood) {
-        RealType density_change_rate{0};
-        auto p_dissipation = VecdZero<VecType>();
-        for (size_t k = 0; k < contact_configuration_size; ++k)
-        {
-            VecType *vel_ave_k = getWallVelAve(k);
-            VecType *n_k = getWallNormal(k);
-            const auto &wall_neighborhood = getWallNeighborhood(k, index_i);
-            for (size_t n = 0; n != wall_neighborhood.current_size(); ++n)
-            {
-                const auto &index_j = wall_neighborhood.j_[n];
-                const auto &e_ij = wall_neighborhood.e_ij_[n];
-                const auto &dW_ijV_j = wall_neighborhood.dW_ijV_j_[n];
-
-                const VecType vel_in_wall = static_cast<RealType>(2.0) * vel_ave_k[index_j] - vel[index_i];
-                density_change_rate += VecdDot(VecType(vel[index_i] - vel_in_wall), e_ij) * dW_ijV_j;
-                const RealType u_jump = static_cast<RealType>(2.0) * VecdDot(VecType(vel[index_i] - vel_ave_k[index_j]), n_k[index_j]);
-                p_dissipation += static_cast<RealType>(riemann_solver.DissipativePJump(u_jump)) * dW_ijV_j * n_k[index_j];
-            }
-        }
-        drho_dt[index_i] += density_change_rate * rho[index_i];
-        acc[index_i] += p_dissipation / rho[index_i];
-    }
-
     void interaction(size_t index_i, Real dt = 0.0) {
         BaseIntegration2ndHalfType::interaction(index_i, dt);
 
-#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
-        interaction(index_i, dt, this->rho_, this->drho_dt_, this->vel_, this->acc_, this->riemann_solver_,
-                    contact_configuration_.size(), [&](auto k){ return this->wall_vel_ave_[k]; },
-                    [&](auto k){ return this->wall_n_[k]; },
-                    [&](auto k, auto index_i) -> const NeighborhoodDevice&
-                        { return this->contact_configuration_[k][index_i]; });
-#else
         DeviceReal density_change_rate{0};
         auto p_dissipation = VecdZero<DeviceVecd>();
         const DeviceVecd vel_i = this->vel_[index_i];
@@ -569,14 +422,10 @@ class BaseIntegration2ndHalfWithWallKernel : public BaseIntegration2ndHalfType {
         }
         this->drho_dt_[index_i] += density_change_rate * this->rho_[index_i];
         this->acc_[index_i] += p_dissipation / this->rho_[index_i];
-#endif
     }
-  private:
-#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
-    StdSharedVec<NeighborhoodDevice*> &contact_configuration_;
-#endif
-    DeviceVecd **wall_vel_ave_, **wall_n_;
 
+  private:
+    DeviceVecd **wall_vel_ave_, **wall_n_;
     size_t contact_bodies_size_;
     CellLinkedListKernel **contact_cell_linked_lists_;
     NeighborBuilderContactKernel **contact_neighbor_builders_;
@@ -598,34 +447,18 @@ class BaseIntegration2ndHalfWithWall : public InteractionWithWall<BaseIntegratio
     template <typename... Args>
     BaseIntegration2ndHalfWithWall(BaseContactRelation& contact_relation, BaseInnerRelation& inner_relation, Args &&...args)
         : InteractionWithWall<BaseIntegration2ndHalfType>(contact_relation, inner_relation, std::forward<Args>(args)...),
-#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
-          device_kernel(*this->contact_configuration_device_, this->wall_vel_ave_device_.data(),
-                        this->wall_n_device_.data(), BaseIntegration2ndHalfType::particles_,
-                        BaseIntegration2ndHalfType::inner_configuration_device_ ?
-                            BaseIntegration2ndHalfType::inner_configuration_device_->data() : nullptr,
-                        this->riemann_solver_) {}
-#else
           device_kernel(contact_relation, this->wall_vel_ave_device_.data(),
                         this->wall_n_device_.data(), inner_relation,
                         BaseIntegration2ndHalfType::particles_, this->riemann_solver_) {}
-#endif
 
           template <typename... Args>
           BaseIntegration2ndHalfWithWall(ComplexRelation& complex_relation, Args &&...args)
               : InteractionWithWall<BaseIntegration2ndHalfType>(complex_relation, std::forward<Args>(args)...),
-#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
-                device_kernel(*this->contact_configuration_device_, this->wall_vel_ave_device_.data(),
-                              this->wall_n_device_.data(), BaseIntegration2ndHalfType::particles_,
-                              BaseIntegration2ndHalfType::inner_configuration_device_ ?
-                                                                                      BaseIntegration2ndHalfType::inner_configuration_device_->data() : nullptr,
-                              this->riemann_solver_) {}
-#else
                 device_kernel(complex_relation.getContactRelation(), this->wall_vel_ave_device_.data(),
                               this->wall_n_device_.data(),
                               complex_relation.getInnerRelation(),
                               BaseIntegration2ndHalfType::particles_,
                               this->riemann_solver_) {}
-#endif
 
     virtual ~BaseIntegration2ndHalfWithWall(){};
 

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_complex.hpp
@@ -178,9 +178,13 @@ BaseDensitySummationComplex<DensitySummationInnerType>::
       contact_inv_rho0_device_(this->contact_particles_.size(), executionQueue.getQueue()),
       contact_mass_(this->contact_particles_.size()),
       contact_mass_device_(this->contact_particles_.size(), executionQueue.getQueue()),
+#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
       device_kernel(contact_inv_rho0_device_.data(), contact_mass_device_.data(),
-                   this->contact_configuration_device_ ? this->contact_configuration_device_->data() : nullptr,
-                   this->contact_configuration_device_ ? this->contact_configuration_device_->size() : 0)
+                    this->contact_configuration_device_ ? this->contact_configuration_device_->data() : nullptr,
+                    this->contact_configuration_device_ ? this->contact_configuration_device_->size() : 0)
+#else
+      device_kernel(contact_inv_rho0_device_.data(), contact_mass_device_.data(), this->contact_relation_)
+#endif
 {
     for (size_t k = 0; k != this->contact_particles_.size(); ++k)
     {

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.cpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.cpp
@@ -28,11 +28,7 @@ void BaseDensitySummationInner::update(size_t index_i, Real dt)
 DensitySummationInner::DensitySummationInner(BaseInnerRelation &inner_relation)
     : BaseDensitySummationInner(inner_relation),
       W0_(sph_body_.sph_adaptation_->getKernel()->W0(ZeroVecd)),
-#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
-      device_kernel(W0_, inner_configuration_device_ ? inner_configuration_device_->data() : nullptr, particles_, rho0_, inv_sigma0_) {}
-#else
       device_kernel(W0_, inner_relation, particles_, rho0_, inv_sigma0_) {}
-#endif
 //=================================================================================================//
 DensitySummationInnerAdaptive::
     DensitySummationInnerAdaptive(BaseInnerRelation &inner_relation)

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.cpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.cpp
@@ -28,7 +28,11 @@ void BaseDensitySummationInner::update(size_t index_i, Real dt)
 DensitySummationInner::DensitySummationInner(BaseInnerRelation &inner_relation)
     : BaseDensitySummationInner(inner_relation),
       W0_(sph_body_.sph_adaptation_->getKernel()->W0(ZeroVecd)),
+#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
       device_kernel(W0_, inner_configuration_device_ ? inner_configuration_device_->data() : nullptr, particles_, rho0_, inv_sigma0_) {}
+#else
+      device_kernel(W0_, inner_relation, particles_, rho0_, inv_sigma0_) {}
+#endif
 //=================================================================================================//
 DensitySummationInnerAdaptive::
     DensitySummationInnerAdaptive(BaseInnerRelation &inner_relation)

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.h
@@ -65,6 +65,14 @@ class FluidInitialCondition : public LocalDynamics, public FluidDataSimple
 
 class BaseDensitySummationInnerKernel {
   public:
+    BaseDensitySummationInnerKernel(const BaseInnerRelation& inner_relation, BaseParticles* particles,
+                                    DeviceReal rho0,DeviceReal invSigma0)
+        : rho_(particles->getDeviceVariableByName<DeviceReal>("Density")),
+          rho_sum_(particles->registerDeviceVariable<DeviceReal>("DensitySummation", particles->total_real_particles_)),
+          mass_(particles->getDeviceVariableByName<DeviceReal>("Mass")), rho0_(rho0), inv_sigma0_(invSigma0),
+          cell_linked_list_(inner_relation.getInnerCellLinkedListDevice()),
+          inner_neighbor_builder_(inner_relation.getInnerNeighborBuilderDevice()) {}
+
     BaseDensitySummationInnerKernel(NeighborhoodDevice* inner_configuration, BaseParticles* particles,
                                     DeviceReal rho0, DeviceReal invSigma0) :
         inner_configuration_(inner_configuration), rho_(particles->getDeviceVariableByName<DeviceReal>("Density")),
@@ -74,6 +82,8 @@ class BaseDensitySummationInnerKernel {
     NeighborhoodDevice* inner_configuration_;
     DeviceReal *rho_, *rho_sum_, *mass_;
     DeviceReal rho0_, inv_sigma0_;
+    CellLinkedListKernel* cell_linked_list_;
+    NeighborBuilderInnerKernel *inner_neighbor_builder_;
 };
 
 /**
@@ -95,7 +105,7 @@ class BaseDensitySummationInner : public LocalDynamics, public FluidDataInner
 class DensitySummationInnerKernel : public BaseDensitySummationInnerKernel {
   public:
     template<class ...Args>
-    DensitySummationInnerKernel(DeviceReal W0, Args ...baseArgs) :
+    DensitySummationInnerKernel(DeviceReal W0, Args &&...baseArgs) :
         BaseDensitySummationInnerKernel(std::forward<Args>(baseArgs)...),  W0_(W0) {}
 
     template<class RealType, class NeighborhoodType>
@@ -109,7 +119,19 @@ class DensitySummationInnerKernel : public BaseDensitySummationInnerKernel {
     }
 
     void interaction(size_t index_i, Real dt = 0.0) {
+#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
         interaction(index_i, dt, inner_configuration_, W0_, rho_sum_, rho0_, inv_sigma0_);
+#else
+        DeviceReal sigma = W0_;
+        const auto &neighbor_builder = *inner_neighbor_builder_;
+        cell_linked_list_->forEachInnerNeighbor(index_i, [&](const DeviceVecd &pos_i, size_t index_j,
+                                                             const DeviceVecd &pos_j, const DeviceReal &Vol_j)
+                                                {
+                                                    if(neighbor_builder.isWithinCutoff(pos_i, pos_j) && index_i != index_j)
+                                                        sigma += neighbor_builder.W_ij(pos_i, pos_j);
+                                                });
+        rho_sum_[index_i] = sigma * rho0_ * inv_sigma0_;
+#endif
     }
 
   private:
@@ -401,11 +423,19 @@ class BaseIntegration : public LocalDynamics, public FluidDataInner
 template<class RiemannSolverType, class MaterialType>
 class BaseIntegration1stHalfKernel : public BaseIntegrationKernel<MaterialType> {
   public:
+    BaseIntegration1stHalfKernel(BaseInnerRelation& inner_relation,
+                                 BaseParticles* particles,
+                                 const RiemannSolverType& riemannSolver)
+        : BaseIntegrationKernel<MaterialType>(particles),
+          riemann_solver_(this->fluid_, this->fluid_),
+          cell_linked_list_(inner_relation.getInnerCellLinkedListDevice()),
+          inner_neighbor_builder_(inner_relation.getInnerNeighborBuilderDevice()) {}
+
     BaseIntegration1stHalfKernel(BaseParticles* particles, NeighborhoodDevice* inner_configuration,
                                  const RiemannSolverType& riemannSolver) :
                                  BaseIntegrationKernel<MaterialType>(particles),
                                  riemann_solver_(this->fluid_, this->fluid_),
-                                 inner_configuration_(inner_configuration){}
+                                 inner_configuration_(inner_configuration) {}
 
     template<class RealType, class VecType, class FluidType>
     static void initialization(size_t index_i, Real dt, RealType* rho, const RealType *drho_dt, RealType *p, VecType* pos,
@@ -448,12 +478,35 @@ class BaseIntegration1stHalfKernel : public BaseIntegrationKernel<MaterialType> 
     }
     
     void interaction(size_t index_i, Real dt = 0.0) {
+#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
         interaction(index_i, dt, this->p_, this->rho_, this->drho_dt_, this->acc_, inner_configuration_, riemann_solver_);
+#else
+        auto acceleration = VecdZero<DeviceVecd>();
+        DeviceReal rho_dissipation(0);
+        const auto &pressure_i = this->p_[index_i];
+        const auto& neighbor_builder = *inner_neighbor_builder_;
+        cell_linked_list_->forEachInnerNeighbor(index_i, [&](const DeviceVecd &pos_i, size_t index_j,
+                                                             const DeviceVecd &pos_j, const DeviceReal& Vol_j)
+                                                {
+                                                    if(neighbor_builder.isWithinCutoff(pos_i, pos_j) && index_i != index_j)
+                                                    {
+                                                        const auto& dW_ijV_j = neighbor_builder.dW_ijV_j(pos_i, pos_j, Vol_j);
+                                                        const auto &e_ij = neighbor_builder.e_ij(pos_i, pos_j);
+
+                                                        acceleration -= (pressure_i + this->p_[index_j]) * dW_ijV_j * e_ij;
+                                                        rho_dissipation += this->riemann_solver_.DissipativeUJump(pressure_i - this->p_[index_j]) * dW_ijV_j;
+                                                    }
+                                                });
+        this->acc_[index_i] += acceleration / this->rho_[index_i];
+        this->drho_dt_[index_i] = rho_dissipation * this->rho_[index_i];
+#endif
     }
     
   protected:
     RiemannSolverType riemann_solver_;
     NeighborhoodDevice* inner_configuration_;
+    CellLinkedListKernel* cell_linked_list_;
+    NeighborBuilderInnerKernel* inner_neighbor_builder_;
 };
 
 /**
@@ -488,11 +541,19 @@ using Integration1stHalfDissipativeRiemann = BaseIntegration1stHalf<DissipativeR
 template<class RiemannSolverType, class FluidKernel>
 class BaseIntegration2ndHalfKernel : public BaseIntegrationKernel<FluidKernel> {
   public:
+    BaseIntegration2ndHalfKernel(BaseInnerRelation& inner_relation,
+                                 BaseParticles* particles,
+                                 const RiemannSolverType& riemannSolver)
+        : BaseIntegrationKernel<FluidKernel>(particles),
+          riemann_solver_(this->fluid_, this->fluid_),
+          cell_linked_list_(inner_relation.getInnerCellLinkedListDevice()),
+          inner_neighbor_builder_(inner_relation.getInnerNeighborBuilderDevice()) {}
+
     BaseIntegration2ndHalfKernel(BaseParticles* particles, NeighborhoodDevice* inner_configuration,
                                  const RiemannSolverType& riemannSolver) :
             BaseIntegrationKernel<FluidKernel>(particles),
             riemann_solver_(this->fluid_, this->fluid_),
-            inner_configuration_(inner_configuration){}
+            inner_configuration_(inner_configuration) {}
 
     template<class VecType>
     static inline void initialization(size_t index_i, Real dt, VecType* pos, VecType *vel) {
@@ -534,12 +595,36 @@ class BaseIntegration2ndHalfKernel : public BaseIntegrationKernel<FluidKernel> {
     }
 
     void interaction(size_t index_i, Real dt = 0.0) {
+#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
         interaction(index_i, dt, this->rho_, this->drho_dt_, this->vel_, this->acc_, inner_configuration_, riemann_solver_);
+#else
+        DeviceReal density_change_rate(0);
+        auto p_dissipation = VecdZero<DeviceVecd>();
+        const DeviceVecd & vel_i = this->vel_[index_i];
+        const auto& neighbor_builder = *inner_neighbor_builder_;
+        cell_linked_list_->forEachInnerNeighbor(index_i, [&](const DeviceVecd &pos_i, size_t index_j,
+                                                             const DeviceVecd &pos_j, const DeviceReal& Vol_j)
+                                                {
+                                                    if(neighbor_builder.isWithinCutoff(pos_i, pos_j) && index_i != index_j)
+                                                    {
+                                                        const auto &e_ij = neighbor_builder.e_ij(pos_i, pos_j);
+                                                        const auto &dW_ijV_j = neighbor_builder.dW_ijV_j(pos_i, pos_j, Vol_j);
+
+                                                        const DeviceReal u_jump = VecdDot(DeviceVecd(vel_i - this->vel_[index_j]), e_ij);
+                                                        density_change_rate += u_jump * dW_ijV_j;
+                                                        p_dissipation += static_cast<DeviceReal>(this->riemann_solver_.DissipativePJump(u_jump)) * dW_ijV_j * e_ij;
+                                                    }
+                                                });
+        this->drho_dt_[index_i] += density_change_rate * this->rho_[index_i];
+        this->acc_[index_i] = p_dissipation / this->rho_[index_i];
+#endif
     }
 
   protected:
     RiemannSolverType riemann_solver_;
     NeighborhoodDevice* inner_configuration_;
+    CellLinkedListKernel* cell_linked_list_;
+    NeighborBuilderInnerKernel* inner_neighbor_builder_;
 };
 
 

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.hpp
@@ -167,7 +167,12 @@ void Oldroyd_BIntegration2ndHalf::
 //=================================================================================================//
 template <class RiemannSolverType>
 BaseIntegration1stHalf<RiemannSolverType>::BaseIntegration1stHalf(BaseInnerRelation &inner_relation)
-    : BaseIntegration(inner_relation), riemann_solver_(fluid_, fluid_)
+    : BaseIntegration(inner_relation), riemann_solver_(fluid_, fluid_),
+#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
+      device_kernel(particles_, this->inner_configuration_device_->data(), riemann_solver_)
+#else
+      device_kernel(inner_relation, particles_, riemann_solver_)
+#endif
 {
     /**
      *	register sortable particle data
@@ -224,7 +229,12 @@ void BaseIntegration1stHalf<RiemannSolverType>::
 template <class RiemannSolverType>
 BaseIntegration2ndHalf<RiemannSolverType>::BaseIntegration2ndHalf(BaseInnerRelation &inner_relation)
     : BaseIntegration(inner_relation), riemann_solver_(fluid_, fluid_),
-      Vol_(particles_->Vol_), mass_(particles_->mass_) {}
+      Vol_(particles_->Vol_), mass_(particles_->mass_),
+#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
+      device_kernel(particles_, this->inner_configuration_device_->data(), riemann_solver_) {}
+#else
+      device_kernel(inner_relation, particles_, riemann_solver_) {}
+#endif
 //=================================================================================================//
 template <class RiemannSolverType>
 void BaseIntegration2ndHalf<RiemannSolverType>::initialization(size_t index_i, Real dt)

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_dynamics_inner.hpp
@@ -18,8 +18,12 @@ namespace fluid_dynamics
 void DensitySummationInner::
     interaction(size_t index_i, Real dt)
 {
-    DensitySummationInnerKernel::interaction(index_i, dt, inner_configuration_.data(), W0_, rho_sum_.data(),
-                                             rho0_, inv_sigma0_);
+    Real sigma = W0_;
+    const Neighborhood &inner_neighborhood = inner_configuration_[index_i];
+    for (size_t n = 0; n != inner_neighborhood.current_size_; ++n)
+        sigma += inner_neighborhood.W_ij_[n];
+
+    rho_sum_[index_i] = sigma * rho0_ * inv_sigma0_;
 }
 //=================================================================================================//
 void DensitySummationInnerAdaptive::
@@ -168,11 +172,7 @@ void Oldroyd_BIntegration2ndHalf::
 template <class RiemannSolverType>
 BaseIntegration1stHalf<RiemannSolverType>::BaseIntegration1stHalf(BaseInnerRelation &inner_relation)
     : BaseIntegration(inner_relation), riemann_solver_(fluid_, fluid_),
-#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
-      device_kernel(particles_, this->inner_configuration_device_->data(), riemann_solver_)
-#else
       device_kernel(inner_relation, particles_, riemann_solver_)
-#endif
 {
     /**
      *	register sortable particle data
@@ -222,19 +222,27 @@ template <class RiemannSolverType>
 void BaseIntegration1stHalf<RiemannSolverType>::
     interaction(size_t index_i, Real dt)
 {
-    decltype(device_kernel)::KernelType::interaction(index_i, dt, p_.data(), rho_.data(), drho_dt_.data(), acc_.data(),
-                              inner_configuration_.data(), riemann_solver_);
+    Vecd acceleration = Vecd::Zero();
+    Real rho_dissipation(0);
+    const Neighborhood &inner_neighborhood = inner_configuration_[index_i];
+    for (size_t n = 0; n != inner_neighborhood.current_size_; ++n)
+    {
+        size_t index_j = inner_neighborhood.j_[n];
+        Real dW_ijV_j = inner_neighborhood.dW_ijV_j_[n];
+        const Vecd &e_ij = inner_neighborhood.e_ij_[n];
+
+        acceleration -= (p_[index_i] + p_[index_j]) * dW_ijV_j * e_ij;
+        rho_dissipation += riemann_solver_.DissipativeUJump(p_[index_i] - p_[index_j]) * dW_ijV_j;
+    }
+    acc_[index_i] += acceleration / rho_[index_i];
+    drho_dt_[index_i] = rho_dissipation * rho_[index_i];
 }
 //=================================================================================================//
 template <class RiemannSolverType>
 BaseIntegration2ndHalf<RiemannSolverType>::BaseIntegration2ndHalf(BaseInnerRelation &inner_relation)
     : BaseIntegration(inner_relation), riemann_solver_(fluid_, fluid_),
       Vol_(particles_->Vol_), mass_(particles_->mass_),
-#ifdef SPHINXSYS_SYCL_COMPUTE_NEIGHBORHOOD
-      device_kernel(particles_, this->inner_configuration_device_->data(), riemann_solver_) {}
-#else
       device_kernel(inner_relation, particles_, riemann_solver_) {}
-#endif
 //=================================================================================================//
 template <class RiemannSolverType>
 void BaseIntegration2ndHalf<RiemannSolverType>::initialization(size_t index_i, Real dt)
@@ -252,8 +260,21 @@ template <class RiemannSolverType>
 void BaseIntegration2ndHalf<RiemannSolverType>::
     interaction(size_t index_i, Real dt)
 {
-    decltype(device_kernel)::KernelType::interaction(index_i, dt, rho_.data(), drho_dt_.data(), vel_.data(),
-                              acc_.data(), inner_configuration_.data(), riemann_solver_);
+    Real density_change_rate(0);
+    Vecd p_dissipation = Vecd::Zero();
+    const Neighborhood &inner_neighborhood = inner_configuration_[index_i];
+    for (size_t n = 0; n != inner_neighborhood.current_size_; ++n)
+    {
+        size_t index_j = inner_neighborhood.j_[n];
+        const Vecd &e_ij = inner_neighborhood.e_ij_[n];
+        Real dW_ijV_j = inner_neighborhood.dW_ijV_j_[n];
+
+        Real u_jump = (vel_[index_i] - vel_[index_j]).dot(e_ij);
+        density_change_rate += u_jump * dW_ijV_j;
+        p_dissipation += riemann_solver_.DissipativePJump(u_jump) * dW_ijV_j * e_ij;
+    }
+    drho_dt_[index_i] += density_change_rate * rho_[index_i];
+    acc_[index_i] = p_dissipation / rho_[index_i];
 };
 //=================================================================================================//
 } // namespace fluid_dynamics

--- a/src/shared/particle_neighborhood/neighborhood.cpp
+++ b/src/shared/particle_neighborhood/neighborhood.cpp
@@ -21,49 +21,6 @@ void Neighborhood::removeANeighbor(size_t neighbor_n)
     r_ij_[neighbor_n] = r_ij_[current_size_];
     e_ij_[neighbor_n] = e_ij_[current_size_];
 }
-
-Neighborhood& Neighborhood::operator=(const NeighborhoodDevice &device) {
-    copyDataFromDevice(&current_size_, device.current_size_, 1)
-        .add(copyDataFromDevice(j_.data(), device.j_, current_size_))
-        .add(copyDataFromDevice(W_ij_.data(), device.W_ij_, current_size_))
-        .add(copyDataFromDevice(dW_ijV_j_.data(), device.dW_ijV_j_, current_size_))
-        .add(copyDataFromDevice(r_ij_.data(), device.r_ij_, current_size_))
-        .add(copyDataFromDevice(e_ij_.data(), device.e_ij_, current_size_))
-        .wait();
-    return *this;
-}
-
-NeighborhoodDevice::NeighborhoodDevice() : current_size_(allocateDeviceData<size_t>(1)),
-                                           allocated_size_(Dimensions == 2 ? 28 : 86),
-                                           j_(allocateDeviceData<size_t>(allocated_size_)),
-                                           W_ij_(allocateDeviceData<DeviceReal>(allocated_size_)),
-                                           dW_ijV_j_(allocateDeviceData<DeviceReal>(allocated_size_)),
-                                           r_ij_(allocateDeviceData<DeviceReal>(allocated_size_)),
-                                           e_ij_(allocateDeviceData<DeviceVecd>(allocated_size_)) {}
-
-NeighborhoodDevice::~NeighborhoodDevice() {
-    freeDeviceData(current_size_);
-    freeDeviceData(j_);
-    freeDeviceData(W_ij_);
-    freeDeviceData(dW_ijV_j_);
-    freeDeviceData(r_ij_);
-    freeDeviceData(e_ij_);
-}
-
-NeighborhoodDevice& NeighborhoodDevice::operator=(const Neighborhood &host) {
-    if(allocated_size_ < host.current_size_)
-        throw std::runtime_error("NeighborhoodDevice allocation size (" + std::to_string(allocated_size_) +
-                                 ") is smaller than host Neighborhood size (" + std::to_string(host.current_size_) + ")");
-    copyDataToDevice(host.j_.data(), j_, host.current_size_)
-        .add(copyDataToDevice(host.W_ij_.data(), W_ij_, host.current_size_))
-        .add(copyDataToDevice(host.dW_ijV_j_.data(), dW_ijV_j_, host.current_size_))
-        .add(copyDataToDevice(host.r_ij_.data(), r_ij_, host.current_size_))
-        .add(copyDataToDevice(host.e_ij_.data(), e_ij_, host.current_size_))
-        .add(copyDataToDevice(&host.current_size_, current_size_, 1))
-        .wait();
-    return *this;
-}
-
 //=================================================================================================//
 void NeighborBuilder::createNeighbor(Neighborhood &neighborhood, const Real &distance,
                                      const Vecd &displacement, size_t index_j, const Real &Vol_j)
@@ -272,18 +229,5 @@ void NeighborBuilderContactAdaptive::operator()(Neighborhood &neighborhood,
         neighborhood.current_size_++;
     }
 }
-//=================================================================================================//
-void NeighborBuilderInnerKernel::operator()(NeighborhoodDevice &neighborhood, const DeviceVecd &pos_i, const size_t index_i, const size_t index_j, const DeviceVecd pos_j, const DeviceReal Vol_j) const
-    {
-        DeviceVecd displacement = pos_i - pos_j;
-        DeviceReal distance_metric = VecdSquareNorm(displacement);
-        if (distance_metric < smoothing_kernel.CutOffRadiusSqr() && index_i != index_j)
-        {
-            auto current_size_atomic = sycl::atomic_ref<size_t, sycl::memory_order::relaxed,
-                                      sycl::memory_scope::device,
-                                      sycl::access::address_space::global_space>(*neighborhood.current_size_);
-            initializeNeighbor(neighborhood, current_size_atomic++, sycl::sqrt(distance_metric), displacement, index_j, Vol_j);
-        }
-    }
 } // namespace SPH
 //=================================================================================================//

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -154,7 +154,7 @@ class BaseParticles
     DeviceDataType *registerDeviceVariable(const std::string &variable_name, std::size_t size,
                                            const HostDataType* host_value = nullptr);
     template <typename DeviceDataType>
-    DeviceDataType *getDeviceVariableByName(const std::string &variable_name)
+    DeviceDataType *getDeviceVariableByName(const std::string &variable_name) const
     {
         DeviceVariable<DeviceDataType> *variable = findVariableByName<DeviceDataType>(all_device_variables_, variable_name);
 

--- a/src/shared/sphinxsys_system/sph_system.cpp
+++ b/src/shared/sphinxsys_system/sph_system.cpp
@@ -41,15 +41,6 @@ void SPHSystem::initializeSystemConfigurations()
     }
 }
 //=================================================================================================//
-execution::ExecutionEvent SPHSystem::initializeSystemDeviceConfigurations()
-{
-    execution::ExecutionEvent update_events;
-    for (auto &body : sph_bodies_)
-        for (auto & body_relation : body->body_relations_)
-            update_events.add(body_relation->updateDeviceConfiguration());
-    return update_events;
-}
-//=================================================================================================//
 Real SPHSystem::getSmallestTimeStepAmongSolidBodies(Real CFL)
 {
     Real dt = Infinity;

--- a/src/shared/sphinxsys_system/sph_system.h
+++ b/src/shared/sphinxsys_system/sph_system.h
@@ -88,7 +88,6 @@ class SPHSystem
     execution::ExecutionEvent initializeSystemCellLinkedLists(execution::ParallelSYCLDevicePolicy);
     /** Initialize particle configuration for the SPH system. */
     void initializeSystemConfigurations();
-    execution::ExecutionEvent initializeSystemDeviceConfigurations();
     /** get the min time step from all bodies. */
     Real getSmallestTimeStepAmongSolidBodies(Real CFL = 0.6);
     /** Command line handle for Ctest. */


### PR DESCRIPTION
# Changes

SYCL code will now iterate over the entire list of particles contained within neighboring cells instead of relying on pre-computed kernel values coming from a configuration update step.

A new method `forEachNeighbor` has been added to `CellLinkedListKernel`, which replaces `searchNeighborsByParticles` and the need to update configuration variables.
In fact, all variables and methods concerning configuration information for device code have been removed.

# Benchmarks

A performance comparison between the old configuration-based execution and the new direct search version shows an improvement up to 6x for larger simulations.

![Benchmark](https://github.com/Xiangyu-Hu/SPHinXsys/assets/43089212/7f6fa9a3-dfab-4128-b43a-f6db4e858cee)

More importantly, removing configuration variables significantly reduced GPU memory usage. For instance, 2 million particles required up to 12GiB of RAM on the old version, while it now only takes 900MiB, ultimately enabling larger simulation on the same graphic cards.