### PR TITLE
size_t also can be registered as discrete variable

### DIFF
--- a/src/shared/common/base_data_package.h
+++ b/src/shared/common/base_data_package.h
@@ -52,7 +52,8 @@ template <typename ContainedDataType>
 using DataContainerUniquePtrKeeper = UniquePtrsKeeper<ContainedDataType>;
 
 template <template <typename> typename KeeperType, template <typename> typename ContainerType>
-using DataAssemble = std::tuple<KeeperType<ContainerType<int>>,
+using DataAssemble = std::tuple<KeeperType<ContainerType<size_t>>,
+                                KeeperType<ContainerType<int>>,
                                 KeeperType<ContainerType<Real>>,
                                 KeeperType<ContainerType<Vec2d>>,
                                 KeeperType<ContainerType<Mat2d>>,

--- a/src/shared/common/base_data_type.h
+++ b/src/shared/common/base_data_type.h
@@ -138,34 +138,39 @@ struct DataTypeIndex
     static constexpr int value = std::numeric_limits<int>::max();
 };
 template <>
-struct DataTypeIndex<int>
+struct DataTypeIndex<size_t>
 {
     static constexpr int value = 0;
 };
 template <>
-struct DataTypeIndex<Real>
+struct DataTypeIndex<int>
 {
     static constexpr int value = 1;
 };
 template <>
-struct DataTypeIndex<Vec2d>
+struct DataTypeIndex<Real>
 {
     static constexpr int value = 2;
 };
 template <>
-struct DataTypeIndex<Mat2d>
+struct DataTypeIndex<Vec2d>
 {
     static constexpr int value = 3;
 };
 template <>
-struct DataTypeIndex<Vec3d>
+struct DataTypeIndex<Mat2d>
 {
     static constexpr int value = 4;
 };
 template <>
-struct DataTypeIndex<Mat3d>
+struct DataTypeIndex<Vec3d>
 {
     static constexpr int value = 5;
+};
+template <>
+struct DataTypeIndex<Mat3d>
+{
+    static constexpr int value = 6;
 };
 
 /** Verbal boolean for positive and negative axis directions. */

--- a/src/shared/io_system/io_base.cpp
+++ b/src/shared/io_system/io_base.cpp
@@ -52,9 +52,14 @@ RestartIO::RestartIO(SPHSystem &sph_system)
     : BaseIO(sph_system), bodies_(sph_system.getRealBodies()),
       overall_file_path_(io_environment_.restart_folder_ + "/Restart_time_")
 {
-    std::transform(bodies_.begin(), bodies_.end(), std::back_inserter(file_names_),
-                   [&](SPHBody *body) -> std::string
-                   { return io_environment_.restart_folder_ + "/" + body->getName() + "_rst_"; });
+    for (size_t i = 0; i < bodies_.size(); ++i)
+    {
+        file_names_.push_back(io_environment_.restart_folder_ + "/" + bodies_[i]->getName() + "_rst_");
+
+        // basic variable for write to restart file
+        BaseParticles &particles = bodies_[i]->getBaseParticles();
+        particles.addVariableToRestart<size_t>("OriginalID");
+    }
 }
 //=============================================================================================//
 void RestartIO::writeToFile(size_t iteration_step)

--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -18,7 +18,7 @@ BaseParticles::BaseParticles(SPHBody &sph_body, BaseMaterial *base_material)
       base_material_(*base_material),
       restart_xml_parser_("xml_restart", "particles"),
       reload_xml_parser_("xml_particle_reload", "particles"),
-      copy_particle_data_(all_state_data_),
+      copy_particle_state_(all_state_data_),
       write_restart_variable_to_xml_(variables_to_restart_, restart_xml_parser_),
       write_reload_variable_to_xml_(variables_to_reload_, reload_xml_parser_),
       read_restart_variable_from_xml_(variables_to_restart_, restart_xml_parser_)
@@ -80,7 +80,7 @@ void BaseParticles::increaseAllParticlesBounds(size_t buffer_size)
 //=================================================================================================//
 void BaseParticles::copyFromAnotherParticle(size_t index, size_t another_index)
 {
-    copy_particle_data_(index, another_index);
+    copy_particle_state_(index, another_index);
 }
 //=================================================================================================//
 size_t BaseParticles::allocateGhostParticles(size_t ghost_size)

--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -18,7 +18,7 @@ BaseParticles::BaseParticles(SPHBody &sph_body, BaseMaterial *base_material)
       base_material_(*base_material),
       restart_xml_parser_("xml_restart", "particles"),
       reload_xml_parser_("xml_particle_reload", "particles"),
-      copy_particle_data_(all_particle_data_),
+      copy_particle_data_(all_state_data_),
       write_restart_variable_to_xml_(variables_to_restart_, restart_xml_parser_),
       write_reload_variable_to_xml_(variables_to_reload_, reload_xml_parser_),
       read_restart_variable_from_xml_(variables_to_restart_, restart_xml_parser_)
@@ -38,13 +38,11 @@ void BaseParticles::initializeBasicParticleVariables()
     //----------------------------------------------------------------------
     //		unregistered variables and data
     //----------------------------------------------------------------------
-    original_id_ = addUnregisteredVariable("OriginalID",
-                                           [&](size_t i) -> size_t
-                                           { return i; });
-    sorted_id_ = addUnregisteredVariable("SortedID",
-                                         [&](size_t i) -> size_t
-                                         { return i; });
-    sequence_ = addUnregisteredVariable("Sequence");
+    original_id_ = registerSharedVariable<size_t>("OriginalID",
+                                                  [&](size_t i) -> size_t
+                                                  { return i; });
+    sorted_id_ = registerSharedVariableFrom<size_t>("SortedID", "OriginalID");
+    sequence_ = registerSharedVariable<size_t>("Sequence");
     particle_sorting_ = particle_sort_ptr_keeper_.createPtr<ParticleSorting>(*this);
 }
 //=================================================================================================//

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -233,7 +233,7 @@ class BaseParticles
     // assembled variables and data sets
     //----------------------------------------------------------------------
   protected:
-    struct CopyParticleData
+    struct CopyParticleState
     {
         template <typename DataType>
         void operator()(DataContainerAddressKeeper<StdLargeVec<DataType>> &data_keeper, size_t index, size_t another_index);
@@ -257,7 +257,7 @@ class BaseParticles
         void operator()(DataContainerAddressKeeper<DiscreteVariable<DataType>> &variables, BaseParticles *base_particles);
     };
 
-    OperationOnDataAssemble<ParticleData, CopyParticleData> copy_particle_data_;
+    OperationOnDataAssemble<ParticleData, CopyParticleState> copy_particle_state_;
     OperationOnDataAssemble<ParticleVariables, WriteAParticleVariableToXml> write_restart_variable_to_xml_, write_reload_variable_to_xml_;
     OperationOnDataAssemble<ParticleVariables, ReadAParticleVariableFromXml> read_restart_variable_from_xml_;
 };

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -83,7 +83,6 @@ class BaseParticles
   private:
     DataContainerUniquePtrAssemble<DiscreteVariable> all_discrete_variable_ptrs_;
     DataContainerUniquePtrAssemble<SingleVariable> all_global_variable_ptrs_;
-    UniquePtrsKeeper<DiscreteVariable<size_t>> unregistered_variable_ptrs_;
     UniquePtrKeeper<ParticleSorting> particle_sort_ptr_keeper_;
 
   public:
@@ -175,9 +174,6 @@ class BaseParticles
     ParticleVariables sortable_variables_;
     ParticleSorting *particle_sorting_;
 
-    template <typename... Args>
-    StdLargeVec<size_t> *addUnregisteredVariable(const std::string &name, Args &&...args);
-
   public:
     template <typename DataType>
     void addVariableToSort(const std::string &name);
@@ -222,7 +218,7 @@ class BaseParticles
     BaseMaterial &base_material_;
     XmlParser restart_xml_parser_;
     XmlParser reload_xml_parser_;
-    ParticleData all_particle_data_;
+    ParticleData all_state_data_; /**< all discrete variable data except those on particle IDs  */
     ParticleVariables all_discrete_variables_;
     SingleVariables all_single_variables_;
     ParticleVariables variables_to_write_;

--- a/src/shared/particles/base_particles.hpp
+++ b/src/shared/particles/base_particles.hpp
@@ -204,16 +204,13 @@ DiscreteVariable<DataType> *BaseParticles::
 template <typename DataType>
 void BaseParticles::addVariableToSort(const std::string &name)
 {
-    constexpr int type_index = DataTypeIndex<DataType>::value;
-    if (type_index != DataTypeIndex<size_t>::value) // particle IDs excluded
+    DiscreteVariable<DataType> *new_sortable =
+        addVariableToList<DataType>(sortable_variables_, name);
+    if (new_sortable != nullptr)
     {
-        DiscreteVariable<DataType> *new_sortable =
-            addVariableToList<DataType>(sortable_variables_, name);
-        if (new_sortable != nullptr)
-        {
-            StdLargeVec<DataType> *variable_data = new_sortable->DataField();
-            std::get<type_index>(sortable_data_).push_back(variable_data);
-        }
+        constexpr int type_index = DataTypeIndex<DataType>::value;
+        StdLargeVec<DataType> *variable_data = new_sortable->DataField();
+        std::get<type_index>(sortable_data_).push_back(variable_data);
     }
 }
 //=================================================================================================//

--- a/src/shared/particles/base_particles.hpp
+++ b/src/shared/particles/base_particles.hpp
@@ -243,7 +243,7 @@ void BaseParticles::sortParticles(SequenceMethod &sequence_method)
 }
 //=================================================================================================//
 template <typename DataType>
-void BaseParticles::CopyParticleData::
+void BaseParticles::CopyParticleState::
 operator()(DataContainerAddressKeeper<StdLargeVec<DataType>> &data_keeper, size_t index, size_t another_index)
 {
     for (size_t i = 0; i != data_keeper.size(); ++i)

--- a/src/shared/particles/particle_sorting.cpp
+++ b/src/shared/particles/particle_sorting.cpp
@@ -10,7 +10,6 @@ namespace SPH
 //=================================================================================================//
 SwapSortableParticleData::SwapSortableParticleData(BaseParticles &base_particles)
     : sequence_(base_particles.ParticleSequences()),
-      original_id_(base_particles.ParticleOriginalIds()),
       sortable_data_(base_particles.SortableParticleData()),
       swap_particle_data_value_(sortable_data_) {}
 //=================================================================================================//
@@ -20,7 +19,6 @@ void SwapSortableParticleData::operator()(size_t *a, size_t *b)
 
     size_t index_a = a - sequence_.data();
     size_t index_b = b - sequence_.data();
-    std::swap(original_id_[index_a], original_id_[index_b]);
     swap_particle_data_value_(index_a, index_b);
 }
 //=================================================================================================//
@@ -31,7 +29,10 @@ ParticleSorting::ParticleSorting(BaseParticles &base_particles)
       sequence_(base_particles.ParticleSequences()),
       swap_sortable_particle_data_(base_particles), compare_(),
       quick_sort_particle_range_(sequence_.data(), 0, compare_, swap_sortable_particle_data_),
-      quick_sort_particle_body_() {}
+      quick_sort_particle_body_()
+{
+    base_particles.addVariableToSort<size_t>("OriginalID");
+}
 //=================================================================================================//
 void ParticleSorting::sortingParticleData(size_t *begin, size_t size)
 {

--- a/src/shared/particles/particle_sorting.h
+++ b/src/shared/particles/particle_sorting.h
@@ -231,7 +231,6 @@ class SwapSortableParticleData
 {
   protected:
     StdLargeVec<size_t> &sequence_;
-    StdLargeVec<size_t> &original_id_;
     ParticleData &sortable_data_;
     OperationOnDataAssemble<ParticleData, SwapParticleDataValue> swap_particle_data_value_;
 


### PR DESCRIPTION
The only difference with other variables is size_t variables, i.e. sequence, original id, sorted id will not included in all state variable as they should not be copied when copy the state of one particle to another.   