### PR TITLE
Fix `TransformShape::findBounds`

### DIFF
--- a/src/shared/geometries/transform_shape.h
+++ b/src/shared/geometries/transform_shape.h
@@ -78,8 +78,8 @@ class TransformShape : public BaseShapeType
     virtual BoundingBox findBounds() override
     {
         BoundingBox original_bound = BaseShapeType::findBounds();
-        Vecd bb_min = Vecd::Constant(Infinity);
-        Vecd bb_max = Vecd::Constant(-Infinity);
+        Vecd bb_min = Vecd::Constant(MaxReal);
+        Vecd bb_max = Vecd::Constant(-MaxReal);
         for (auto x : {original_bound.first_.x(), original_bound.second_.x()})
         {
             for (auto y : {original_bound.first_.y(), original_bound.second_.y()})

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/general_reduce_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/general_reduce_ck.hpp
@@ -16,7 +16,7 @@ template <typename DataType, typename NormType, class DynamicsIdentifier>
 template <class ExecutionPolicy, class EncloserType>
 VariableNormCK<DataType, NormType, DynamicsIdentifier>::ReduceKernel::
     ReduceKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
-    : variable_(encloser.dv_variable_->template DelegatedDataField(ex_policy)) {}
+    : variable_(encloser.dv_variable_->DelegatedDataField(ex_policy)) {}
 //=================================================================================================//
 template <class ExecutionPolicy, class EncloserType>
 TotalKineticEnergyCK::ReduceKernel::


### PR DESCRIPTION
Previous implementation returned the rotated bounds of the underlying shape, which are only 2 points of the underlying shape AABB. Therefore, for a random rotation, it is common to have the generated particles truncated, e.g. during generation for a `TransformShape<GeometricShapeBox>`, see below

![image](https://github.com/user-attachments/assets/94076e9b-3cfd-4cd7-8b2b-8e477ef25415)

This PR fixes that by returning the bounds of the rotated bounding box instead and results in the expected outcome below
![image](https://github.com/user-attachments/assets/b21cfc5a-7722-4ce0-b6d0-771c73eddd8b)
