### PR TITLE
Contact stiffness composite body

### DIFF
--- a/src/shared/materials/base_material.h
+++ b/src/shared/materials/base_material.h
@@ -113,6 +113,7 @@ class Solid : public BaseMaterial
 
     Real ContactFriction() { return contact_friction_; };
     Real ContactStiffness() { return contact_stiffness_; };
+    virtual Real ContactStiffness(size_t index_i) { return contact_stiffness_; };
     virtual Solid *ThisObjectPtr() override { return this; };
     /** Get average velocity when interacting with fluid. */
     virtual StdLargeVec<Vecd> *AverageVelocity(BaseParticles *base_particles);

--- a/src/shared/materials/complex_solid.cpp
+++ b/src/shared/materials/complex_solid.cpp
@@ -36,6 +36,11 @@ Real CompositeSolid::CompositeDensity(size_t index_i)
     return composite_materials_[(*material_id_)[index_i]]->ReferenceDensity();
 }
 //=================================================================================================//
+Real CompositeSolid::ContactStiffness(size_t index_i)
+{
+    return composite_materials_[(*material_id_)[index_i]]->ContactStiffness();
+}
+//=================================================================================================//
 void CompositeSolid::initializeLocalParameters(BaseParticles *base_particles)
 {
     ElasticSolid::initializeLocalParameters(base_particles);

--- a/src/shared/materials/complex_solid.h
+++ b/src/shared/materials/complex_solid.h
@@ -78,6 +78,8 @@ class CompositeSolid : public ElasticSolid
     virtual Real VolumetricKirchhoff(Real J) override { return 0.0; };
     virtual std::string getRelevantStressMeasureName() override { return "PK2"; };
 
+    Real ContactStiffness(size_t index_i) override;
+
     Real CompositeDensity(size_t index_i);
 
     template <class ElasticSolidType, typename... Args>

--- a/src/shared/particle_dynamics/solid_dynamics/contact_dynamics/contact_repulsion.h
+++ b/src/shared/particle_dynamics/solid_dynamics/contact_dynamics/contact_repulsion.h
@@ -86,7 +86,6 @@ class RepulsionForce<Contact<>> : public RepulsionForce<Base, DataDelegateContac
     Solid &solid_;
     StdLargeVec<Real> &repulsion_factor_;
     StdVec<Solid *> contact_solids_;
-    StdVec<Real> contact_stiffness_ave_;
     StdVec<StdLargeVec<Real> *> contact_repulsion_factor_, contact_Vol_;
 };
 using ContactForce = RepulsionForce<Contact<>>;


### PR DESCRIPTION
I added a function `Real ContactStiffness(size_t index_i)` in `Solid`. For composite material, it will return `composite_materials_[(*material_id_)[index_i]]->ContactStiffness();`.

In `RepulsionForce`, `solid_material->ContactStiffness()` is replaced by `solid_material->ContactStiffness(index_i)`.

I think the contact impedance of self-contact also needs to be modified. How should be calculate the impedance between particle i and j with different rho and contact stiffness?