### PR TITLE
increase buffer independency

### DIFF
--- a/src/shared/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary.h
@@ -98,7 +98,7 @@ class InflowVelocityCondition : public BaseFlowBoundaryCondition
 
     void update(size_t index_i, Real dt = 0.0)
     {
-        if (aligned_box_.checkInBounds(pos_[index_i]))
+        if (aligned_box_.checkContain(pos_[index_i]))
         {
             Vecd frame_position = transform_.shiftBaseStationToFrame(pos_[index_i]);
             Vecd frame_velocity = transform_.xformBaseVecToFrame(vel_[index_i]);

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/bidirectional_buffer.h
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/bidirectional_buffer.h
@@ -66,11 +66,11 @@ class BidirectionalBuffer
         {
             particles_->addVariableToSort<int>("BufferParticleIndicator");
         };
-        virtual ~TagBufferParticles() {};
+        virtual ~TagBufferParticles(){};
 
         virtual void update(size_t index_i, Real dt = 0.0)
         {
-            if (aligned_box_.checkInBounds(pos_[index_i]))
+            if (aligned_box_.checkContain(pos_[index_i]))
             {
                 buffer_particle_indicator_[index_i] = part_id_;
             }
@@ -104,7 +104,7 @@ class BidirectionalBuffer
         {
             particle_buffer_.checkParticlesReserved();
         };
-        virtual ~Injection() {};
+        virtual ~Injection(){};
 
         void update(size_t index_i, Real dt = 0.0)
         {
@@ -154,8 +154,8 @@ class BidirectionalBuffer
               part_id_(aligned_box_part.getPartID()),
               aligned_box_(aligned_box_part.getAlignedBox()),
               pos_(particles_->getVariableDataByName<Vecd>("Position")),
-              buffer_particle_indicator_(particles_->getVariableDataByName<int>("BufferParticleIndicator")) {};
-        virtual ~Deletion() {};
+              buffer_particle_indicator_(particles_->getVariableDataByName<int>("BufferParticleIndicator")){};
+        virtual ~Deletion(){};
 
         void update(size_t index_i, Real dt = 0.0)
         {
@@ -185,8 +185,8 @@ class BidirectionalBuffer
         : target_pressure_(*this),
           tag_buffer_particles(aligned_box_part),
           injection(aligned_box_part, particle_buffer, target_pressure_),
-          deletion(aligned_box_part) {};
-    virtual ~BidirectionalBuffer() {};
+          deletion(aligned_box_part){};
+    virtual ~BidirectionalBuffer(){};
 
     SimpleDynamics<TagBufferParticles, ExecutionPolicy> tag_buffer_particles;
     SimpleDynamics<Injection, ExecutionPolicy> injection;

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/pressure_boundary.h
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/pressure_boundary.h
@@ -54,11 +54,14 @@ class PressureCondition : public BaseFlowBoundaryCondition
 
     void update(size_t index_i, Real dt = 0.0)
     {
-        vel_[index_i] += 2.0 * kernel_sum_[index_i] * target_pressure_(p_[index_i], *physical_time_) / rho_[index_i] * dt;
+        if (aligned_box_.checkContain(pos_[index_i]))
+        {
+            vel_[index_i] += 2.0 * kernel_sum_[index_i] * target_pressure_(p_[index_i], *physical_time_) / rho_[index_i] * dt;
 
-        Vecd frame_velocity = Vecd::Zero();
-        frame_velocity[alignment_axis_] = transform_.xformBaseVecToFrame(vel_[index_i])[alignment_axis_];
-        vel_[index_i] = transform_.xformFrameVecToBase(frame_velocity);
+            Vecd frame_velocity = Vecd::Zero();
+            frame_velocity[alignment_axis_] = transform_.xformBaseVecToFrame(vel_[index_i])[alignment_axis_];
+            vel_[index_i] = transform_.xformFrameVecToBase(frame_velocity);
+        }
     };
 
   protected:


### PR DESCRIPTION
To avoid buffer interference that happens when several buffer regions stack vertically.
The relevant checkInBound is changed to checkContain. 
And the region restriction is imposed on pressure BC.