### PR TITLE
Rkcg for open boundary flow pull request

### DIFF
--- a/src/shared/particle_dynamics/fluid_dynamics/density_summation.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/density_summation.h
@@ -142,10 +142,10 @@ struct FreeStream
 {
     Real operator()(Real rho_sum, Real rho0, Real rho)
     {
-        //if (rho_sum < rho)
-        //{
-        //    return rho_sum + SMAX(Real(0), (rho - rho_sum)) * rho0 / rho;
-        //}
+        if (rho_sum < rho)
+        {
+            return rho_sum + SMAX(Real(0), (rho - rho_sum)) * rho0 / rho;
+        }
         return rho_sum;
     };
 };

--- a/src/shared/particle_dynamics/fluid_dynamics/density_summation.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/density_summation.h
@@ -144,8 +144,7 @@ struct FreeStream
     {
         if (rho_sum < rho)
         {
-            //return rho_sum + SMAX(Real(0), (rho - rho_sum)) * rho0 / rho;
-            return rho;
+            return rho_sum + SMAX(Real(0), (rho - rho_sum)) * rho0 / rho;
         }
         return rho_sum;
     };

--- a/src/shared/particle_dynamics/fluid_dynamics/density_summation.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/density_summation.h
@@ -142,10 +142,10 @@ struct FreeStream
 {
     Real operator()(Real rho_sum, Real rho0, Real rho)
     {
-        if (rho_sum < rho)
-        {
-            return rho_sum + SMAX(Real(0), (rho - rho_sum)) * rho0 / rho;
-        }
+        //if (rho_sum < rho)
+        //{
+        //    return rho_sum + SMAX(Real(0), (rho - rho_sum)) * rho0 / rho;
+        //}
         return rho_sum;
     };
 };

--- a/src/shared/particle_dynamics/fluid_dynamics/density_summation.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/density_summation.h
@@ -144,7 +144,8 @@ struct FreeStream
     {
         if (rho_sum < rho)
         {
-            return rho_sum + SMAX(Real(0), (rho - rho_sum)) * rho0 / rho;
+            //return rho_sum + SMAX(Real(0), (rho - rho_sum)) * rho0 / rho;
+            return rho;
         }
         return rho_sum;
     };

--- a/src/shared/particle_dynamics/fluid_dynamics/density_summation.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/density_summation.hpp
@@ -43,6 +43,8 @@ void DensitySummation<Inner<NearSurfaceType, SummationType...>>::update(size_t i
         isNearFreeSurface(index_i)
             ? near_surface_rho_(this->rho_sum_[index_i], this->rho0_, this->rho_[index_i])
             : this->rho_sum_[index_i];
+    //** Temporary treatment *
+    this->Vol_[index_i] = this->mass_[index_i] / this->rho_[index_i];
 }
 //=================================================================================================//
 template <typename NearSurfaceType, typename... SummationType>

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_integration.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_integration.h
@@ -143,6 +143,7 @@ using Integration1stHalfWithWall = ComplexInteraction<Integration1stHalf<Inner<>
 using Integration1stHalfWithWallNoRiemann = Integration1stHalfWithWall<NoRiemannSolver, NoKernelCorrection>;
 using Integration1stHalfWithWallRiemann = Integration1stHalfWithWall<AcousticRiemannSolver, NoKernelCorrection>;
 using Integration1stHalfCorrectionWithWallRiemann = Integration1stHalfWithWall<AcousticRiemannSolver, LinearGradientCorrection>;
+using Integration1stHalfCorrectionForOpenBoundaryFlowWithWallRiemann = Integration1stHalfWithWall<AcousticRiemannSolver, LinearGradientCorrectionWithBulkScope>;
 
 using MultiPhaseIntegration1stHalfWithWallRiemann =
     ComplexInteraction<Integration1stHalf<Inner<>, Contact<>, Contact<Wall>>, AcousticRiemannSolver, NoKernelCorrection>;

--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_integration.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_integration.hpp
@@ -84,7 +84,7 @@ void Integration1stHalf<Inner<>, RiemannSolverType, KernelCorrectionType>::inter
         Real dW_ijV_j = inner_neighborhood.dW_ij_[n] * Vol_[index_j];
         const Vecd &e_ij = inner_neighborhood.e_ij_[n];
 
-        force -= (p_[index_i] * correction_(index_j) + p_[index_j] * correction_(index_i)) * dW_ijV_j * e_ij;
+        force -= (p_[index_i] * correction_(index_j, index_i) + p_[index_j] * correction_(index_i)) * dW_ijV_j * e_ij;
         rho_dissipation += riemann_solver_.DissipativeUJump(p_[index_i] - p_[index_j]) * dW_ijV_j;
     }
     force_[index_i] += force * Vol_[index_i];

--- a/src/shared/particle_dynamics/fluid_dynamics/transport_velocity_correction.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/transport_velocity_correction.h
@@ -128,6 +128,10 @@ using TransportVelocityCorrectionCorrectedForOpenBoundaryFlowComplex =
     BaseTransportVelocityCorrectionComplex<SingleResolution, NoLimiter, LinearGradientCorrectionWithBulkScope, ParticleScope>;
 
 template <class ParticleScope>
+using TransportVelocityLimitedCorrectionCorrectedForOpenBoundaryFlowComplex =
+    BaseTransportVelocityCorrectionComplex<SingleResolution, TruncatedLinear, LinearGradientCorrectionWithBulkScope, ParticleScope>;
+
+template <class ParticleScope>
 using TransportVelocityLimitedCorrectionComplex =
     BaseTransportVelocityCorrectionComplex<SingleResolution, TruncatedLinear, NoKernelCorrection, ParticleScope>;
 

--- a/src/shared/particle_dynamics/fluid_dynamics/transport_velocity_correction.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/transport_velocity_correction.h
@@ -124,6 +124,10 @@ using TransportVelocityCorrectionCorrectedComplex =
     BaseTransportVelocityCorrectionComplex<SingleResolution, NoLimiter, LinearGradientCorrection, ParticleScope>;
 
 template <class ParticleScope>
+using TransportVelocityCorrectionCorrectedForOpenBoundaryFlowComplex =
+    BaseTransportVelocityCorrectionComplex<SingleResolution, NoLimiter, LinearGradientCorrectionWithBulkScope, ParticleScope>;
+
+template <class ParticleScope>
 using TransportVelocityLimitedCorrectionComplex =
     BaseTransportVelocityCorrectionComplex<SingleResolution, TruncatedLinear, NoKernelCorrection, ParticleScope>;
 

--- a/src/shared/particle_dynamics/fluid_dynamics/transport_velocity_correction.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/transport_velocity_correction.hpp
@@ -45,7 +45,7 @@ void TransportVelocityCorrection<Inner<ResolutionType, LimiterType>, CommonContr
         {
             size_t index_j = inner_neighborhood.j_[n];
             // acceleration for transport velocity
-            inconsistency -= (this->kernel_correction_(index_i) + this->kernel_correction_(index_j)) *
+            inconsistency -= (this->kernel_correction_(index_i) + this->kernel_correction_(index_j, index_i)) *
                              inner_neighborhood.dW_ij_[n] * this->Vol_[index_j] * inner_neighborhood.e_ij_[n];
         }
         this->zero_gradient_residue_[index_i] = inconsistency;

--- a/src/shared/particle_dynamics/particle_functors.h
+++ b/src/shared/particle_dynamics/particle_functors.h
@@ -186,7 +186,12 @@ class NoKernelCorrection : public KernelCorrection
 {
   public:
     NoKernelCorrection(BaseParticles *particles) : KernelCorrection(){};
-    Real operator()(size_t index_i, size_t index_j = 0)
+    Real operator()(size_t index_i, size_t index_j)
+    {
+        return 1.0;
+    };
+
+    Real operator()(size_t index_i)
     {
         return 1.0;
     };
@@ -199,7 +204,12 @@ class LinearGradientCorrection : public KernelCorrection
         : KernelCorrection(),
           B_(*particles->getVariableDataByName<Matd>("LinearGradientCorrectionMatrix")){};
 
-    Matd operator()(size_t index_i, size_t index_j = 0)
+    Matd operator()(size_t index_i, size_t index_j)
+    {
+        return B_[index_i];
+    };
+
+    Matd operator()(size_t index_i)
     {
         return B_[index_i];
     };

--- a/src/shared/particle_dynamics/particle_functors.h
+++ b/src/shared/particle_dynamics/particle_functors.h
@@ -186,7 +186,7 @@ class NoKernelCorrection : public KernelCorrection
 {
   public:
     NoKernelCorrection(BaseParticles *particles) : KernelCorrection(){};
-    Real operator()(size_t index_i)
+    Real operator()(size_t index_i, size_t index_j = 0)
     {
         return 1.0;
     };
@@ -199,6 +199,28 @@ class LinearGradientCorrection : public KernelCorrection
         : KernelCorrection(),
           B_(*particles->getVariableDataByName<Matd>("LinearGradientCorrectionMatrix")){};
 
+    Matd operator()(size_t index_i, size_t index_j = 0)
+    {
+        return B_[index_i];
+    };
+
+  protected:
+    StdLargeVec<Matd> &B_;
+};
+
+class LinearGradientCorrectionWithBulkScope : public KernelCorrection
+{
+  public:
+    LinearGradientCorrectionWithBulkScope(BaseParticles *particles)
+        : KernelCorrection(),
+          B_(*particles->getVariableDataByName<Matd>("LinearGradientCorrectionMatrix")),
+          within_scope_(particles){};
+
+    Matd operator()(size_t index_j, size_t index_i)
+    {
+        return within_scope_(index_j) ? B_[index_j] : B_[index_i];
+    };
+
     Matd operator()(size_t index_i)
     {
         return B_[index_i];
@@ -206,6 +228,7 @@ class LinearGradientCorrection : public KernelCorrection
 
   protected:
     StdLargeVec<Matd> &B_;
+    BulkParticles within_scope_;
 };
 
 class SingleResolution

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/density_correciton.h
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/density_correciton.h
@@ -70,7 +70,7 @@ class DensitySummationPressure<Inner<>> : public DensitySummationPressure<Inner<
   public:
     explicit DensitySummationPressure(BaseInnerRelation &inner_relation)
         : DensitySummationPressure<Inner<Base>>(inner_relation),
-          buffer_particle_indicator_(*particles_->getVariableDataByName<int>("Indicator")){};
+          buffer_particle_indicator_(*particles_->getVariableDataByName<int>("BufferParticleIndicator")){};
     virtual ~DensitySummationPressure(){};
     void interaction(size_t index_i, Real dt = 0.0);
     void update(size_t index_i, Real dt = 0.0)

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/density_correciton.h
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/density_correciton.h
@@ -48,7 +48,7 @@ class DensitySummationPressure<Base, DataDelegationType>
     virtual ~DensitySummationPressure(){};
 
   protected:
-    StdLargeVec<Real> &rho_, &mass_, &rho_sum_;
+    StdLargeVec<Real> &rho_, &mass_, &rho_sum_, &Vol_;
     Real rho0_, inv_sigma0_, W0_;
 };
 
@@ -77,6 +77,8 @@ class DensitySummationPressure<Inner<>> : public DensitySummationPressure<Inner<
     {
         if (buffer_particle_indicator_[index_i] == 0)
             assignDensity(index_i);
+        //** Temporary treatment *
+        this->Vol_[index_i] = this->mass_[index_i] / this->rho_[index_i];
     };
 
   protected:

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/density_correciton.h
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/density_correciton.h
@@ -70,7 +70,7 @@ class DensitySummationPressure<Inner<>> : public DensitySummationPressure<Inner<
   public:
     explicit DensitySummationPressure(BaseInnerRelation &inner_relation)
         : DensitySummationPressure<Inner<Base>>(inner_relation),
-          buffer_particle_indicator_(*particles_->getVariableDataByName<int>("BufferParticleIndicator")){};
+          buffer_particle_indicator_(*particles_->getVariableDataByName<int>("Indicator")){};
     virtual ~DensitySummationPressure(){};
     void interaction(size_t index_i, Real dt = 0.0);
     void update(size_t index_i, Real dt = 0.0)

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/density_correciton.hpp
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/density_correciton.hpp
@@ -13,6 +13,7 @@ DensitySummationPressure<Base, DataDelegationType>::DensitySummationPressure(Bas
       rho_(*this->particles_->template getVariableDataByName<Real>("Density")),
       mass_(*this->particles_->template getVariableDataByName<Real>("Mass")),
       rho_sum_(*this->particles_->template registerSharedVariable<Real>("DensitySummation")),
+      Vol_(*this->particles_->template getVariableDataByName<Real>("VolumetricMeasure")),
       rho0_(this->sph_body_.base_material_->ReferenceDensity()),
       inv_sigma0_(1.0 / this->sph_body_.sph_adaptation_->LatticeNumberDensity()),
       W0_(this->sph_body_.sph_adaptation_->getKernel()->W0(ZeroVecd)) {}

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/pressure_boundary.h
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/pressure_boundary.h
@@ -47,13 +47,15 @@ class PressureCondition : public BaseFlowBoundaryCondition
           alignment_axis_(aligned_box_.AlignmentAxis()),
           transform_(aligned_box_.getTransform()),
           target_pressure_(*this),
-          kernel_sum_(*particles_->getVariableDataByName<Vecd>("KernelSummation")){};
+          kernel_sum_(*particles_->getVariableDataByName<Vecd>("KernelSummation")),
+          B_(*particles_->getVariableDataByName<Matd>("LinearGradientCorrectionMatrix")){};
     virtual ~PressureCondition(){};
     AlignedBoxShape &getAlignedBox() { return aligned_box_; };
 
     void update(size_t index_i, Real dt = 0.0)
     {
-        vel_[index_i] += 2.0 * kernel_sum_[index_i] * target_pressure_(p_[index_i]) / rho_[index_i] * dt;
+        //vel_[index_i] += 2.0 * kernel_sum_[index_i] * target_pressure_(p_[index_i]) / rho_[index_i] * dt;
+        vel_[index_i] += 2.0 * B_[index_i] * kernel_sum_[index_i] * target_pressure_(p_[index_i]) / rho_[index_i] * dt;
 
         Vecd frame_velocity = Vecd::Zero();
         frame_velocity[alignment_axis_] = transform_.xformBaseVecToFrame(vel_[index_i])[alignment_axis_];
@@ -66,6 +68,7 @@ class PressureCondition : public BaseFlowBoundaryCondition
     Transform &transform_;
     TargetPressure target_pressure_;
     StdLargeVec<Vecd> &kernel_sum_;
+    StdLargeVec<Matd> &B_;
 };
 } // namespace fluid_dynamics
 } // namespace SPH

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/pressure_boundary.h
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/pressure_boundary.h
@@ -36,26 +36,26 @@ namespace SPH
 {
 namespace fluid_dynamics
 {
-template <typename TargetPressure>
-class PressureCondition : public BaseFlowBoundaryCondition
+template <typename TargetPressure, class KernelCorrectionType>
+class PressureBoundaryCondition : public BaseFlowBoundaryCondition
 {
   public:
     /** default parameter indicates prescribe pressure */
-    explicit PressureCondition(BodyAlignedBoxByCell &aligned_box_part)
+    explicit PressureBoundaryCondition(BodyAlignedBoxByCell &aligned_box_part)
         : BaseFlowBoundaryCondition(aligned_box_part),
           aligned_box_(aligned_box_part.getAlignedBoxShape()),
           alignment_axis_(aligned_box_.AlignmentAxis()),
           transform_(aligned_box_.getTransform()),
           target_pressure_(*this),
           kernel_sum_(*particles_->getVariableDataByName<Vecd>("KernelSummation")),
-          B_(*particles_->getVariableDataByName<Matd>("LinearGradientCorrectionMatrix")){};
-    virtual ~PressureCondition(){};
+          kernel_correction_(this->particles_){};
+    virtual ~PressureBoundaryCondition(){};
     AlignedBoxShape &getAlignedBox() { return aligned_box_; };
 
     void update(size_t index_i, Real dt = 0.0)
     {
         //vel_[index_i] += 2.0 * kernel_sum_[index_i] * target_pressure_(p_[index_i]) / rho_[index_i] * dt;
-        vel_[index_i] += 2.0 * B_[index_i] * kernel_sum_[index_i] * target_pressure_(p_[index_i]) / rho_[index_i] * dt;
+        vel_[index_i] += 2.0 * kernel_correction_(index_i) * kernel_sum_[index_i] * target_pressure_(p_[index_i]) / rho_[index_i] * dt;
 
         Vecd frame_velocity = Vecd::Zero();
         frame_velocity[alignment_axis_] = transform_.xformBaseVecToFrame(vel_[index_i])[alignment_axis_];
@@ -68,8 +68,15 @@ class PressureCondition : public BaseFlowBoundaryCondition
     Transform &transform_;
     TargetPressure target_pressure_;
     StdLargeVec<Vecd> &kernel_sum_;
-    StdLargeVec<Matd> &B_;
+    KernelCorrectionType kernel_correction_;
 };
+
+template <typename TargetPressure>
+using PressureCondition = PressureBoundaryCondition<TargetPressure, NoKernelCorrection>;
+
+template <typename TargetPressure>
+using PressureConditionCorrection = PressureBoundaryCondition<TargetPressure, LinearGradientCorrection>;
+
 } // namespace fluid_dynamics
 } // namespace SPH
 #endif // PRESSURE_BOUNDARY_H

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -188,10 +188,15 @@ int main(int ac, char *av[])
     InteractionDynamics<NablaWVComplex> kernel_summation(water_block_inner, water_block_contact);
     InteractionWithUpdate<SpatialTemporalFreeSurfaceIndicationComplex> boundary_indicator(water_block_inner, water_block_contact);
 
-    Dynamics1Level<fluid_dynamics::Integration1stHalfWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    InteractionWithUpdate<LinearGradientCorrectionMatrixComplex> corrected_configuration_fluid(water_block_inner, water_block_contact);
+    //Dynamics1Level<fluid_dynamics::Integration1stHalfWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    
     Dynamics1Level<fluid_dynamics::Integration2ndHalfWithWallRiemann> density_relaxation(water_block_inner, water_block_contact);
     InteractionWithUpdate<fluid_dynamics::ViscousForceWithWall> viscous_acceleration(water_block_inner, water_block_contact);
-    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    
+    //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
 
     ReduceDynamics<fluid_dynamics::AdvectionTimeStepSize> get_fluid_advection_time_step_size(water_block, U_f);
     ReduceDynamics<fluid_dynamics::AcousticTimeStepSize> get_fluid_time_step_size(water_block);
@@ -264,6 +269,9 @@ int main(int ac, char *av[])
             time_instance = TickCount::now();
             Real Dt = get_fluid_advection_time_step_size.exec();
             update_fluid_density.exec();
+            
+            corrected_configuration_fluid.exec();
+            
             viscous_acceleration.exec();
             transport_velocity_correction.exec();
             interval_computing_time_step += TickCount::now() - time_instance;

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -213,8 +213,8 @@ int main(int ac, char *av[])
     BodyAlignedBoxByCell right_emitter(water_block, makeShared<AlignedBoxShape>(xAxis, Transform(Rotation2d(Pi), Vec2d(right_bidirectional_translation)), bidirectional_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<RightInflowPressure> right_emitter_inflow_injection(right_emitter, in_outlet_particle_buffer);
 
-    InteractionWithUpdate<fluid_dynamics::DensitySummationPressureComplex> update_fluid_density(water_block_inner, water_block_contact);
-    //InteractionWithUpdate<fluid_dynamics::DensitySummationFreeStreamComplex> update_fluid_density(water_block_inner, water_block_contact);
+    //InteractionWithUpdate<fluid_dynamics::DensitySummationPressureComplex> update_fluid_density(water_block_inner, water_block_contact);
+    InteractionWithUpdate<fluid_dynamics::DensitySummationFreeStreamComplex> update_fluid_density(water_block_inner, water_block_contact);
     
     SimpleDynamics<fluid_dynamics::PressureCondition<LeftInflowPressure>> left_inflow_pressure_condition(left_emitter);
     SimpleDynamics<fluid_dynamics::PressureCondition<RightInflowPressure>> right_inflow_pressure_condition(right_emitter);

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -26,7 +26,7 @@ BoundingBox system_domain_bounds(Vec2d(-BW, -BW), Vec2d(DL + BW, DH + BW));
 //	Material parameters.
 //----------------------------------------------------------------------
 Real Inlet_pressure = 0.2;
-Real Outlet_pressure = 0.0;
+Real Outlet_pressure = 0.1;
 Real rho0_f = 1000.0;
 Real Re = 50.0;
 Real mu_f = sqrt(rho0_f * pow(0.5 * DH, 3.0) * fabs(Inlet_pressure - Outlet_pressure) / (Re * DL));
@@ -190,16 +190,16 @@ int main(int ac, char *av[])
 
     InteractionWithUpdate<LinearGradientCorrectionMatrixComplex> corrected_configuration_fluid(water_block_inner, water_block_contact);
     
-    Dynamics1Level<fluid_dynamics::Integration1stHalfWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    //Dynamics1Level<fluid_dynamics::Integration1stHalfWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
     //Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
-    //Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionForOpenBoundaryFlowWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionForOpenBoundaryFlowWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
     
     Dynamics1Level<fluid_dynamics::Integration2ndHalfWithWallRiemann> density_relaxation(water_block_inner, water_block_contact);
     InteractionWithUpdate<fluid_dynamics::ViscousForceWithWall> viscous_acceleration(water_block_inner, water_block_contact);
     
-    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
     //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
-    //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedForOpenBoundaryFlowComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedForOpenBoundaryFlowComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
 
     ReduceDynamics<fluid_dynamics::AdvectionTimeStepSize> get_fluid_advection_time_step_size(water_block, U_f);
     ReduceDynamics<fluid_dynamics::AcousticTimeStepSize> get_fluid_time_step_size(water_block);

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -196,7 +196,8 @@ int main(int ac, char *av[])
     InteractionWithUpdate<fluid_dynamics::ViscousForceWithWall> viscous_acceleration(water_block_inner, water_block_contact);
     
     //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
-    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedForOpenBoundaryFlowComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
 
     ReduceDynamics<fluid_dynamics::AdvectionTimeStepSize> get_fluid_advection_time_step_size(water_block, U_f);
     ReduceDynamics<fluid_dynamics::AcousticTimeStepSize> get_fluid_time_step_size(water_block);

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -215,9 +215,12 @@ int main(int ac, char *av[])
 
     InteractionWithUpdate<fluid_dynamics::DensitySummationPressureComplex> update_fluid_density(water_block_inner, water_block_contact);
     //InteractionWithUpdate<fluid_dynamics::DensitySummationFreeStreamComplex> update_fluid_density(water_block_inner, water_block_contact);
+
+    //SimpleDynamics<fluid_dynamics::PressureCondition<LeftInflowPressure>> left_inflow_pressure_condition(left_emitter);
+    //SimpleDynamics<fluid_dynamics::PressureCondition<RightInflowPressure>> right_inflow_pressure_condition(right_emitter);
+    SimpleDynamics<fluid_dynamics::PressureConditionCorrection<LeftInflowPressure>> left_inflow_pressure_condition(left_emitter);
+    SimpleDynamics<fluid_dynamics::PressureConditionCorrection<RightInflowPressure>> right_inflow_pressure_condition(right_emitter);
     
-    SimpleDynamics<fluid_dynamics::PressureCondition<LeftInflowPressure>> left_inflow_pressure_condition(left_emitter);
-    SimpleDynamics<fluid_dynamics::PressureCondition<RightInflowPressure>> right_inflow_pressure_condition(right_emitter);
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<InflowVelocity>> inflow_velocity_condition(left_disposer);
     //----------------------------------------------------------------------
     //	Define the methods for I/O operations, observations

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -213,8 +213,8 @@ int main(int ac, char *av[])
     BodyAlignedBoxByCell right_emitter(water_block, makeShared<AlignedBoxShape>(xAxis, Transform(Rotation2d(Pi), Vec2d(right_bidirectional_translation)), bidirectional_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<RightInflowPressure> right_emitter_inflow_injection(right_emitter, in_outlet_particle_buffer);
 
-    //InteractionWithUpdate<fluid_dynamics::DensitySummationPressureComplex> update_fluid_density(water_block_inner, water_block_contact);
-    InteractionWithUpdate<fluid_dynamics::DensitySummationFreeStreamComplex> update_fluid_density(water_block_inner, water_block_contact);
+    InteractionWithUpdate<fluid_dynamics::DensitySummationPressureComplex> update_fluid_density(water_block_inner, water_block_contact);
+    //InteractionWithUpdate<fluid_dynamics::DensitySummationFreeStreamComplex> update_fluid_density(water_block_inner, water_block_contact);
     
     SimpleDynamics<fluid_dynamics::PressureCondition<LeftInflowPressure>> left_inflow_pressure_condition(left_emitter);
     SimpleDynamics<fluid_dynamics::PressureCondition<RightInflowPressure>> right_inflow_pressure_condition(right_emitter);

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -190,16 +190,16 @@ int main(int ac, char *av[])
 
     InteractionWithUpdate<LinearGradientCorrectionMatrixComplex> corrected_configuration_fluid(water_block_inner, water_block_contact);
     
-    //Dynamics1Level<fluid_dynamics::Integration1stHalfWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    Dynamics1Level<fluid_dynamics::Integration1stHalfWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
     //Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
-    Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionForOpenBoundaryFlowWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    //Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionForOpenBoundaryFlowWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
     
     Dynamics1Level<fluid_dynamics::Integration2ndHalfWithWallRiemann> density_relaxation(water_block_inner, water_block_contact);
     InteractionWithUpdate<fluid_dynamics::ViscousForceWithWall> viscous_acceleration(water_block_inner, water_block_contact);
     
-    //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
     //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
-    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedForOpenBoundaryFlowComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedForOpenBoundaryFlowComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
 
     ReduceDynamics<fluid_dynamics::AdvectionTimeStepSize> get_fluid_advection_time_step_size(water_block, U_f);
     ReduceDynamics<fluid_dynamics::AcousticTimeStepSize> get_fluid_time_step_size(water_block);
@@ -213,7 +213,9 @@ int main(int ac, char *av[])
     BodyAlignedBoxByCell right_emitter(water_block, makeShared<AlignedBoxShape>(xAxis, Transform(Rotation2d(Pi), Vec2d(right_bidirectional_translation)), bidirectional_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<RightInflowPressure> right_emitter_inflow_injection(right_emitter, in_outlet_particle_buffer);
 
-    InteractionWithUpdate<fluid_dynamics::DensitySummationPressureComplex> update_fluid_density(water_block_inner, water_block_contact);
+    //InteractionWithUpdate<fluid_dynamics::DensitySummationPressureComplex> update_fluid_density(water_block_inner, water_block_contact);
+    InteractionWithUpdate<fluid_dynamics::DensitySummationFreeStreamComplex> update_fluid_density(water_block_inner, water_block_contact);
+    
     SimpleDynamics<fluid_dynamics::PressureCondition<LeftInflowPressure>> left_inflow_pressure_condition(left_emitter);
     SimpleDynamics<fluid_dynamics::PressureCondition<RightInflowPressure>> right_inflow_pressure_condition(right_emitter);
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<InflowVelocity>> inflow_velocity_condition(left_disposer);
@@ -226,6 +228,9 @@ int main(int ac, char *av[])
     body_states_recording.addToWrite<int>(water_block, "Indicator");
     body_states_recording.addToWrite<Real>(water_block, "Density");
     body_states_recording.addToWrite<int>(water_block, "BufferParticleIndicator");
+    body_states_recording.addToWrite<Matd>(water_block, "LinearGradientCorrectionMatrix");
+    body_states_recording.addToWrite<Vecd>(water_block, "ZeroGradientResidue");
+    body_states_recording.addToWrite<Vecd>(water_block, "KernelSummation");
     RegressionTestDynamicTimeWarping<ObservedQuantityRecording<Vecd>> write_centerline_velocity("Velocity", velocity_observer_contact);
     //----------------------------------------------------------------------
     //	Prepare the simulation with cell linked list, configuration

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -26,7 +26,7 @@ BoundingBox system_domain_bounds(Vec2d(-BW, -BW), Vec2d(DL + BW, DH + BW));
 //	Material parameters.
 //----------------------------------------------------------------------
 Real Inlet_pressure = 0.2;
-Real Outlet_pressure = 0.1;
+Real Outlet_pressure = 0.0;
 Real rho0_f = 1000.0;
 Real Re = 50.0;
 Real mu_f = sqrt(rho0_f * pow(0.5 * DH, 3.0) * fabs(Inlet_pressure - Outlet_pressure) / (Re * DL));
@@ -197,7 +197,8 @@ int main(int ac, char *av[])
     Dynamics1Level<fluid_dynamics::Integration2ndHalfWithWallRiemann> density_relaxation(water_block_inner, water_block_contact);
     InteractionWithUpdate<fluid_dynamics::ViscousForceWithWall> viscous_acceleration(water_block_inner, water_block_contact);
     
-    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
     //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedForOpenBoundaryFlowComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
 
     ReduceDynamics<fluid_dynamics::AdvectionTimeStepSize> get_fluid_advection_time_step_size(water_block, U_f);

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -25,8 +25,8 @@ BoundingBox system_domain_bounds(Vec2d(-BW, -BW), Vec2d(DL + BW, DH + BW));
 //----------------------------------------------------------------------
 //	Material parameters.
 //----------------------------------------------------------------------
-Real Inlet_pressure = 0.2;
-Real Outlet_pressure = 0.1;
+Real Inlet_pressure = 2000.0;
+Real Outlet_pressure = 1000.0;
 Real rho0_f = 1000.0;
 Real Re = 50.0;
 Real mu_f = sqrt(rho0_f * pow(0.5 * DH, 3.0) * fabs(Inlet_pressure - Outlet_pressure) / (Re * DL));
@@ -251,7 +251,7 @@ int main(int ac, char *av[])
     size_t number_of_iterations = sph_system.RestartStep();
     int screen_output_interval = 100;
     int observation_sample_interval = screen_output_interval * 2;
-    Real end_time = 10.0;   /**< End time. */
+    Real end_time = 1.0;   /**< End time. */
     Real Output_Time = 0.1; /**< Time stamps for output of body states. */
     Real dt = 0.0;          /**< Default acoustic time step sizes. */
     //----------------------------------------------------------------------

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -25,8 +25,8 @@ BoundingBox system_domain_bounds(Vec2d(-BW, -BW), Vec2d(DL + BW, DH + BW));
 //----------------------------------------------------------------------
 //	Material parameters.
 //----------------------------------------------------------------------
-Real Inlet_pressure = 2000.0;
-Real Outlet_pressure = 1000.0;
+Real Inlet_pressure = 0.2;
+Real Outlet_pressure = 0.0;
 Real rho0_f = 1000.0;
 Real Re = 50.0;
 Real mu_f = sqrt(rho0_f * pow(0.5 * DH, 3.0) * fabs(Inlet_pressure - Outlet_pressure) / (Re * DL));
@@ -251,8 +251,8 @@ int main(int ac, char *av[])
     size_t number_of_iterations = sph_system.RestartStep();
     int screen_output_interval = 100;
     int observation_sample_interval = screen_output_interval * 2;
-    Real end_time = 1.0;   /**< End time. */
-    Real Output_Time = 0.1; /**< Time stamps for output of body states. */
+    Real end_time = 10.0;   /**< End time. */
+    Real Output_Time = 1.0; /**< Time stamps for output of body states. */
     Real dt = 0.0;          /**< Default acoustic time step sizes. */
     //----------------------------------------------------------------------
     //	Statistics for CPU time

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -190,16 +190,16 @@ int main(int ac, char *av[])
 
     InteractionWithUpdate<LinearGradientCorrectionMatrixComplex> corrected_configuration_fluid(water_block_inner, water_block_contact);
     
-    Dynamics1Level<fluid_dynamics::Integration1stHalfWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    //Dynamics1Level<fluid_dynamics::Integration1stHalfWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
     //Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
-    //Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionForOpenBoundaryFlowWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionForOpenBoundaryFlowWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
     
     Dynamics1Level<fluid_dynamics::Integration2ndHalfWithWallRiemann> density_relaxation(water_block_inner, water_block_contact);
     InteractionWithUpdate<fluid_dynamics::ViscousForceWithWall> viscous_acceleration(water_block_inner, water_block_contact);
     
-    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
     //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
-    //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedForOpenBoundaryFlowComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedForOpenBoundaryFlowComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
 
     ReduceDynamics<fluid_dynamics::AdvectionTimeStepSize> get_fluid_advection_time_step_size(water_block, U_f);
     ReduceDynamics<fluid_dynamics::AcousticTimeStepSize> get_fluid_time_step_size(water_block);

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -190,16 +190,16 @@ int main(int ac, char *av[])
 
     InteractionWithUpdate<LinearGradientCorrectionMatrixComplex> corrected_configuration_fluid(water_block_inner, water_block_contact);
     
-    Dynamics1Level<fluid_dynamics::Integration1stHalfWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    //Dynamics1Level<fluid_dynamics::Integration1stHalfWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
     //Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
-    //Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionForOpenBoundaryFlowWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionForOpenBoundaryFlowWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
     
     Dynamics1Level<fluid_dynamics::Integration2ndHalfWithWallRiemann> density_relaxation(water_block_inner, water_block_contact);
     InteractionWithUpdate<fluid_dynamics::ViscousForceWithWall> viscous_acceleration(water_block_inner, water_block_contact);
     
-    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
     //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
-    //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedForOpenBoundaryFlowComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedForOpenBoundaryFlowComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
 
     ReduceDynamics<fluid_dynamics::AdvectionTimeStepSize> get_fluid_advection_time_step_size(water_block, U_f);
     ReduceDynamics<fluid_dynamics::AcousticTimeStepSize> get_fluid_time_step_size(water_block);
@@ -216,10 +216,10 @@ int main(int ac, char *av[])
     InteractionWithUpdate<fluid_dynamics::DensitySummationPressureComplex> update_fluid_density(water_block_inner, water_block_contact);
     //InteractionWithUpdate<fluid_dynamics::DensitySummationFreeStreamComplex> update_fluid_density(water_block_inner, water_block_contact);
 
-    SimpleDynamics<fluid_dynamics::PressureCondition<LeftInflowPressure>> left_inflow_pressure_condition(left_emitter);
-    SimpleDynamics<fluid_dynamics::PressureCondition<RightInflowPressure>> right_inflow_pressure_condition(right_emitter);
-    //SimpleDynamics<fluid_dynamics::PressureConditionCorrection<LeftInflowPressure>> left_inflow_pressure_condition(left_emitter);
-    //SimpleDynamics<fluid_dynamics::PressureConditionCorrection<RightInflowPressure>> right_inflow_pressure_condition(right_emitter);
+    //SimpleDynamics<fluid_dynamics::PressureCondition<LeftInflowPressure>> left_inflow_pressure_condition(left_emitter);
+    //SimpleDynamics<fluid_dynamics::PressureCondition<RightInflowPressure>> right_inflow_pressure_condition(right_emitter);
+    SimpleDynamics<fluid_dynamics::PressureConditionCorrection<LeftInflowPressure>> left_inflow_pressure_condition(left_emitter);
+    SimpleDynamics<fluid_dynamics::PressureConditionCorrection<RightInflowPressure>> right_inflow_pressure_condition(right_emitter);
     
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<InflowVelocity>> inflow_velocity_condition(left_disposer);
     //----------------------------------------------------------------------

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -189,12 +189,16 @@ int main(int ac, char *av[])
     InteractionWithUpdate<SpatialTemporalFreeSurfaceIndicationComplex> boundary_indicator(water_block_inner, water_block_contact);
 
     InteractionWithUpdate<LinearGradientCorrectionMatrixComplex> corrected_configuration_fluid(water_block_inner, water_block_contact);
-    Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionForOpenBoundaryFlowWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    
+    Dynamics1Level<fluid_dynamics::Integration1stHalfWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    //Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    //Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionForOpenBoundaryFlowWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
     
     Dynamics1Level<fluid_dynamics::Integration2ndHalfWithWallRiemann> density_relaxation(water_block_inner, water_block_contact);
     InteractionWithUpdate<fluid_dynamics::ViscousForceWithWall> viscous_acceleration(water_block_inner, water_block_contact);
     
-    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedForOpenBoundaryFlowComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedForOpenBoundaryFlowComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
 
     ReduceDynamics<fluid_dynamics::AdvectionTimeStepSize> get_fluid_advection_time_step_size(water_block, U_f);
     ReduceDynamics<fluid_dynamics::AcousticTimeStepSize> get_fluid_time_step_size(water_block);

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -190,16 +190,16 @@ int main(int ac, char *av[])
 
     InteractionWithUpdate<LinearGradientCorrectionMatrixComplex> corrected_configuration_fluid(water_block_inner, water_block_contact);
     
-    //Dynamics1Level<fluid_dynamics::Integration1stHalfWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    Dynamics1Level<fluid_dynamics::Integration1stHalfWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
     //Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
-    Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionForOpenBoundaryFlowWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    //Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionForOpenBoundaryFlowWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
     
     Dynamics1Level<fluid_dynamics::Integration2ndHalfWithWallRiemann> density_relaxation(water_block_inner, water_block_contact);
     InteractionWithUpdate<fluid_dynamics::ViscousForceWithWall> viscous_acceleration(water_block_inner, water_block_contact);
     
-    //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
     //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
-    InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedForOpenBoundaryFlowComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
+    //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedForOpenBoundaryFlowComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
 
     ReduceDynamics<fluid_dynamics::AdvectionTimeStepSize> get_fluid_advection_time_step_size(water_block, U_f);
     ReduceDynamics<fluid_dynamics::AcousticTimeStepSize> get_fluid_time_step_size(water_block);
@@ -216,10 +216,10 @@ int main(int ac, char *av[])
     InteractionWithUpdate<fluid_dynamics::DensitySummationPressureComplex> update_fluid_density(water_block_inner, water_block_contact);
     //InteractionWithUpdate<fluid_dynamics::DensitySummationFreeStreamComplex> update_fluid_density(water_block_inner, water_block_contact);
 
-    //SimpleDynamics<fluid_dynamics::PressureCondition<LeftInflowPressure>> left_inflow_pressure_condition(left_emitter);
-    //SimpleDynamics<fluid_dynamics::PressureCondition<RightInflowPressure>> right_inflow_pressure_condition(right_emitter);
-    SimpleDynamics<fluid_dynamics::PressureConditionCorrection<LeftInflowPressure>> left_inflow_pressure_condition(left_emitter);
-    SimpleDynamics<fluid_dynamics::PressureConditionCorrection<RightInflowPressure>> right_inflow_pressure_condition(right_emitter);
+    SimpleDynamics<fluid_dynamics::PressureCondition<LeftInflowPressure>> left_inflow_pressure_condition(left_emitter);
+    SimpleDynamics<fluid_dynamics::PressureCondition<RightInflowPressure>> right_inflow_pressure_condition(right_emitter);
+    //SimpleDynamics<fluid_dynamics::PressureConditionCorrection<LeftInflowPressure>> left_inflow_pressure_condition(left_emitter);
+    //SimpleDynamics<fluid_dynamics::PressureConditionCorrection<RightInflowPressure>> right_inflow_pressure_condition(right_emitter);
     
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<InflowVelocity>> inflow_velocity_condition(left_disposer);
     //----------------------------------------------------------------------

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -190,7 +190,8 @@ int main(int ac, char *av[])
 
     InteractionWithUpdate<LinearGradientCorrectionMatrixComplex> corrected_configuration_fluid(water_block_inner, water_block_contact);
     //Dynamics1Level<fluid_dynamics::Integration1stHalfWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
-    Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    //Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
+    Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionForOpenBoundaryFlowWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
     
     Dynamics1Level<fluid_dynamics::Integration2ndHalfWithWallRiemann> density_relaxation(water_block_inner, water_block_contact);
     InteractionWithUpdate<fluid_dynamics::ViscousForceWithWall> viscous_acceleration(water_block_inner, water_block_contact);

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -189,15 +189,11 @@ int main(int ac, char *av[])
     InteractionWithUpdate<SpatialTemporalFreeSurfaceIndicationComplex> boundary_indicator(water_block_inner, water_block_contact);
 
     InteractionWithUpdate<LinearGradientCorrectionMatrixComplex> corrected_configuration_fluid(water_block_inner, water_block_contact);
-    //Dynamics1Level<fluid_dynamics::Integration1stHalfWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
-    //Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
     Dynamics1Level<fluid_dynamics::Integration1stHalfCorrectionForOpenBoundaryFlowWithWallRiemann> pressure_relaxation(water_block_inner, water_block_contact);
     
     Dynamics1Level<fluid_dynamics::Integration2ndHalfWithWallRiemann> density_relaxation(water_block_inner, water_block_contact);
     InteractionWithUpdate<fluid_dynamics::ViscousForceWithWall> viscous_acceleration(water_block_inner, water_block_contact);
     
-    //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
-    //InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
     InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionCorrectedForOpenBoundaryFlowComplex<BulkParticles>> transport_velocity_correction(water_block_inner, water_block_contact);
 
     ReduceDynamics<fluid_dynamics::AdvectionTimeStepSize> get_fluid_advection_time_step_size(water_block, U_f);


### PR DESCRIPTION
1. Make the RKCG applicable for OpenBoundaryFlow by Correcting Bj when j is truncated.
2. Correct the bug that in the DensitySummationFreestream, the volume is not updated.
3. Improve the pressure outlet to make it compatible with RKCG.