### PR TITLE
Fix orthotropic material

### DIFF
--- a/src/for_3D_build/materials/elastic_solid_3d.cpp
+++ b/src/for_3D_build/materials/elastic_solid_3d.cpp
@@ -7,18 +7,18 @@ namespace SPH
 void OrthotropicSolid::CalculateAllMu()
 {
 
-    Mu_[0] = 1 / G_[0] + 1 / G_[2] - 1 / G_[1];
-    Mu_[1] = 1 / G_[1] + 1 / G_[0] - 1 / G_[2];
-    Mu_[2] = 1 / G_[2] + 1 / G_[1] - 1 / G_[0];
+    Mu_[0] = G_[0] + G_[2] - G_[1];
+    Mu_[1] = G_[1] + G_[0] - G_[2];
+    Mu_[2] = G_[2] + G_[1] - G_[0];
 }
 //=================================================================================================//
 void OrthotropicSolid::CalculateAllLambda()
 {
     // first we calculate the upper left part, a 3x3 matrix of the full compliance matrix
     Matd Compliance = Matd::Zero();
-    Compliance.col(0) = Vecd(1 / E_[0], -poisson_[0] / E_[1], -poisson_[1] / E_[2]);
+    Compliance.col(0) = Vecd(1 / E_[0], -poisson_[0] / E_[0], -poisson_[1] / E_[2]);
     Compliance.col(1) = Vecd(-poisson_[0] / E_[0], 1 / E_[1], -poisson_[2] / E_[1]);
-    Compliance.col(2) = Vecd(-poisson_[1] / E_[0], -poisson_[2] / E_[1], 1 / E_[2]);
+    Compliance.col(2) = Vecd(-poisson_[1] / E_[2], -poisson_[2] / E_[1], 1 / E_[2]);
     // we calculate the inverse of the Compliance matrix, and calculate the lambdas elementwise
     Matd Compliance_inv = Compliance.inverse();
     // Lambda_ is a 3x3 matrix

--- a/src/shared/materials/elastic_solid.h
+++ b/src/shared/materials/elastic_solid.h
@@ -213,10 +213,10 @@ class NeoHookeanSolidIncompressible : public LinearElasticSolid
  * @class OrthotropicSolid
  * @brief Generic definition with 3 orthogonal directions + 9 independent parameters,
  * ONLY for 3D applications
- * @param "a" --> 3 principal direction vectors
- * @param "E" --> 3 principal Young's moduli
- * @param "G" --> 3 principal shear moduli
- * @param "poisson" --> 3 principal Poisson's ratios
+ * @param "a" --> 3 principal direction vectors in the order of a_x, a_y, a_z
+ * @param "E" --> 3 principal Young's moduli in the order of E_x, E_y, E_z
+ * @param "G" --> 3 principal shear moduli in the order of G_xy, G_yz, G_zx
+ * @param "poisson" --> 3 principal Poisson's ratios in the order of nu_xy, ny_zx, nu_yz
  */
 class OrthotropicSolid : public LinearElasticSolid
 {
@@ -225,9 +225,10 @@ class OrthotropicSolid : public LinearElasticSolid
                      std::array<Real, Dimensions> G, std::array<Real, Dimensions> poisson);
 
     /** second Piola-Kirchhoff stress related with green-lagrangian deformation tensor */
-    virtual Matd StressPK2(Matd &deformation, size_t particle_index_i) override;
+    Matd StressPK2(Matd &deformation, size_t particle_index_i) override;
+    Matd StressCauchy(Matd &almansi_strain, size_t particle_index_i) override;
     /** Volumetric Kirchhoff stress determinate */
-    virtual Real VolumetricKirchhoff(Real J) override;
+    Real VolumetricKirchhoff(Real J) override;
 
   protected:
     // input data
@@ -236,13 +237,14 @@ class OrthotropicSolid : public LinearElasticSolid
     std::array<Real, Dimensions> G_;
     std::array<Real, Dimensions> poisson_;
     // calculated data
-    Real Mu_[Dimensions];
+    std::array<Real, Dimensions> Mu_;
     Matd Lambda_;
-    Matd A_[Dimensions];
+    std::array<Matd, Dimensions> A_;
 
-    virtual void CalculateAllMu();
-    virtual void CalculateAllLambda();
-    virtual void CalculateA0();
+    void CalculateAllMu();
+    void CalculateAllLambda();
+    void CalculateA0();
+    void reset_sound_speeds();
 };
 
 /**


### PR DESCRIPTION
See issue #680 

The major changes are:

1. Fix `CalculateAllLambda()`
2. Fix `CalculateAllMu()`
3. Fix the wrong parentheses and the integer division 1/2 (!) in PK2 stress computation
4. Use the maximum bulk modulus in three principle directions $\max (\frac{1}{3}(\sum_j \lambda_{ij} + 2\mu_i))$ instead of maximum E and nu to compute K0 and c0, as the relation between K and E, nu no longer holds for anisotropic material 

TODO:
1. Add parameter check
2. Implement Cauchy stress
3. Add unit test