### PR TITLE
Add Docker Hub link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ SPHinXsys is cross-platform can be compiled and used in Windows, Linux and McOS 
 
 For installation, program manual and tutorials, please check <https://www.sphinxsys.org/html/sphinx_index.html>.
 Please check the documentation of the code at <https://xiangyu-hu.github.io/SPHinXsys/>.
+For a docker image, check <https://hub.docker.com/repository/docker/toshev/sphinxsys/general>.
 
 ## Get involved to SPHinXsys
 


### PR DESCRIPTION
The existing Dockerfile didn't work for me, so I created my own Docker image and uploaded it to Docker Hub. 
I also added detailed information on how the image was created: https://hub.docker.com/repository/docker/toshev/sphinxsys/general

I wasn't sure where to put my link, so I suggest putting it in the README, but I'm happy to move it somewhere else if you have suggestions.

Ultimately, this readily built image should save students 1.5h compilation time, at the cost of working with a fixed version (the one from 21.05.2021 for now). But with the detailed instructions on Docker Hub, it should be rather easy to rebuild the image whenever needed.