### PR TITLE
using singular variable for aligned box

### DIFF
--- a/src/shared/bodies/base_body_part.cpp
+++ b/src/shared/bodies/base_body_part.cpp
@@ -157,15 +157,21 @@ bool NearShapeSurface::checkNearSurface(Vecd cell_position, Real threshold)
     return level_set_shape_.checkNearSurface(cell_position, threshold);
 }
 //=================================================================================================//
-BodyAlignedBoxByParticle::BodyAlignedBoxByParticle(RealBody &real_body, const AlignedBox &aligned_box)
-    : BodyPartByParticle(real_body, "AlignedBoxByParticle"), aligned_box_(aligned_box)
+AlignedBoxPart::AlignedBoxPart(const std::string &name, const AlignedBox &aligned_box)
+    : aligned_box_(*sv_aligned_box_keeper_
+                        .createPtr<SingularVariable<AlignedBox>>("AlignedBox" + name, aligned_box)
+                        ->Data()) {}
+//=================================================================================================//
+AlignedBoxPartByParticle::AlignedBoxPartByParticle(RealBody &real_body, const AlignedBox &aligned_box)
+    : BodyPartByParticle(real_body, "AlignedBoxByParticle"),
+      AlignedBoxPart(body_part_name_, aligned_box)
 {
     TaggingParticleMethod tagging_particle_method =
-        std::bind(&BodyAlignedBoxByParticle::tagByContain, this, _1);
+        std::bind(&AlignedBoxPartByParticle::tagByContain, this, _1);
     tagParticles(tagging_particle_method);
 }
 //=================================================================================================//
-void BodyAlignedBoxByParticle::tagByContain(size_t particle_index)
+void AlignedBoxPartByParticle::tagByContain(size_t particle_index)
 {
     if (aligned_box_.checkContain(pos_[particle_index]))
     {
@@ -173,15 +179,16 @@ void BodyAlignedBoxByParticle::tagByContain(size_t particle_index)
     }
 }
 //=================================================================================================//
-BodyAlignedBoxByCell::BodyAlignedBoxByCell(RealBody &real_body, const AlignedBox &aligned_box)
-    : BodyPartByCell(real_body, "AlignedBoxByCell"), aligned_box_(aligned_box)
+AlignedBoxPartByCell::AlignedBoxPartByCell(RealBody &real_body, const AlignedBox &aligned_box)
+    : BodyPartByCell(real_body, "AlignedBoxByCell"),
+      AlignedBoxPart(body_part_name_, aligned_box)
 {
     TaggingCellMethod tagging_cell_method =
-        std::bind(&BodyAlignedBoxByCell::checkNotFar, this, _1, _2);
+        std::bind(&AlignedBoxPartByCell::checkNotFar, this, _1, _2);
     tagCells(tagging_cell_method);
 }
 //=================================================================================================//
-bool BodyAlignedBoxByCell::checkNotFar(Vecd cell_position, Real threshold)
+bool AlignedBoxPartByCell::checkNotFar(Vecd cell_position, Real threshold)
 {
     return aligned_box_.checkNotFar(cell_position, threshold);
 }

--- a/src/shared/bodies/base_body_part.h
+++ b/src/shared/bodies/base_body_part.h
@@ -214,27 +214,37 @@ class NearShapeSurface : public BodyPartByCell
     bool checkNearSurface(Vecd cell_position, Real threshold);
 };
 
-class BodyAlignedBoxByParticle : public BodyPartByParticle
+class AlignedBoxPart
 {
+    UniquePtrKeeper<SingularVariable<AlignedBox>> sv_aligned_box_keeper_;
+
   public:
-    BodyAlignedBoxByParticle(RealBody &real_body, const AlignedBox &aligned_box);
-    virtual ~BodyAlignedBoxByParticle() {};
+    AlignedBoxPart(const std::string &name, const AlignedBox &aligned_box);
+    virtual ~AlignedBoxPart() {};
+    SingularVariable<AlignedBox> *svAlignedBox() { return sv_aligned_box_keeper_.getPtr(); };
     AlignedBox &getAlignedBox() { return aligned_box_; };
 
   protected:
-    AlignedBox aligned_box_;
+    AlignedBox &aligned_box_;
+};
+
+class AlignedBoxPartByParticle : public BodyPartByParticle, public AlignedBoxPart
+{
+  public:
+    AlignedBoxPartByParticle(RealBody &real_body, const AlignedBox &aligned_box);
+    virtual ~AlignedBoxPartByParticle() {};
+
+  protected:
     void tagByContain(size_t particle_index);
 };
 
-class BodyAlignedBoxByCell : public BodyPartByCell
+class AlignedBoxPartByCell : public BodyPartByCell, public AlignedBoxPart
 {
   public:
-    BodyAlignedBoxByCell(RealBody &real_body, const AlignedBox &aligned_box);
-    virtual ~BodyAlignedBoxByCell() {};
-    AlignedBox &getAlignedBox() { return aligned_box_; };
+    AlignedBoxPartByCell(RealBody &real_body, const AlignedBox &aligned_box);
+    virtual ~AlignedBoxPartByCell() {};
 
   protected:
-    AlignedBox aligned_box_;
     bool checkNotFar(Vecd cell_position, Real threshold);
 };
 } // namespace SPH

--- a/src/shared/common/ownership.h
+++ b/src/shared/common/ownership.h
@@ -111,6 +111,11 @@ class UniquePtrKeeper
         return ptr_member_.get();
     };
 
+    BaseType *getPtr()
+    {
+        return ptr_member_.get();
+    };
+
   private:
     UniquePtr<BaseType> ptr_member_;
 };

--- a/src/shared/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary.cpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary.cpp
@@ -32,7 +32,7 @@ void DampingBoundaryCondition::update(size_t index_i, Real dt)
 }
 //=================================================================================================//
 EmitterInflowCondition::
-    EmitterInflowCondition(BodyAlignedBoxByParticle &aligned_box_part)
+    EmitterInflowCondition(AlignedBoxPartByParticle &aligned_box_part)
     : BaseLocalDynamics<BodyPartByParticle>(aligned_box_part),
       fluid_(DynamicCast<Fluid>(this, particles_->getBaseMaterial())),
       sorted_id_(particles_->ParticleSortedIds()),
@@ -59,7 +59,7 @@ void EmitterInflowCondition ::update(size_t original_index_i, Real dt)
 }
 //=================================================================================================//
 EmitterInflowInjection::
-    EmitterInflowInjection(BodyAlignedBoxByParticle &aligned_box_part, ParticleBuffer<Base> &buffer)
+    EmitterInflowInjection(AlignedBoxPartByParticle &aligned_box_part, ParticleBuffer<Base> &buffer)
     : BaseLocalDynamics<BodyPartByParticle>(aligned_box_part),
       fluid_(DynamicCast<Fluid>(this, particles_->getBaseMaterial())),
       original_id_(particles_->ParticleOriginalIds()),
@@ -90,7 +90,7 @@ void EmitterInflowInjection::update(size_t original_index_i, Real dt)
 }
 //=================================================================================================//
 DisposerOutflowDeletion::
-    DisposerOutflowDeletion(BodyAlignedBoxByCell &aligned_box_part)
+    DisposerOutflowDeletion(AlignedBoxPartByCell &aligned_box_part)
     : BaseLocalDynamics<BodyPartByCell>(aligned_box_part),
       pos_(particles_->getVariableDataByName<Vecd>("Position")),
       aligned_box_(aligned_box_part.getAlignedBox()) {}

--- a/src/shared/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary.h
@@ -87,7 +87,7 @@ class InflowVelocityCondition : public BaseFlowBoundaryCondition
 {
   public:
     /** default parameter indicates prescribe velocity */
-    explicit InflowVelocityCondition(BodyAlignedBoxByCell &aligned_box_part, Real relaxation_rate = 1.0)
+    explicit InflowVelocityCondition(AlignedBoxPartByCell &aligned_box_part, Real relaxation_rate = 1.0)
         : BaseFlowBoundaryCondition(aligned_box_part),
           relaxation_rate_(relaxation_rate), aligned_box_(aligned_box_part.getAlignedBox()),
           transform_(aligned_box_.getTransform()), halfsize_(aligned_box_.HalfSize()),
@@ -190,7 +190,7 @@ class DampingBoundaryCondition : public BaseFlowBoundaryCondition
 class EmitterInflowCondition : public BaseLocalDynamics<BodyPartByParticle>
 {
   public:
-    explicit EmitterInflowCondition(BodyAlignedBoxByParticle &aligned_box_part);
+    explicit EmitterInflowCondition(AlignedBoxPartByParticle &aligned_box_part);
     virtual ~EmitterInflowCondition(){};
 
     virtual void setupDynamics(Real dt = 0.0) override { updateTransform(); };
@@ -221,7 +221,7 @@ class EmitterInflowCondition : public BaseLocalDynamics<BodyPartByParticle>
 class EmitterInflowInjection : public BaseLocalDynamics<BodyPartByParticle>
 {
   public:
-    EmitterInflowInjection(BodyAlignedBoxByParticle &aligned_box_part, ParticleBuffer<Base> &buffer);
+    EmitterInflowInjection(AlignedBoxPartByParticle &aligned_box_part, ParticleBuffer<Base> &buffer);
     virtual ~EmitterInflowInjection(){};
 
     void update(size_t original_index_i, Real dt = 0.0);
@@ -244,7 +244,7 @@ class EmitterInflowInjection : public BaseLocalDynamics<BodyPartByParticle>
 class DisposerOutflowDeletion : public BaseLocalDynamics<BodyPartByCell>
 {
   public:
-    DisposerOutflowDeletion(BodyAlignedBoxByCell &aligned_box_part);
+    DisposerOutflowDeletion(AlignedBoxPartByCell &aligned_box_part);
     virtual ~DisposerOutflowDeletion(){};
 
     void update(size_t index_i, Real dt = 0.0);

--- a/tests/2d_examples/test_2d_T_shaped_pipe/T_shaped_pipe.cpp
+++ b/tests/2d_examples/test_2d_T_shaped_pipe/T_shaped_pipe.cpp
@@ -138,22 +138,22 @@ int main(int ac, char *av[])
 
     Vec2d emitter_halfsize = Vec2d(0.5 * BW, 0.5 * DH);
     Vec2d emitter_translation = Vec2d(-DL_sponge, 0.0) + emitter_halfsize;
-    BodyAlignedBoxByParticle emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_translation)), emitter_halfsize));
+    AlignedBoxPartByParticle emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_translation)), emitter_halfsize));
     SimpleDynamics<fluid_dynamics::EmitterInflowInjection> emitter_inflow_injection(emitter, inlet_particle_buffer);
 
     Vec2d inlet_flow_buffer_halfsize = Vec2d(0.5 * DL_sponge, 0.5 * DH);
     Vec2d inlet_flow_buffer_translation = Vec2d(-DL_sponge, 0.0) + inlet_flow_buffer_halfsize;
-    BodyAlignedBoxByCell inlet_flow_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(inlet_flow_buffer_translation)), inlet_flow_buffer_halfsize));
+    AlignedBoxPartByCell inlet_flow_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(inlet_flow_buffer_translation)), inlet_flow_buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<InflowVelocity>> inflow_condition(inlet_flow_buffer);
     Vec2d disposer_up_halfsize = Vec2d(0.3 * DH, 0.5 * BW);
     Vec2d disposer_up_translation = Vec2d(DL + 0.05 * DH, 2.0 * DH) - disposer_up_halfsize;
-    BodyAlignedBoxByCell disposer_up(
+    AlignedBoxPartByCell disposer_up(
         water_block, AlignedBox(yAxis, Transform(Vec2d(disposer_up_translation)), disposer_up_halfsize));
     SimpleDynamics<fluid_dynamics::DisposerOutflowDeletion> disposer_up_outflow_deletion(disposer_up);
 
     Vec2d disposer_down_halfsize = disposer_up_halfsize;
     Vec2d disposer_down_translation = Vec2d(DL1 - 0.05 * DH, -DH) + disposer_down_halfsize;
-    BodyAlignedBoxByCell disposer_down(
+    AlignedBoxPartByCell disposer_down(
         water_block, AlignedBox(yAxis, Transform(Rotation2d(Pi), Vec2d(disposer_down_translation)), disposer_down_halfsize));
     SimpleDynamics<fluid_dynamics::DisposerOutflowDeletion> disposer_down_outflow_deletion(disposer_down);
     //----------------------------------------------------------------------

--- a/tests/2d_examples/test_2d_channel_flow_fluid_shell/channel_flow_shell.cpp
+++ b/tests/2d_examples/test_2d_channel_flow_fluid_shell/channel_flow_shell.cpp
@@ -215,7 +215,7 @@ void channel_flow_shell(const Real resolution_ref, const Real wall_thickness)
     InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionComplex<AllParticles>> transport_correction(water_block_inner, water_block_contact);
     InteractionWithUpdate<fluid_dynamics::ViscousForceWithWall> viscous_acceleration(water_block_inner, water_block_contact);
     /** Inflow boundary condition. */
-    BodyAlignedBoxByCell inflow_buffer(
+    AlignedBoxPartByCell inflow_buffer(
         water_block, AlignedBox(xAxis, Transform(Vec2d(buffer_translation)), buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<InflowVelocity>> parabolic_inflow(inflow_buffer);
     /** Periodic BCs in x direction. */

--- a/tests/2d_examples/test_2d_filling_tank/filling_tank.cpp
+++ b/tests/2d_examples/test_2d_filling_tank/filling_tank.cpp
@@ -73,7 +73,7 @@ class WallBoundary : public MultiPolygonShape
 class InletInflowCondition : public fluid_dynamics::EmitterInflowCondition
 {
   public:
-    InletInflowCondition(BodyAlignedBoxByParticle &aligned_box_part)
+    InletInflowCondition(AlignedBoxPartByParticle &aligned_box_part)
         : EmitterInflowCondition(aligned_box_part) {}
 
   protected:
@@ -136,7 +136,7 @@ int main(int ac, char *av[])
     ReduceDynamics<fluid_dynamics::AdvectionTimeStep> get_fluid_advection_time_step_size(water_body, U_f);
     ReduceDynamics<fluid_dynamics::AcousticTimeStep> get_fluid_time_step_size(water_body);
 
-    BodyAlignedBoxByParticle emitter(water_body, AlignedBox(xAxis, Transform(inlet_translation), inlet_halfsize));
+    AlignedBoxPartByParticle emitter(water_body, AlignedBox(xAxis, Transform(inlet_translation), inlet_halfsize));
     SimpleDynamics<InletInflowCondition> inflow_condition(emitter);
     SimpleDynamics<fluid_dynamics::EmitterInflowInjection> emitter_injection(emitter, inlet_buffer);
     //----------------------------------------------------------------------

--- a/tests/2d_examples/test_2d_flow_stream_around_fish/2d_flow_stream_around_fish.cpp
+++ b/tests/2d_examples/test_2d_flow_stream_around_fish/2d_flow_stream_around_fish.cpp
@@ -122,13 +122,13 @@ int main(int ac, char *av[])
     ReduceDynamics<fluid_dynamics::AdvectionViscousTimeStep> get_fluid_advection_time_step_size(water_block, U_f);
     ReduceDynamics<fluid_dynamics::AcousticTimeStep> get_fluid_time_step_size(water_block);
 
-    BodyAlignedBoxByParticle emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_translation)), emitter_halfsize));
+    AlignedBoxPartByParticle emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_translation)), emitter_halfsize));
     SimpleDynamics<fluid_dynamics::EmitterInflowInjection> emitter_inflow_injection(emitter, inlet_particle_buffer);
 
-    BodyAlignedBoxByCell emitter_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_buffer_translation)), emitter_buffer_halfsize));
+    AlignedBoxPartByCell emitter_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_buffer_translation)), emitter_buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<FreeStreamVelocity>> emitter_buffer_inflow_condition(emitter_buffer);
 
-    BodyAlignedBoxByCell disposer(water_block, AlignedBox(xAxis, Transform(Vec2d(disposer_translation)), disposer_halfsize));
+    AlignedBoxPartByCell disposer(water_block, AlignedBox(xAxis, Transform(Vec2d(disposer_translation)), disposer_halfsize));
     SimpleDynamics<fluid_dynamics::DisposerOutflowDeletion> disposer_outflow_deletion(disposer);
 
     SimpleDynamics<fluid_dynamics::FreeStreamVelocityCorrection<FreeStreamVelocity>> velocity_boundary_condition_constraint(water_block);

--- a/tests/2d_examples/test_2d_free_stream_around_cylinder/2d_free_stream_around_cylinder.cpp
+++ b/tests/2d_examples/test_2d_free_stream_around_cylinder/2d_free_stream_around_cylinder.cpp
@@ -113,13 +113,13 @@ int main(int ac, char *av[])
     Dynamics1Level<fluid_dynamics::Integration2ndHalfWithWallNoRiemann> density_relaxation(water_block_inner, water_block_contact);
     InteractionWithUpdate<fluid_dynamics::DensitySummationFreeStreamComplex> update_fluid_density(water_block_inner, water_block_contact);
 
-    BodyAlignedBoxByParticle emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_translation)), emitter_halfsize));
+    AlignedBoxPartByParticle emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_translation)), emitter_halfsize));
     SimpleDynamics<fluid_dynamics::EmitterInflowInjection> emitter_inflow_injection(emitter, inlet_particle_buffer);
 
-    BodyAlignedBoxByCell emitter_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_buffer_translation)), emitter_buffer_halfsize));
+    AlignedBoxPartByCell emitter_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_buffer_translation)), emitter_buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<FreeStreamVelocity>> emitter_buffer_inflow_condition(emitter_buffer);
 
-    BodyAlignedBoxByCell disposer(water_block, AlignedBox(xAxis, Transform(Vec2d(disposer_translation)), disposer_halfsize));
+    AlignedBoxPartByCell disposer(water_block, AlignedBox(xAxis, Transform(Vec2d(disposer_translation)), disposer_halfsize));
     SimpleDynamics<fluid_dynamics::DisposerOutflowDeletion> disposer_outflow_deletion(disposer);
 
     ReduceDynamics<fluid_dynamics::AdvectionViscousTimeStep> get_fluid_advection_time_step_size(water_block, U_f);

--- a/tests/2d_examples/test_2d_free_stream_around_cylinder_mr/mr_free_stream_around_cylinder.cpp
+++ b/tests/2d_examples/test_2d_free_stream_around_cylinder_mr/mr_free_stream_around_cylinder.cpp
@@ -123,11 +123,11 @@ int main(int ac, char *av[])
     Dynamics1Level<fluid_dynamics::Integration2ndHalfWithWallNoRiemann> density_relaxation(water_block_inner, water_contact);
     InteractionWithUpdate<fluid_dynamics::DensitySummationFreeStreamComplexAdaptive> update_fluid_density(water_block_inner, water_contact);
 
-    BodyAlignedBoxByParticle emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_translation)), emitter_halfsize));
+    AlignedBoxPartByParticle emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_translation)), emitter_halfsize));
     SimpleDynamics<fluid_dynamics::EmitterInflowInjection> emitter_inflow_injection(emitter, inlet_particle_buffer);
-    BodyAlignedBoxByCell emitter_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_buffer_translation)), emitter_buffer_halfsize));
+    AlignedBoxPartByCell emitter_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_buffer_translation)), emitter_buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<FreeStreamVelocity>> emitter_buffer_inflow_condition(emitter_buffer, 0.1);
-    BodyAlignedBoxByCell disposer(water_block, AlignedBox(xAxis, Transform(Vec2d(disposer_translation)), disposer_halfsize));
+    AlignedBoxPartByCell disposer(water_block, AlignedBox(xAxis, Transform(Vec2d(disposer_translation)), disposer_halfsize));
     SimpleDynamics<fluid_dynamics::DisposerOutflowDeletion> disposer_outflow_deletion(disposer);
 
     /** Time step size without considering sound wave speed. */

--- a/tests/2d_examples/test_2d_fsi2/fsi2.cpp
+++ b/tests/2d_examples/test_2d_fsi2/fsi2.cpp
@@ -142,7 +142,7 @@ int main(int ac, char *av[])
     ReduceDynamics<fluid_dynamics::AdvectionViscousTimeStep> get_fluid_advection_time_step_size(water_block, U_f);
     ReduceDynamics<fluid_dynamics::AcousticTimeStep> get_fluid_time_step_size(water_block);
 
-    BodyAlignedBoxByCell inflow_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(buffer_translation)), buffer_halfsize));
+    AlignedBoxPartByCell inflow_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(buffer_translation)), buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<InflowVelocity>> parabolic_inflow(inflow_buffer);
     PeriodicAlongAxis periodic_along_x(water_block.getSPHBodyBounds(), xAxis);
     PeriodicConditionUsingCellLinkedList periodic_condition(water_block, periodic_along_x);

--- a/tests/2d_examples/test_2d_heat_transfer/heat_transfer.cpp
+++ b/tests/2d_examples/test_2d_heat_transfer/heat_transfer.cpp
@@ -241,7 +241,7 @@ int main(int ac, char *av[])
     ReduceDynamics<fluid_dynamics::AcousticTimeStep> get_fluid_time_step(thermofluid_body);
     PeriodicAlongAxis periodic_along_x(thermofluid_body.getSPHBodyBounds(), xAxis);
     PeriodicConditionUsingCellLinkedList periodic_condition(thermofluid_body, periodic_along_x);
-    BodyAlignedBoxByCell inflow_buffer(thermofluid_body, AlignedBox(xAxis, Transform(Vec2d(buffer_translation)), buffer_halfsize));
+    AlignedBoxPartByCell inflow_buffer(thermofluid_body, AlignedBox(xAxis, Transform(Vec2d(buffer_translation)), buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<InflowVelocity>> parabolic_inflow(inflow_buffer);
 
     GetDiffusionTimeStepSize get_thermal_time_step(thermofluid_body);

--- a/tests/2d_examples/test_2d_tethered_dead_fish_in_flow/src/tethered_dead_fish_in_flow.cpp
+++ b/tests/2d_examples/test_2d_tethered_dead_fish_in_flow/src/tethered_dead_fish_in_flow.cpp
@@ -319,7 +319,7 @@ int main(int ac, char *av[])
     /** Computing vorticity in the flow. */
     InteractionDynamics<fluid_dynamics::VorticityInner> compute_vorticity(water_block_inner);
     /** Inflow boundary condition. */
-    BodyAlignedBoxByCell inflow_buffer(
+    AlignedBoxPartByCell inflow_buffer(
         water_block, AlignedBox(xAxis, Transform(Vec2d(buffer_translation)), buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<InflowVelocity>> parabolic_inflow(inflow_buffer);
 

--- a/tests/3d_examples/test_3d_poiseuille_flow_shell/poiseuille_flow_shell.cpp
+++ b/tests/3d_examples/test_3d_poiseuille_flow_shell/poiseuille_flow_shell.cpp
@@ -233,11 +233,11 @@ void poiseuille_flow(const Real resolution_ref, const Real resolution_shell, con
     //----------------------------------------------------------------------
     //	Boundary conditions. Inflow & Outflow in Y-direction
     //----------------------------------------------------------------------
-    BodyAlignedBoxByParticle emitter(water_block, AlignedBox(yAxis, Transform(Vec3d(emitter_translation)), emitter_halfsize));
+    AlignedBoxPartByParticle emitter(water_block, AlignedBox(yAxis, Transform(Vec3d(emitter_translation)), emitter_halfsize));
     SimpleDynamics<fluid_dynamics::EmitterInflowInjection> emitter_inflow_injection(emitter, inlet_particle_buffer);
-    BodyAlignedBoxByCell emitter_buffer(water_block, AlignedBox(yAxis, Transform(Vec3d(emitter_buffer_translation)), emitter_buffer_halfsize));
+    AlignedBoxPartByCell emitter_buffer(water_block, AlignedBox(yAxis, Transform(Vec3d(emitter_buffer_translation)), emitter_buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<InflowVelocity>> emitter_buffer_inflow_condition(emitter_buffer);
-    BodyAlignedBoxByCell disposer(water_block, AlignedBox(yAxis, Transform(Vec3d(disposer_translation)), disposer_halfsize));
+    AlignedBoxPartByCell disposer(water_block, AlignedBox(yAxis, Transform(Vec3d(disposer_translation)), disposer_halfsize));
     SimpleDynamics<fluid_dynamics::DisposerOutflowDeletion> disposer_outflow_deletion(disposer);
     //----------------------------------------------------------------------
     //	Define the configuration related particles dynamics.

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/bidirectional_buffer.h
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/bidirectional_buffer.h
@@ -57,7 +57,7 @@ class BidirectionalBuffer
     class TagBufferParticles : public BaseLocalDynamics<BodyPartByCell>
     {
       public:
-        TagBufferParticles(BodyAlignedBoxByCell &aligned_box_part)
+        TagBufferParticles(AlignedBoxPartByCell &aligned_box_part)
             : BaseLocalDynamics<BodyPartByCell>(aligned_box_part),
               part_id_(aligned_box_part.getPartID()),
               pos_(particles_->getVariableDataByName<Vecd>("Position")),
@@ -86,7 +86,7 @@ class BidirectionalBuffer
     class Injection : public BaseLocalDynamics<BodyPartByCell>
     {
       public:
-        Injection(BodyAlignedBoxByCell &aligned_box_part, ParticleBuffer<Base> &particle_buffer,
+        Injection(AlignedBoxPartByCell &aligned_box_part, ParticleBuffer<Base> &particle_buffer,
                   TargetPressure &target_pressure)
             : BaseLocalDynamics<BodyPartByCell>(aligned_box_part),
               part_id_(aligned_box_part.getPartID()),
@@ -149,7 +149,7 @@ class BidirectionalBuffer
     class Deletion : public BaseLocalDynamics<BodyPartByCell>
     {
       public:
-        Deletion(BodyAlignedBoxByCell &aligned_box_part)
+        Deletion(AlignedBoxPartByCell &aligned_box_part)
             : BaseLocalDynamics<BodyPartByCell>(aligned_box_part),
               part_id_(aligned_box_part.getPartID()),
               aligned_box_(aligned_box_part.getAlignedBox()),
@@ -181,7 +181,7 @@ class BidirectionalBuffer
     };
 
   public:
-    BidirectionalBuffer(BodyAlignedBoxByCell &aligned_box_part, ParticleBuffer<Base> &particle_buffer)
+    BidirectionalBuffer(AlignedBoxPartByCell &aligned_box_part, ParticleBuffer<Base> &particle_buffer)
         : target_pressure_(*this),
           tag_buffer_particles(aligned_box_part),
           injection(aligned_box_part, particle_buffer, target_pressure_),

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/pressure_boundary.h
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/pressure_boundary.h
@@ -41,7 +41,7 @@ class PressureCondition : public BaseFlowBoundaryCondition
 {
   public:
     /** default parameter indicates prescribe pressure */
-    explicit PressureCondition(BodyAlignedBoxByCell &aligned_box_part)
+    explicit PressureCondition(AlignedBoxPartByCell &aligned_box_part)
         : BaseFlowBoundaryCondition(aligned_box_part),
           aligned_box_(aligned_box_part.getAlignedBox()),
           alignment_axis_(aligned_box_.AlignmentAxis()),

--- a/tests/extra_source_and_tests/test_2d_T_pipe_VIPO_shell/T_pipe_VIPO_shell.cpp
+++ b/tests/extra_source_and_tests/test_2d_T_pipe_VIPO_shell/T_pipe_VIPO_shell.cpp
@@ -319,17 +319,17 @@ int main(int ac, char *av[])
     // left buffer
     Vec2d left_buffer_halfsize = Vec2d(0.5 * buffer_width, 0.5 * DH);
     Vec2d left_buffer_translation = Vec2d(-DL_sponge, 0.0) + left_buffer_halfsize;
-    BodyAlignedBoxByCell left_emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(left_buffer_translation)), left_buffer_halfsize));
+    AlignedBoxPartByCell left_emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(left_buffer_translation)), left_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<LeftInflowPressure> left_bidirection_buffer(left_emitter, in_outlet_particle_buffer);
     // up buffer
     Vec2d up_buffer_halfsize = Vec2d(0.5 * buffer_width, 0.75);
     Vec2d up_buffer_translation = Vec2d(0.5 * (DL + DL1), 2.0 * DH - 0.5 * buffer_width);
-    BodyAlignedBoxByCell up_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(-0.5 * Pi), Vec2d(up_buffer_translation)), up_buffer_halfsize));
+    AlignedBoxPartByCell up_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(-0.5 * Pi), Vec2d(up_buffer_translation)), up_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<UpOutflowPressure> right_up_bidirection_buffer(up_emitter, in_outlet_particle_buffer);
     // down buffer
     Vec2d down_buffer_halfsize = Vec2d(0.5 * buffer_width, 0.75);
     Vec2d down_buffer_translation = Vec2d(0.5 * (DL + DL1), -DH + 0.5 * buffer_width);
-    BodyAlignedBoxByCell down_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(0.5 * Pi), Vec2d(down_buffer_translation)), down_buffer_halfsize));
+    AlignedBoxPartByCell down_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(0.5 * Pi), Vec2d(down_buffer_translation)), down_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<DownOutflowPressure> right_down_bidirection_buffer(down_emitter, in_outlet_particle_buffer);
 
     InteractionWithUpdate<fluid_dynamics::DensitySummationPressureComplex> update_fluid_density(water_block_inner, water_shell_contact);

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -195,9 +195,9 @@ int main(int ac, char *av[])
     ReduceDynamics<fluid_dynamics::AdvectionViscousTimeStep> get_fluid_advection_time_step_size(water_block, U_f);
     ReduceDynamics<fluid_dynamics::AcousticTimeStep> get_fluid_time_step_size(water_block);
 
-    BodyAlignedBoxByCell left_emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(left_bidirectional_translation)), bidirectional_buffer_halfsize));
+    AlignedBoxPartByCell left_emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(left_bidirectional_translation)), bidirectional_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<LeftInflowPressure> left_bidirection_buffer(left_emitter, in_outlet_particle_buffer);
-    BodyAlignedBoxByCell right_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(Pi), Vec2d(right_bidirectional_translation)), bidirectional_buffer_halfsize));
+    AlignedBoxPartByCell right_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(Pi), Vec2d(right_bidirectional_translation)), bidirectional_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<RightInflowPressure> right_bidirection_buffer(right_emitter, in_outlet_particle_buffer);
 
     InteractionWithUpdate<fluid_dynamics::DensitySummationPressureComplex> update_fluid_density(water_block_inner, water_block_contact);

--- a/tests/extra_source_and_tests/test_2d_modified_T_flow/modified_T_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_modified_T_flow/modified_T_flow.cpp
@@ -200,21 +200,21 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     Vec2d left_buffer_halfsize = Vec2d(0.5 * BW, 0.5 * DH);
     Vec2d left_buffer_translation = Vec2d(-DL_sponge, 0.0) + left_buffer_halfsize;
-    BodyAlignedBoxByCell left_emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(left_buffer_translation)), left_buffer_halfsize));
+    AlignedBoxPartByCell left_emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(left_buffer_translation)), left_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<LeftInflowPressure> left_bidirection_buffer(left_emitter, in_outlet_particle_buffer);
     //----------------------------------------------------------------------
     // Up buffer
     //----------------------------------------------------------------------
     Vec2d up_buffer_halfsize = Vec2d(0.5 * BW, 0.75);
     Vec2d up_buffer_translation = Vec2d(0.5 * (DL + DL1), 2.0 * DH - 0.5 * BW);
-    BodyAlignedBoxByCell up_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(-0.5 * Pi), Vec2d(up_buffer_translation)), up_buffer_halfsize));
+    AlignedBoxPartByCell up_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(-0.5 * Pi), Vec2d(up_buffer_translation)), up_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<UpOutflowPressure> up_bidirection_buffer(up_emitter, in_outlet_particle_buffer);
     //----------------------------------------------------------------------
     // Down buffer
     //----------------------------------------------------------------------
     Vec2d down_buffer_halfsize = Vec2d(0.5 * BW, 0.75);
     Vec2d down_buffer_translation = Vec2d(0.5 * (DL + DL1), -DH + 0.5 * BW);
-    BodyAlignedBoxByCell down_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(0.5 * Pi), Vec2d(down_buffer_translation)), down_buffer_halfsize));
+    AlignedBoxPartByCell down_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(0.5 * Pi), Vec2d(down_buffer_translation)), down_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<DownOutflowPressure> down_bidirection_buffer(down_emitter, in_outlet_particle_buffer);
 
     InteractionWithUpdate<fluid_dynamics::DensitySummationPressureComplex> update_fluid_density(water_block_inner, water_block_contact);

--- a/tests/extra_source_and_tests/test_2d_pulsatile_poiseuille_flow/pulsatile_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_pulsatile_poiseuille_flow/pulsatile_poiseuille_flow.cpp
@@ -180,11 +180,11 @@ int main(int ac, char *av[])
     ReduceDynamics<fluid_dynamics::AcousticTimeStep> get_fluid_time_step_size(water_block);
 
     AlignedBox left_emitter_shape(xAxis, Transform(Vec2d(left_bidirectional_translation)), bidirectional_buffer_halfsize);
-    BodyAlignedBoxByCell left_emitter(water_block, left_emitter_shape);
+    AlignedBoxPartByCell left_emitter(water_block, left_emitter_shape);
     fluid_dynamics::BidirectionalBuffer<LeftInflowPressure> left_bidirection_buffer(left_emitter, in_outlet_particle_buffer);
 
     AlignedBox right_emitter_shape(xAxis, Transform(Rotation2d(Pi), Vec2d(right_bidirectional_translation)), bidirectional_buffer_halfsize);
-    BodyAlignedBoxByCell right_emitter(water_block, right_emitter_shape);
+    AlignedBoxPartByCell right_emitter(water_block, right_emitter_shape);
     fluid_dynamics::BidirectionalBuffer<RightInflowPressure> right_bidirection_buffer(right_emitter, in_outlet_particle_buffer);
 
     SimpleDynamics<fluid_dynamics::PressureCondition<LeftInflowPressure>> left_inflow_pressure_condition(left_emitter);


### PR DESCRIPTION
This pull request introduces significant refactoring to replace the `BodyAlignedBoxByParticle` and `BodyAlignedBoxByCell` classes with `AlignedBoxPartByParticle` and `AlignedBoxPartByCell` respectively. Additionally, a new `AlignedBoxPart` class is introduced to handle common functionality. This change affects multiple files across the codebase, including header files, source files, and test examples.

Key changes include:

### Refactoring and Class Renaming:
* [`src/shared/bodies/base_body_part.cpp`](diffhunk://#diff-f1c10084a4ad0b18bcc8b6ec8a5b36cc53aae0e943a7580524e9729e5ce9ccecL160-R191): Replaced `BodyAlignedBoxByParticle` and `BodyAlignedBoxByCell` with `AlignedBoxPartByParticle` and `AlignedBoxPartByCell`. Introduced `AlignedBoxPart` for shared functionality.
* [`src/shared/bodies/base_body_part.h`](diffhunk://#diff-d6e7fed8f35c0f6a75461bc22dbb6dfeb49c4165d573ddab5e0f2187945fcf51L217-L237): Defined new `AlignedBoxPart` class and updated classes to inherit from it.

### Utility Enhancements:
* [`src/shared/common/ownership.h`](diffhunk://#diff-16817eae23e7ab9928e649800e5d324c634c8ac20e131be6fb6ece30ab9e3d9dR114-R118): Added a `getPtr` method to `UniquePtrKeeper` to facilitate pointer access.

### Updates in Fluid Dynamics:
* [`src/shared/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary.cpp`](diffhunk://#diff-9c19354efe01266306017bffadb297a9c171343bbff3bcf46413e17726a7e2a2L35-R35): Updated constructors to use `AlignedBoxPartByParticle` and `AlignedBoxPartByCell`. [[1]](diffhunk://#diff-9c19354efe01266306017bffadb297a9c171343bbff3bcf46413e17726a7e2a2L35-R35) [[2]](diffhunk://#diff-9c19354efe01266306017bffadb297a9c171343bbff3bcf46413e17726a7e2a2L62-R62) [[3]](diffhunk://#diff-9c19354efe01266306017bffadb297a9c171343bbff3bcf46413e17726a7e2a2L93-R93)
* [`src/shared/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary.h`](diffhunk://#diff-8d4676c0d29f07cbbae79acee8b4caebf83f4f9cb4d4958f0ce6a4dbae2c10bfL90-R90): Reflected changes in class names for boundary conditions. [[1]](diffhunk://#diff-8d4676c0d29f07cbbae79acee8b4caebf83f4f9cb4d4958f0ce6a4dbae2c10bfL90-R90) [[2]](diffhunk://#diff-8d4676c0d29f07cbbae79acee8b4caebf83f4f9cb4d4958f0ce6a4dbae2c10bfL193-R193) [[3]](diffhunk://#diff-8d4676c0d29f07cbbae79acee8b4caebf83f4f9cb4d4958f0ce6a4dbae2c10bfL224-R224) [[4]](diffhunk://#diff-8d4676c0d29f07cbbae79acee8b4caebf83f4f9cb4d4958f0ce6a4dbae2c10bfL247-R247)

### Test Case Adjustments:
* Multiple test files (`tests/2d_examples/test_2d_T_shaped_pipe/T_shaped_pipe.cpp`, `tests/2d_examples/test_2d_channel_flow_fluid_shell/channel_flow_shell.cpp`, and others) have been updated to use the new class names `AlignedBoxPartByParticle` and `AlignedBoxPartByCell`. [[1]](diffhunk://#diff-7f12efc05c008ad5d8a69de1a12f78bcb57e2265b988c80e8d98647e52aeabd0L141-R156) [[2]](diffhunk://#diff-117366183f425ff71bb76f1cef1a3f4c2b5433ab68847ec2d4930d4d7e527487L218-R218) [[3]](diffhunk://#diff-bfee2356190b26ebb8583f865adeaf7cc7586bdd11131fa6cdc2b54f29b93e5cL76-R76) [[4]](diffhunk://#diff-bfee2356190b26ebb8583f865adeaf7cc7586bdd11131fa6cdc2b54f29b93e5cL139-R139) [[5]](diffhunk://#diff-edcea6914ed828ef2b12e27bf1a1fcc50fb51ade7e61003bb4b4f060f854483bL125-R131) [[6]](diffhunk://#diff-521d4b74e75ccd793d7a7c720843b9f4eec0b1dfb143ddaf327914f2442ce614L116-R122) [[7]](diffhunk://#diff-045a8a0d33b61fa75b5ce3b96be77cd0975e65685bfa5d9d855ff4a80078bd58L126-R130) [[8]](diffhunk://#diff-4666a12d9710612d0e8d3ce0bb24e7c60bed8371fb3a65e37e9ed53accbd9a36L145-R145) [[9]](diffhunk://#diff-22bd113943e125b78d6b88c0e473b2db8ca4fc2d6ccb9788580c8f18ec694fdaL244-R244) [[10]](diffhunk://#diff-c0c49f84183eeacccd6041394f66580bb17fbdfbb6022208ad111c60f056719cL322-R322)

These changes streamline the codebase by centralizing aligned box functionality and updating references across the project to maintain consistency.