### PR TITLE
Fix speed of sound calculation for elastic solids

### DIFF
--- a/src/shared/materials/elastic_solid.cpp
+++ b/src/shared/materials/elastic_solid.cpp
@@ -10,8 +10,8 @@ namespace SPH
 //=================================================================================================//
 void ElasticSolid::setSoundSpeeds()
 {
-    c0_ = sqrt(K0_ / rho0_);
-    ct0_ = sqrt(E0_ / rho0_);
+    c0_ = sqrt((K0_ + 4.*G/3.) / rho0_); // https://en.wikipedia.org/wiki/Speed_of_sound#Three-dimensional_solids
+    ct0_ = sqrt(E0_ / rho0_); // ⚠️ Calculation valid only for 1D solid https://en.wikipedia.org/wiki/Speed_of_sound#One-dimensional_solids
     cs0_ = sqrt(G0_ / rho0_);
 };
 //=================================================================================================//


### PR DESCRIPTION
This pull request includes a change to the `ElasticSolid` class in the `src/shared/materials/elastic_solid.cpp` file. The change modifies the calculation of the sound speeds to ensure accuracy for three-dimensional solids.