### PR TITLE
Add check for fluid & shell reference space

### DIFF
--- a/src/shared/particle_neighborhood/neighborhood.cpp
+++ b/src/shared/particle_neighborhood/neighborhood.cpp
@@ -253,9 +253,10 @@ NeighborBuilderContactToShell::NeighborBuilderContactToShell(SPHBody &body, SPHB
     : BaseNeighborBuilderContactShell(contact_body),
       direction_corrector_(normal_correction ? -1 : 1)
 {
-    Real fluid_smoothing_length = body.sph_adaptation_->ReferenceSmoothingLength();
-    Real shell_smoothing_length = contact_body.sph_adaptation_->ReferenceSmoothingLength();
-    kernel_ = (fluid_smoothing_length >= shell_smoothing_length ? body.sph_adaptation_->getKernel() : kernel_keeper_.createPtr<KernelWendlandC2>(shell_smoothing_length));
+    Real fluid_reference_spacing = body.sph_adaptation_->ReferenceSpacing();
+    Real shell_reference_spacing = contact_body.sph_adaptation_->ReferenceSpacing();
+    if (fluid_reference_spacing < shell_reference_spacing)
+        throw std::runtime_error("NeighborBuilderContactToShell: fluid spacing should be larger or equal than shell spacing...");
 }
 //=================================================================================================//
 void NeighborBuilderContactToShell::update_neighbors(Neighborhood &neighborhood,
@@ -323,9 +324,10 @@ NeighborBuilderContactFromShell::NeighborBuilderContactFromShell(SPHBody &body, 
     : BaseNeighborBuilderContactShell(body),
       direction_corrector_(normal_correction ? -1 : 1)
 {
-    Real shell_smoothing_length = body.sph_adaptation_->ReferenceSmoothingLength();
-    Real fluid_smoothing_length = contact_body.sph_adaptation_->ReferenceSmoothingLength();
-    kernel_ = (fluid_smoothing_length >= shell_smoothing_length ? contact_body.sph_adaptation_->getKernel() : kernel_keeper_.createPtr<KernelWendlandC2>(shell_smoothing_length));
+    Real shell_reference_spacing = body.sph_adaptation_->ReferenceSpacing();
+    Real fluid_reference_spacing = contact_body.sph_adaptation_->ReferenceSpacing();
+    if (fluid_reference_spacing < shell_reference_spacing)
+        throw std::runtime_error("NeighborBuilderContactFromShell: fluid spacing should be larger or equal than shell spacing...");
 }
 //=================================================================================================//
 void NeighborBuilderContactFromShell::operator()(Neighborhood &neighborhood,

--- a/src/shared/particle_neighborhood/neighborhood.cpp
+++ b/src/shared/particle_neighborhood/neighborhood.cpp
@@ -257,6 +257,7 @@ NeighborBuilderContactToShell::NeighborBuilderContactToShell(SPHBody &body, SPHB
     Real shell_reference_spacing = contact_body.sph_adaptation_->ReferenceSpacing();
     if (fluid_reference_spacing < shell_reference_spacing)
         throw std::runtime_error("NeighborBuilderContactToShell: fluid spacing should be larger or equal than shell spacing...");
+    kernel_ = body.sph_adaptation_->getKernel();
 }
 //=================================================================================================//
 void NeighborBuilderContactToShell::update_neighbors(Neighborhood &neighborhood,
@@ -328,6 +329,7 @@ NeighborBuilderContactFromShell::NeighborBuilderContactFromShell(SPHBody &body, 
     Real fluid_reference_spacing = contact_body.sph_adaptation_->ReferenceSpacing();
     if (fluid_reference_spacing < shell_reference_spacing)
         throw std::runtime_error("NeighborBuilderContactFromShell: fluid spacing should be larger or equal than shell spacing...");
+    kernel_ = contact_body.sph_adaptation_->getKernel();
 }
 //=================================================================================================//
 void NeighborBuilderContactFromShell::operator()(Neighborhood &neighborhood,

--- a/tests/2d_examples/test_2d_hydrostatic_fluid_shell/test_2d_hydrostatic_fluid_shell.cpp
+++ b/tests/2d_examples/test_2d_hydrostatic_fluid_shell/test_2d_hydrostatic_fluid_shell.cpp
@@ -404,11 +404,11 @@ TEST(hydrostatic_fsi, dp_2)
     hydrostatic_fsi(particle_spacing_gate, particle_spacing_ref);
 }
 
-TEST(DISABLED_hydrostatic_fsi, dp_s_2_dp_f_1)
+TEST(DISABLED_hydrostatic_fsi, dp_4)
 { // for CI
     const Real Gate_thickness = 0.05;
-    const Real particle_spacing_gate = Gate_thickness / 2.0;
-    const Real particle_spacing_ref = 0.5 * particle_spacing_gate;
+    const Real particle_spacing_gate = Gate_thickness / 4.0;
+    const Real particle_spacing_ref = particle_spacing_gate;
     hydrostatic_fsi(particle_spacing_gate, particle_spacing_ref);
 }
 //----------------------------------------------------------------------

--- a/tests/3d_examples/test_3d_poiseuille_flow_shell/poiseuille_flow_shell.cpp
+++ b/tests/3d_examples/test_3d_poiseuille_flow_shell/poiseuille_flow_shell.cpp
@@ -413,7 +413,7 @@ void poiseuille_flow(const Real resolution_ref, const Real resolution_shell, con
     }
 }
 
-TEST(poiseuille_flow, 10_fluid_particles_20_shell_particles)
+TEST(poiseuille_flow, 10_particles)
 { // for CI
     const int number_of_particles = 10;
     const Real resolution_ref = diameter / number_of_particles;
@@ -422,11 +422,11 @@ TEST(poiseuille_flow, 10_fluid_particles_20_shell_particles)
     poiseuille_flow(resolution_ref, resolution_shell, shell_thickness);
 }
 
-TEST(DISABLED_poiseuille_flow, 20_fluid_particles_10_shell_particles)
+TEST(DISABLED_poiseuille_flow, 20_particles)
 { // for CI
     const int number_of_particles = 20;
     const Real resolution_ref = diameter / number_of_particles;
-    const Real resolution_shell = 2 * resolution_ref;
+    const Real resolution_shell = 0.5 * resolution_ref;
     const Real shell_thickness = 0.5 * resolution_shell;
     poiseuille_flow(resolution_ref, resolution_shell, shell_thickness);
 }


### PR DESCRIPTION
## Description

This PR adds a check in `NeighborBuilderContactToShell` and `NeighborBuilderContactFromShell`, ensuring that the reference spacing of fluid will be larger than or equal to that of shell.