### PR TITLE
Refactory/revise data assemble

### DIFF
--- a/src/shared/common/base_data_package.h
+++ b/src/shared/common/base_data_package.h
@@ -131,5 +131,4 @@ class OperationOnDataAssemble
     }
 };
 } // namespace SPH
-
 #endif // BASE_DATA_PACKAGE_H

--- a/src/shared/common/base_data_package.h
+++ b/src/shared/common/base_data_package.h
@@ -105,6 +105,7 @@ class DataAssembleOperation
     }
 };
 
+// Please refer: https://www.cppstories.com/2022/tuple-iteration-basics/ for the following code
 template <typename DataAssembleType, typename OperationType>
 class OperationOnDataAssemble
 {
@@ -119,8 +120,9 @@ class OperationOnDataAssemble
     }
 
   public:
-    OperationOnDataAssemble(DataAssembleType &data_assemble)
-        : data_assemble_(data_assemble){};
+    template <typename... Args>
+    OperationOnDataAssemble(DataAssembleType &data_assemble, Args &&...args)
+        : data_assemble_(data_assemble), operation_(std::forward<Args>(args)...){};
 
     template <typename... OperationArgs>
     void operator()(OperationArgs &&...operation_args)

--- a/src/shared/common/base_data_package.h
+++ b/src/shared/common/base_data_package.h
@@ -67,12 +67,6 @@ using DataContainerAddressAssemble = DataAssemble<DataContainerAddressKeeper, Co
 template <template <typename> typename ContainerType>
 using DataContainerUniquePtrAssemble = DataAssemble<DataContainerUniquePtrKeeper, ContainerType>;
 
-template <typename ContainedDataType>
-using DataContainerEmptyKeeper = ContainedDataType;
-
-template <template <typename> typename ContainerType>
-using DataContainerEmptyKeeperAssemble = DataAssemble<DataContainerEmptyKeeper, ContainerType>;
-
 /** a type irrelevant operation on the data assembles  */
 template <template <typename> typename OperationType>
 class DataAssembleOperation

--- a/src/shared/common/base_data_package.h
+++ b/src/shared/common/base_data_package.h
@@ -40,34 +40,38 @@ namespace SPH
 {
 constexpr Real OneOverDimensions = 1.0 / (Real)Dimensions;
 constexpr int lastAxis = Dimensions - 1;
+/** Generalized data container keeper */
+template <typename ContainedDataType>
+using DataContainerKeeper = StdVec<ContainedDataType>;
+/** Generalized data address container keeper */
+template <typename ContainedDataType>
+using DataContainerAddressKeeper = StdVec<ContainedDataType *>;
+/** Generalized data container unique pointer keeper */
+template <typename ContainedDataType>
+using DataContainerUniquePtrKeeper = UniquePtrsKeeper<ContainedDataType>;
 
+template <template <typename> typename KeeperType, template <typename> typename ContainerType>
+using DataAssemble = std::tuple<KeeperType<ContainerType<Real>>,
+                                KeeperType<ContainerType<Vec2d>>,
+                                KeeperType<ContainerType<Vec3d>>,
+                                KeeperType<ContainerType<Mat2d>>,
+                                KeeperType<ContainerType<Mat3d>>,
+                                KeeperType<ContainerType<int>>>;
 /** Generalized data container assemble type */
-template <template <typename> typename DataContainerType>
-using DataContainerAssemble =
-    std::tuple<StdVec<DataContainerType<Real>>,
-               StdVec<DataContainerType<Vec2d>>,
-               StdVec<DataContainerType<Vec3d>>,
-               StdVec<DataContainerType<Mat2d>>,
-               StdVec<DataContainerType<Mat3d>>,
-               StdVec<DataContainerType<int>>>;
-/** Generalized data container address assemble type */
-template <template <typename> typename DataContainerType>
-using DataContainerAddressAssemble =
-    std::tuple<StdVec<DataContainerType<Real> *>,
-               StdVec<DataContainerType<Vec2d> *>,
-               StdVec<DataContainerType<Vec3d> *>,
-               StdVec<DataContainerType<Mat2d> *>,
-               StdVec<DataContainerType<Mat3d> *>,
-               StdVec<DataContainerType<int> *>>;
+template <template <typename> typename ContainerType>
+using DataContainerAssemble = DataAssemble<DataContainerKeeper, ContainerType>;
+/** Generalized data address container assemble type */
+template <template <typename> typename ContainerType>
+using DataContainerAddressAssemble = DataAssemble<DataContainerAddressKeeper, ContainerType>;
 /** Generalized data container unique pointer assemble type */
-template <template <typename> typename DataContainerType>
-using DataContainerUniquePtrAssemble =
-    std::tuple<UniquePtrsKeeper<DataContainerType<Real>>,
-               UniquePtrsKeeper<DataContainerType<Vec2d>>,
-               UniquePtrsKeeper<DataContainerType<Vec3d>>,
-               UniquePtrsKeeper<DataContainerType<Mat2d>>,
-               UniquePtrsKeeper<DataContainerType<Mat3d>>,
-               UniquePtrsKeeper<DataContainerType<int>>>;
+template <template <typename> typename ContainerType>
+using DataContainerUniquePtrAssemble = DataAssemble<DataContainerUniquePtrKeeper, ContainerType>;
+
+template <typename ContainedDataType>
+using DataContainerEmptyKeeper = ContainedDataType;
+
+template <template <typename> typename ContainerType>
+using DataContainerEmptyKeeperAssemble = DataAssemble<DataContainerEmptyKeeper, ContainerType>;
 
 /** a type irrelevant operation on the data assembles  */
 template <template <typename> typename OperationType>

--- a/src/shared/common/base_data_package.h
+++ b/src/shared/common/base_data_package.h
@@ -104,6 +104,29 @@ class DataAssembleOperation
         integer_operation(std::forward<OperationArgs>(operation_args)...);
     }
 };
+
+template <typename DataAssembleType, typename OperationType>
+class OperationOnDataAssemble
+{
+    DataAssembleType &data_assemble_;
+    static constexpr std::size_t tuple_size_ = std::tuple_size_v<DataAssembleType>;
+
+    template <std::size_t... Is, typename... OperationArgs>
+    void operationSequence(std::index_sequence<Is...>, OperationArgs &&...operation_args)
+    {
+        (OperationType(std::get<Is>(data_assemble_), std::forward<OperationArgs>(operation_args)...), ...);
+    }
+
+  public:
+    OperationOnDataAssemble(DataAssembleType &data_assemble)
+        : data_assemble_(data_assemble){};
+
+    template <typename... OperationArgs>
+    void operator()(OperationArgs &&...operation_args)
+    {
+        operationSequence(std::make_index_sequence<tuple_size_>{}, std::forward<OperationArgs>(operation_args)...);
+    }
+};
 } // namespace SPH
 
 #endif // BASE_DATA_PACKAGE_H

--- a/src/shared/common/base_data_package.h
+++ b/src/shared/common/base_data_package.h
@@ -108,13 +108,14 @@ class DataAssembleOperation
 template <typename DataAssembleType, typename OperationType>
 class OperationOnDataAssemble
 {
-    DataAssembleType &data_assemble_;
     static constexpr std::size_t tuple_size_ = std::tuple_size_v<DataAssembleType>;
+    DataAssembleType &data_assemble_;
+    OperationType operation_;
 
     template <std::size_t... Is, typename... OperationArgs>
     void operationSequence(std::index_sequence<Is...>, OperationArgs &&...operation_args)
     {
-        (OperationType(std::get<Is>(data_assemble_), std::forward<OperationArgs>(operation_args)...), ...);
+        (operation_(std::get<Is>(data_assemble_), std::forward<OperationArgs>(operation_args)...), ...);
     }
 
   public:

--- a/src/shared/common/sph_data_containers.h
+++ b/src/shared/common/sph_data_containers.h
@@ -79,21 +79,5 @@ template <typename DataType>
 using MeshVariable = DiscreteVariable<DataType>;
 typedef DataContainerAddressAssemble<MeshVariable> MeshVariableAssemble;
 
-/** operation by looping or going through a particle variables */
-template <typename DataType>
-struct loopParticleVariables
-{
-    template <typename VariableOperation>
-    void operator()(ParticleData &particle_data,
-                    ParticleVariables &particle_variables, VariableOperation &variable_operation) const
-    {
-        constexpr int type_index = DataTypeIndex<DataType>::value;
-        for (DiscreteVariable<DataType> *variable : std::get<type_index>(particle_variables))
-        {
-            StdLargeVec<DataType> &variable_data = *(std::get<type_index>(particle_data)[variable->IndexInContainer()]);
-            variable_operation(variable->Name(), variable_data);
-        }
-    };
-};
 } // namespace SPH
 #endif // SPH_DATA_CONTAINERS_H

--- a/src/shared/particle_dynamics/general_dynamics/general_refinement.cpp
+++ b/src/shared/particle_dynamics/general_dynamics/general_refinement.cpp
@@ -439,7 +439,8 @@ ParticleMergeWithPrescribedArea::
     ParticleMergeWithPrescribedArea(BaseInnerRelation &inner_relation, Shape &refinement_region)
     : ParticleRefinementWithPrescribedArea(inner_relation.getSPHBody(), refinement_region),
       DataDelegateInner<BaseParticles, DataDelegateEmptyBase>(inner_relation),
-      all_particle_data_(particles_->getAllParticleData()), vel_n_(particles_->vel_)
+      all_particle_data_(particles_->getAllParticleData()), vel_n_(particles_->vel_),
+      merge_particle_value_(all_particle_data_)
 {
     particles_->registerVariable(total_merge_error_, "MergeDensityError", Real(0));
 }
@@ -527,7 +528,7 @@ void ParticleMergeWithPrescribedArea::
         merge_mass_.push_back(mass_[merge_indices[k]]);
         total_mass += mass_[merge_indices[k]];
     }
-    merge_particle_value_(all_particle_data_, merged_index, merge_indices, merge_mass_);
+    merge_particle_value_(merged_index, merge_indices, merge_mass_);
     mass_[merged_index] = total_mass;
     Vol_[merged_index] = mass_[merged_index] * inv_rho0_;
     Real particle_spacing = pow(Vol_[merged_index], 1.0 / (Real)Dimensions);

--- a/src/shared/particle_dynamics/general_dynamics/general_refinement.h
+++ b/src/shared/particle_dynamics/general_dynamics/general_refinement.h
@@ -246,27 +246,28 @@ class ParticleMergeWithPrescribedArea : public ParticleRefinementWithPrescribedA
     bool findMergeParticles(size_t index_i, StdVec<size_t> &merge_indices, Real search_size, Real search_distance);
     virtual void updateMergedParticleInformation(size_t merged_index, const StdVec<size_t> &merge_indices);
 
-    template <typename VariableType>
-    struct mergeParticleDataValue
+    struct MergeParticleDataValue
     {
-        void operator()(ParticleData &particle_data, size_t merged_index, const StdVec<size_t> &merge_indices, StdVec<Real> merge_mass)
+        template <typename DataType>
+        void operator()(DataContainerAddressKeeper<StdLargeVec<DataType>> &data_keeper,
+                        size_t merged_index, const StdVec<size_t> &merge_indices, StdVec<Real> merge_mass)
         {
             Real total_mass = 0.0;
             for (size_t k = 0; k != merge_indices.size(); ++k)
                 total_mass += merge_mass[k];
 
-            constexpr int type_index = DataTypeIndex<VariableType>::value;
-            for (size_t i = 0; i != std::get<type_index>(particle_data).size(); ++i)
+            for (size_t i = 0; i != data_keeper.size(); ++i)
             {
-                VariableType particle_data_temp = ZeroData<VariableType>::value;
+                DataType particle_data_temp = ZeroData<DataType>::value;
                 for (size_t k = 0; k != merge_indices.size(); ++k)
-                    particle_data_temp += merge_mass[k] * (*std::get<type_index>(particle_data)[i])[merge_indices[k]];
+                    particle_data_temp += merge_mass[k] * (*data_keeper[i])[merge_indices[k]];
 
-                (*std::get<type_index>(particle_data)[i])[merged_index] = particle_data_temp / (total_mass + TinyReal);
+                (*data_keeper[i])[merged_index] = particle_data_temp / (total_mass + TinyReal);
             }
         };
     };
-    DataAssembleOperation<mergeParticleDataValue> merge_particle_value_;
+
+    OperationOnDataAssemble<ParticleData, MergeParticleDataValue> merge_particle_value_;
 };
 
 /**

--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -17,8 +17,8 @@ BaseParticles::BaseParticles(SPHBody &sph_body, BaseMaterial *base_material)
       base_material_(*base_material),
       restart_xml_parser_("xml_restart", "particles"),
       reload_xml_parser_("xml_particle_reload", "particles"),
-      resize_particle_data_(all_particle_data_),
-      resize_particles_(all_particle_data_)
+      resize_particles_(all_particle_data_),
+      copy_particle_data_(all_particle_data_)
 {
     //----------------------------------------------------------------------
     //		register geometric data only
@@ -81,7 +81,7 @@ void BaseParticles::increaseAllParticlesBounds(size_t buffer_size)
 //=================================================================================================//
 void BaseParticles::copyFromAnotherParticle(size_t index, size_t another_index)
 {
-    copy_particle_data_(all_particle_data_, index, another_index);
+    copy_particle_data_(index, another_index);
 }
 //=================================================================================================//
 void BaseParticles::updateGhostParticle(size_t ghost_index, size_t index)
@@ -308,9 +308,9 @@ void BaseParticles::resizeXmlDocForParticles(XmlParser &xml_parser)
 void BaseParticles::writeParticlesToXmlForRestart(std::string &filefullpath)
 {
     resizeXmlDocForParticles(restart_xml_parser_);
-    WriteAParticleVariableToXml write_variable_to_xml(restart_xml_parser_, total_real_particles_);
-    DataAssembleOperation<loopParticleVariables> loop_variable_namelist;
-    loop_variable_namelist(all_particle_data_, variables_to_restart_, write_variable_to_xml);
+    OperationOnDataAssemble<ParticleVariables, WriteAParticleVariableToXml>
+        write_variable_to_xml(variables_to_restart_, restart_xml_parser_);
+    write_variable_to_xml(all_particle_data_);
     restart_xml_parser_.writeToXmlFile(filefullpath);
 }
 //=================================================================================================//
@@ -325,9 +325,9 @@ void BaseParticles::readParticleFromXmlForRestart(std::string &filefullpath)
 void BaseParticles::writeToXmlForReloadParticle(std::string &filefullpath)
 {
     resizeXmlDocForParticles(reload_xml_parser_);
-    WriteAParticleVariableToXml write_variable_to_xml(reload_xml_parser_, total_real_particles_);
-    DataAssembleOperation<loopParticleVariables> loop_variable_namelist;
-    loop_variable_namelist(all_particle_data_, variables_to_reload_, write_variable_to_xml);
+    OperationOnDataAssemble<ParticleVariables, WriteAParticleVariableToXml>
+        write_variable_to_xml(variables_to_reload_, reload_xml_parser_);
+    write_variable_to_xml(all_particle_data_);
     reload_xml_parser_.writeToXmlFile(filefullpath);
 }
 //=================================================================================================//
@@ -339,7 +339,7 @@ void BaseParticles::readFromXmlForReloadParticle(std::string &filefullpath)
     {
         unsorted_id_.push_back(i);
     };
-    resize_particle_data_(total_real_particles_);
+    resize_particles_(total_real_particles_);
     ReadAParticleVariableFromXml read_variable_from_xml(reload_xml_parser_, total_real_particles_);
     DataAssembleOperation<loopParticleVariables> loop_variable_namelist;
     loop_variable_namelist(all_particle_data_, variables_to_reload_, read_variable_from_xml);

--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -18,7 +18,11 @@ BaseParticles::BaseParticles(SPHBody &sph_body, BaseMaterial *base_material)
       restart_xml_parser_("xml_restart", "particles"),
       reload_xml_parser_("xml_particle_reload", "particles"),
       resize_particles_(all_particle_data_),
-      copy_particle_data_(all_particle_data_)
+      copy_particle_data_(all_particle_data_),
+      write_restart_variable_to_xml_(variables_to_restart_, restart_xml_parser_),
+      write_reload_variable_to_xml_(variables_to_reload_, reload_xml_parser_),
+      read_restart_variable_from_xml_(variables_to_restart_, restart_xml_parser_),
+      read_reload_variable_from_xml_(variables_to_reload_, reload_xml_parser_)
 {
     //----------------------------------------------------------------------
     //		register geometric data only
@@ -308,26 +312,20 @@ void BaseParticles::resizeXmlDocForParticles(XmlParser &xml_parser)
 void BaseParticles::writeParticlesToXmlForRestart(std::string &filefullpath)
 {
     resizeXmlDocForParticles(restart_xml_parser_);
-    OperationOnDataAssemble<ParticleVariables, WriteAParticleVariableToXml>
-        write_variable_to_xml(variables_to_restart_, restart_xml_parser_);
-    write_variable_to_xml(all_particle_data_);
+    write_restart_variable_to_xml_(all_particle_data_);
     restart_xml_parser_.writeToXmlFile(filefullpath);
 }
 //=================================================================================================//
 void BaseParticles::readParticleFromXmlForRestart(std::string &filefullpath)
 {
     restart_xml_parser_.loadXmlFile(filefullpath);
-    ReadAParticleVariableFromXml read_variable_from_xml(restart_xml_parser_, total_real_particles_);
-    DataAssembleOperation<loopParticleVariables> loop_variable_namelist;
-    loop_variable_namelist(all_particle_data_, variables_to_restart_, read_variable_from_xml);
+    read_restart_variable_from_xml_(all_particle_data_);
 }
 //=================================================================================================//
 void BaseParticles::writeToXmlForReloadParticle(std::string &filefullpath)
 {
     resizeXmlDocForParticles(reload_xml_parser_);
-    OperationOnDataAssemble<ParticleVariables, WriteAParticleVariableToXml>
-        write_variable_to_xml(variables_to_reload_, reload_xml_parser_);
-    write_variable_to_xml(all_particle_data_);
+    write_reload_variable_to_xml_(all_particle_data_);
     reload_xml_parser_.writeToXmlFile(filefullpath);
 }
 //=================================================================================================//
@@ -340,9 +338,7 @@ void BaseParticles::readFromXmlForReloadParticle(std::string &filefullpath)
         unsorted_id_.push_back(i);
     };
     resize_particles_(total_real_particles_);
-    ReadAParticleVariableFromXml read_variable_from_xml(reload_xml_parser_, total_real_particles_);
-    DataAssembleOperation<loopParticleVariables> loop_variable_namelist;
-    loop_variable_namelist(all_particle_data_, variables_to_reload_, read_variable_from_xml);
+    read_reload_variable_from_xml_(all_particle_data_);
 }
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -17,7 +17,8 @@ BaseParticles::BaseParticles(SPHBody &sph_body, BaseMaterial *base_material)
       base_material_(*base_material),
       restart_xml_parser_("xml_restart", "particles"),
       reload_xml_parser_("xml_particle_reload", "particles"),
-      resize_particle_data_(all_particle_data_)
+      resize_particle_data_(all_particle_data_),
+      resize_particles_(all_particle_data_)
 {
     //----------------------------------------------------------------------
     //		register geometric data only

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -242,6 +242,13 @@ class BaseParticles
     DataAssembleOperation<resizeParticleData> resize_particle_data_;
     DataAssembleOperation<addParticleDataWithDefaultValue> add_particle_data_with_default_value_;
     DataAssembleOperation<copyParticleData> copy_particle_data_;
+
+    struct ResizeParticles
+    {
+        template <typename DataType>
+        void operator()(DataContainerAddressKeeper<StdLargeVec<DataType>> &data_keeper, size_t new_size);
+    };
+    OperationOnDataAssemble<ParticleData, ResizeParticles> resize_particles_;
 };
 
 /**

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -224,40 +224,34 @@ class BaseParticles
         void operator()(DataContainerAddressKeeper<StdLargeVec<DataType>> &data_keeper, size_t index, size_t another_index);
     };
 
+    struct WriteAParticleVariableToXml
+    {
+        XmlParser &xml_parser_;
+        WriteAParticleVariableToXml(XmlParser &xml_parser) : xml_parser_(xml_parser){};
+
+        template <typename DataType>
+        void operator()(DataContainerAddressKeeper<DiscreteVariable<DataType>> &variables, ParticleData &all_particle_data);
+    };
+
+    struct ReadAParticleVariableFromXml
+    {
+        XmlParser &xml_parser_;
+        ReadAParticleVariableFromXml(XmlParser &xml_parser) : xml_parser_(xml_parser){};
+
+        template <typename DataType>
+        void operator()(DataContainerAddressKeeper<DiscreteVariable<DataType>> &variables, ParticleData &all_particle_data);
+    };
+
   public:
     //----------------------------------------------------------------------
     //		Assemble based generalize particle operations
     //----------------------------------------------------------------------
     OperationOnDataAssemble<ParticleData, ResizeParticles> resize_particles_;
     OperationOnDataAssemble<ParticleData, CopyParticleData> copy_particle_data_;
-};
 
-/**
- * @struct WriteAParticleVariableToXml
- * @brief Define a operator for writing particle variable to XML format.
- */
-struct WriteAParticleVariableToXml
-{
-    XmlParser &xml_parser_;
-    WriteAParticleVariableToXml(XmlParser &xml_parser) : xml_parser_(xml_parser){};
-
-    template <typename DataType>
-    void operator()(DataContainerAddressKeeper<DiscreteVariable<DataType>> &variables, ParticleData &all_particle_data) const;
-};
-
-/**
- * @struct ReadAParticleVariableFromXml
- * @brief Define a operator for reading particle variable to XML format.
- */
-struct ReadAParticleVariableFromXml
-{
-    XmlParser &xml_parser_;
-    size_t &total_real_particles_;
-    ReadAParticleVariableFromXml(XmlParser &xml_parser, size_t &total_real_particles)
-        : xml_parser_(xml_parser), total_real_particles_(total_real_particles){};
-
-    template <typename DataType>
-    void operator()(const std::string &variable_name, StdLargeVec<DataType> &variable) const;
+  protected:
+    OperationOnDataAssemble<ParticleVariables, WriteAParticleVariableToXml> write_restart_variable_to_xml_, write_reload_variable_to_xml_;
+    OperationOnDataAssemble<ParticleVariables, ReadAParticleVariableFromXml> read_restart_variable_from_xml_, read_reload_variable_from_xml_;
 };
 
 /**

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -212,43 +212,24 @@ class BaseParticles
     //----------------------------------------------------------------------
     //		Small structs for generalize particle operations
     //----------------------------------------------------------------------
-    template <typename DataType>
-    class resizeParticleData
+    struct ResizeParticles
     {
-        ParticleData &all_particle_data_;
-
-      public:
-        resizeParticleData(ParticleData &all_particle_data);
-        void operator()(size_t new_size) const;
+        template <typename DataType>
+        void operator()(DataContainerAddressKeeper<StdLargeVec<DataType>> &data_keeper, size_t new_size);
     };
 
-    /** Add a particle data with default value. */
-    template <typename DataType>
-    struct addParticleDataWithDefaultValue
+    struct CopyParticleData
     {
-        void operator()(ParticleData &particle_data) const;
-    };
-
-    template <typename DataType>
-    struct copyParticleData
-    {
-        void operator()(ParticleData &particle_data, size_t index, size_t another_index) const;
+        template <typename DataType>
+        void operator()(DataContainerAddressKeeper<StdLargeVec<DataType>> &data_keeper, size_t index, size_t another_index);
     };
 
   public:
     //----------------------------------------------------------------------
     //		Assemble based generalize particle operations
     //----------------------------------------------------------------------
-    DataAssembleOperation<resizeParticleData> resize_particle_data_;
-    DataAssembleOperation<addParticleDataWithDefaultValue> add_particle_data_with_default_value_;
-    DataAssembleOperation<copyParticleData> copy_particle_data_;
-
-    struct ResizeParticles
-    {
-        template <typename DataType>
-        void operator()(DataContainerAddressKeeper<StdLargeVec<DataType>> &data_keeper, size_t new_size);
-    };
     OperationOnDataAssemble<ParticleData, ResizeParticles> resize_particles_;
+    OperationOnDataAssemble<ParticleData, CopyParticleData> copy_particle_data_;
 };
 
 /**
@@ -258,12 +239,10 @@ class BaseParticles
 struct WriteAParticleVariableToXml
 {
     XmlParser &xml_parser_;
-    size_t &total_real_particles_;
-    WriteAParticleVariableToXml(XmlParser &xml_parser, size_t &total_real_particles)
-        : xml_parser_(xml_parser), total_real_particles_(total_real_particles){};
+    WriteAParticleVariableToXml(XmlParser &xml_parser) : xml_parser_(xml_parser){};
 
     template <typename DataType>
-    void operator()(const std::string &variable_name, StdLargeVec<DataType> &variable) const;
+    void operator()(DataContainerAddressKeeper<DiscreteVariable<DataType>> &variables, ParticleData &all_particle_data) const;
 };
 
 /**

--- a/src/shared/particles/base_particles.hpp
+++ b/src/shared/particles/base_particles.hpp
@@ -325,6 +325,7 @@ operator()(DataContainerAddressKeeper<DiscreteVariable<DataType>> &variables, Pa
         for (auto child = xml_parser_.first_element_->FirstChildElement(); child; child = child->NextSiblingElement())
         {
             xml_parser_.setAttributeToElement(child, variables[i]->Name(), variable_data[index]);
+            index++;
         }
     }
 }

--- a/src/shared/particles/base_particles.hpp
+++ b/src/shared/particles/base_particles.hpp
@@ -235,6 +235,16 @@ operator()(ParticleData &particle_data, size_t index, size_t another_index) cons
             (*std::get<type_index>(particle_data)[i])[another_index];
 }
 //=================================================================================================//
+template <typename DataType>
+void BaseParticles::ResizeParticles::
+operator()(DataContainerAddressKeeper<StdLargeVec<DataType>> &data_keeper, size_t new_size)
+{
+    for (size_t i = 0; i != data_keeper.size(); ++i)
+    {
+        data_keeper[i]->resize(new_size, ZeroData<DataType>::value);
+    }
+}
+//=================================================================================================//
 template <typename StreamType>
 void BaseParticles::writeParticlesToVtk(StreamType &output_stream)
 {

--- a/src/shared/particles/base_particles.hpp
+++ b/src/shared/particles/base_particles.hpp
@@ -221,6 +221,40 @@ operator()(DataContainerAddressKeeper<StdLargeVec<DataType>> &data_keeper, size_
     }
 }
 //=================================================================================================//
+template <typename DataType>
+void BaseParticles::WriteAParticleVariableToXml::
+operator()(DataContainerAddressKeeper<DiscreteVariable<DataType>> &variables, ParticleData &all_particle_data)
+{
+    constexpr int type_index = DataTypeIndex<DataType>::value;
+    for (size_t i = 0; i != variables.size(); ++i)
+    {
+        size_t index = 0;
+        StdLargeVec<DataType> &variable_data = *(std::get<type_index>(all_particle_data)[variables[i]->IndexInContainer()]);
+        for (auto child = xml_parser_.first_element_->FirstChildElement(); child; child = child->NextSiblingElement())
+        {
+            xml_parser_.setAttributeToElement(child, variables[i]->Name(), variable_data[index]);
+            index++;
+        }
+    }
+}
+//=================================================================================================//
+template <typename DataType>
+void BaseParticles::ReadAParticleVariableFromXml::
+operator()(DataContainerAddressKeeper<DiscreteVariable<DataType>> &variables, ParticleData &all_particle_data)
+{
+    constexpr int type_index = DataTypeIndex<DataType>::value;
+    for (size_t i = 0; i != variables.size(); ++i)
+    {
+        size_t index = 0;
+        StdLargeVec<DataType> &variable_data = *(std::get<type_index>(all_particle_data)[variables[i]->IndexInContainer()]);
+        for (auto child = xml_parser_.first_element_->FirstChildElement(); child; child = child->NextSiblingElement())
+        {
+            xml_parser_.queryAttributeValue(child, variables[i]->Name(), variable_data[index]);
+            index++;
+        }
+    }
+}
+//=================================================================================================//
 template <typename StreamType>
 void BaseParticles::writeParticlesToVtk(StreamType &output_stream)
 {
@@ -310,37 +344,6 @@ void BaseParticles::writeParticlesToVtk(StreamType &output_stream)
         }
         output_stream << std::endl;
         output_stream << "    </DataArray>\n";
-    }
-}
-//=================================================================================================//
-template <typename DataType>
-void WriteAParticleVariableToXml::
-operator()(DataContainerAddressKeeper<DiscreteVariable<DataType>> &variables, ParticleData &all_particle_data) const
-{
-    constexpr int type_index = DataTypeIndex<DataType>::value;
-    for (size_t i = 0; i != variables.size(); ++i)
-    {
-        size_t index = 0;
-        StdLargeVec<DataType> &variable_data = *(std::get<type_index>(all_particle_data)[variables[i]->IndexInContainer()]);
-        for (auto child = xml_parser_.first_element_->FirstChildElement(); child; child = child->NextSiblingElement())
-        {
-            xml_parser_.setAttributeToElement(child, variables[i]->Name(), variable_data[index]);
-            index++;
-        }
-    }
-}
-//=================================================================================================//
-template <typename DataType>
-void ReadAParticleVariableFromXml::
-operator()(const std::string &variable_name, StdLargeVec<DataType> &variable) const
-{
-    size_t index = 0;
-    for (auto child = xml_parser_.first_element_->FirstChildElement();
-         child;
-         child = child->NextSiblingElement())
-    {
-        xml_parser_.queryAttributeValue(child, variable_name, variable[index]);
-        index++;
     }
 }
 //=================================================================================================//

--- a/src/shared/particles/particle_reserve.cpp
+++ b/src/shared/particles/particle_reserve.cpp
@@ -61,7 +61,7 @@ size_t Ghost<Base>::allocateGhostParticles(BaseParticles &base_particles, size_t
 {
     size_t ghost_lower_bound = base_particles.particles_bound_;
     base_particles.particles_bound_ += ghost_size;
-    base_particles.resize_particle_data_(base_particles.particles_bound_);
+    base_particles.resize_particles_(base_particles.particles_bound_);
     base_particles.unsorted_id_.resize(base_particles.particles_bound_, 0);
     return ghost_lower_bound;
 }

--- a/src/shared/particles/particle_reserve.cpp
+++ b/src/shared/particles/particle_reserve.cpp
@@ -35,7 +35,7 @@ void ParticleBuffer<Base>::allocateBufferParticles(BaseParticles &base_particles
     base_particles.increaseAllParticlesBounds(buffer_size);
     size_t new_bound = base_particles.real_particles_bound_;
 
-    base_particles.resize_particle_data_(new_bound);
+    base_particles.resize_particles_(new_bound);
     for (size_t i = old_bound; i != new_bound; ++i)
     {
         base_particles.unsorted_id_.push_back(i);

--- a/src/shared/particles/particle_sorting.cpp
+++ b/src/shared/particles/particle_sorting.cpp
@@ -11,7 +11,8 @@ namespace SPH
 SwapSortableParticleData::SwapSortableParticleData(BaseParticles &base_particles)
     : sequence_(base_particles.sequence_),
       unsorted_id_(base_particles.unsorted_id_),
-      sortable_data_(base_particles.sortable_data_) {}
+      sortable_data_(base_particles.sortable_data_),
+      swap_particle_data_value_(sortable_data_) {}
 //=================================================================================================//
 void SwapSortableParticleData::operator()(size_t *a, size_t *b)
 {
@@ -20,7 +21,7 @@ void SwapSortableParticleData::operator()(size_t *a, size_t *b)
     size_t index_a = a - sequence_.data();
     size_t index_b = b - sequence_.data();
     std::swap(unsorted_id_[index_a], unsorted_id_[index_b]);
-    swap_particle_data_value_(sortable_data_, index_a, index_b);
+    swap_particle_data_value_(index_a, index_b);
 }
 //=================================================================================================//
 ParticleSorting::ParticleSorting(BaseParticles &base_particles)

--- a/src/shared/particles/particle_sorting.h
+++ b/src/shared/particles/particle_sorting.h
@@ -198,17 +198,14 @@ namespace SPH
 {
 class BaseParticles;
 
-template <typename VariableType>
-struct swapParticleDataValue
+struct SwapParticleDataValue
 {
-    void operator()(ParticleData &particle_data, size_t index_a, size_t index_b) const
+    template <typename DataType>
+    void operator()(DataContainerAddressKeeper<StdLargeVec<DataType>> &data_keeper, size_t index_a, size_t index_b) const
     {
-        constexpr int type_index = DataTypeIndex<VariableType>::value;
-
-        StdVec<StdLargeVec<VariableType> *> variables = std::get<type_index>(particle_data);
-        for (size_t i = 0; i != variables.size(); ++i)
+        for (size_t i = 0; i != data_keeper.size(); ++i)
         {
-            StdLargeVec<VariableType> &variable = *variables[i];
+            StdLargeVec<DataType> &variable = *data_keeper[i];
             std::swap(variable[index_a], variable[index_b]);
         }
     };
@@ -236,7 +233,7 @@ class SwapSortableParticleData
     StdLargeVec<size_t> &sequence_;
     StdLargeVec<size_t> &unsorted_id_;
     ParticleData &sortable_data_;
-    DataAssembleOperation<swapParticleDataValue> swap_particle_data_value_;
+    OperationOnDataAssemble<ParticleData, SwapParticleDataValue> swap_particle_data_value_;
 
   public:
     explicit SwapSortableParticleData(BaseParticles &base_particles);


### PR DESCRIPTION
Try to used data assemble tuple explicitly only once so that we can easily add more data types.
This is not done for mesh data yet as they need new formulation on variable containers.  
