### PR TITLE
no memeber data in OperationOnDataAssemble

### DIFF
--- a/src/shared/common/base_data_package.h
+++ b/src/shared/common/base_data_package.h
@@ -77,24 +77,22 @@ template <typename DataAssembleType, typename OperationType>
 class OperationOnDataAssemble
 {
     static constexpr std::size_t tuple_size_ = std::tuple_size_v<DataAssembleType>;
-    DataAssembleType &data_assemble_;
     OperationType operation_;
 
     template <std::size_t... Is, typename... OperationArgs>
-    void operationSequence(std::index_sequence<Is...>, OperationArgs &&...operation_args)
+    void operationSequence(DataAssembleType &data_assemble, std::index_sequence<Is...>, OperationArgs &&...operation_args)
     {
-        (operation_(std::get<Is>(data_assemble_), std::forward<OperationArgs>(operation_args)...), ...);
+        (operation_(std::get<Is>(data_assemble), std::forward<OperationArgs>(operation_args)...), ...);
     }
 
   public:
     template <typename... Args>
-    OperationOnDataAssemble(DataAssembleType &data_assemble, Args &&...args)
-        : data_assemble_(data_assemble), operation_(std::forward<Args>(args)...){};
+    OperationOnDataAssemble(Args &&...args) : operation_(std::forward<Args>(args)...){};
 
     template <typename... OperationArgs>
-    void operator()(OperationArgs &&...operation_args)
+    void operator()(DataAssembleType &data_assemble, OperationArgs &&...operation_args)
     {
-        operationSequence(std::make_index_sequence<tuple_size_>{}, std::forward<OperationArgs>(operation_args)...);
+        operationSequence(data_assemble, std::make_index_sequence<tuple_size_>{}, std::forward<OperationArgs>(operation_args)...);
     }
 };
 } // namespace SPH

--- a/src/shared/io_system/io_base.cpp
+++ b/src/shared/io_system/io_base.cpp
@@ -25,15 +25,13 @@ bool BaseIO::isBodyIncluded(const SPHBodyVector &bodies, SPHBody *sph_body)
 //=============================================================================================//
 BodyStatesRecording::BodyStatesRecording(SPHSystem &sph_system)
     : BaseIO(sph_system), bodies_(sph_system.getRealBodies()),
+      prepare_variable_to_write_(),
       state_recording_(sph_system_.StateRecording())
 {
     for (size_t i = 0; i < bodies_.size(); ++i)
     {
         BaseParticles &particles = bodies_[i]->getBaseParticles();
         dv_all_pos_.push_back(particles.getVariableByName<Vecd>("Position"));
-        prepare_variable_to_write_.push_back(
-            OperationOnDataAssemble<ParticleVariables, prepareVariablesToWrite>(
-                particles.VariablesToWrite()));
     }
 }
 //=============================================================================================//
@@ -61,18 +59,12 @@ void BodyStatesRecording::writeToFile(size_t iteration_step)
 //=============================================================================================//
 RestartIO::RestartIO(SPHSystem &sph_system)
     : BaseIO(sph_system), bodies_(sph_system.getRealBodies()),
-      overall_file_path_(io_environment_.restart_folder_ + "/Restart_time_")
+      overall_file_path_(io_environment_.restart_folder_ + "/Restart_time_"),
+      prepare_variable_to_restart_()
 {
     for (size_t i = 0; i < bodies_.size(); ++i)
     {
         file_names_.push_back(io_environment_.restart_folder_ + "/" + bodies_[i]->getName() + "_rst_");
-
-        // basic variable for write to restart file
-        BaseParticles &particles = bodies_[i]->getBaseParticles();
-        particles.addVariableToRestart<UnsignedInt>("OriginalID");
-        prepare_variable_to_restart_.push_back(
-            OperationOnDataAssemble<ParticleVariables, prepareVariablesToWrite>(
-                particles.VariablesToRestart()));
     }
 }
 //=============================================================================================//
@@ -135,17 +127,12 @@ void RestartIO::readFromFile(size_t restart_step)
 }
 //=============================================================================================//
 ReloadParticleIO::ReloadParticleIO(SPHBodyVector bodies)
-    : BaseIO(bodies[0]->getSPHSystem()), bodies_(bodies)
+    : BaseIO(bodies[0]->getSPHSystem()), bodies_(bodies),
+      prepare_variable_to_reload_()
 {
     for (size_t i = 0; i < bodies_.size(); ++i)
     {
         file_names_.push_back(io_environment_.reload_folder_ + "/" + bodies_[i]->getName() + "_rld.xml");
-
-        // basic variable for write to restart file
-        BaseParticles &particles = bodies_[i]->getBaseParticles();
-        prepare_variable_to_reload_.push_back(
-            OperationOnDataAssemble<ParticleVariables, prepareVariablesToWrite>(
-                particles.VariablesToReload()));
     }
 }
 //=============================================================================================//

--- a/src/shared/meshes/mesh_with_data_packages.h
+++ b/src/shared/meshes/mesh_with_data_packages.h
@@ -122,7 +122,7 @@ class MeshWithGridDataPackages : public Mesh
             }
         }
     };
-    OperationOnDataAssemble<MeshVariableAssemble, ResizeMeshVariableData> resize_mesh_variable_data_{all_mesh_variables_};
+    OperationOnDataAssemble<MeshVariableAssemble, ResizeMeshVariableData> resize_mesh_variable_data_{};
 
     /** probe by applying bi and tri-linear interpolation within the package. */
     template <class DataType>
@@ -176,7 +176,7 @@ class MeshWithGridDataPackages : public Mesh
     void for_each_cell_data(const FunctionOnData &function);
     void resizeMeshVariableData()
     {
-        resize_mesh_variable_data_(num_grid_pkgs_);
+        resize_mesh_variable_data_(all_mesh_variables_, num_grid_pkgs_);
     }
 
     template <typename DataType>

--- a/src/shared/particle_dynamics/configuration_dynamics/particle_sorting.cpp
+++ b/src/shared/particle_dynamics/configuration_dynamics/particle_sorting.cpp
@@ -11,7 +11,7 @@ namespace SPH
 SwapSortableParticleData::SwapSortableParticleData(BaseParticles *base_particles)
     : sequence_(base_particles->getVariableDataByName<UnsignedInt>("Sequence")),
       sortable_data_(base_particles->SortableParticleData()),
-      swap_particle_data_value_(sortable_data_) {}
+      swap_particle_data_value_() {}
 //=================================================================================================//
 void SwapSortableParticleData::operator()(UnsignedInt *a, UnsignedInt *b)
 {
@@ -19,7 +19,7 @@ void SwapSortableParticleData::operator()(UnsignedInt *a, UnsignedInt *b)
 
     UnsignedInt index_a = a - sequence_;
     UnsignedInt index_b = b - sequence_;
-    swap_particle_data_value_(index_a, index_b);
+    swap_particle_data_value_(sortable_data_, index_a, index_b);
 }
 //=================================================================================================//
 ParticleSequence::ParticleSequence(RealBody &real_body)

--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -17,10 +17,10 @@ BaseParticles::BaseParticles(SPHBody &sph_body, BaseMaterial *base_material)
       base_material_(*base_material),
       restart_xml_parser_("xml_restart", "particles"),
       reload_xml_parser_("xml_particle_reload", "particles"),
-      copy_particle_state_(all_state_data_),
-      write_restart_variable_to_xml_(variables_to_restart_, restart_xml_parser_),
-      write_reload_variable_to_xml_(variables_to_reload_, reload_xml_parser_),
-      read_restart_variable_from_xml_(variables_to_restart_, restart_xml_parser_)
+      copy_particle_state_(),
+      write_restart_variable_to_xml_(restart_xml_parser_),
+      write_reload_variable_to_xml_(reload_xml_parser_),
+      read_restart_variable_from_xml_(restart_xml_parser_)
 {
     sph_body.assignBaseParticles(this);
     sv_total_real_particles_ = registerSingularVariable<UnsignedInt>("TotalRealParticles");
@@ -77,7 +77,7 @@ void BaseParticles::increaseAllParticlesBounds(size_t buffer_size)
 //=================================================================================================//
 void BaseParticles::copyFromAnotherParticle(size_t index, size_t another_index)
 {
-    copy_particle_state_(index, another_index);
+    copy_particle_state_(all_state_data_, index, another_index);
 }
 //=================================================================================================//
 size_t BaseParticles::allocateGhostParticles(size_t ghost_size)
@@ -132,20 +132,20 @@ void BaseParticles::resizeXmlDocForParticles(XmlParser &xml_parser)
 void BaseParticles::writeParticlesToXmlForRestart(std::string &filefullpath)
 {
     resizeXmlDocForParticles(restart_xml_parser_);
-    write_restart_variable_to_xml_();
+    write_restart_variable_to_xml_(variables_to_restart_);
     restart_xml_parser_.writeToXmlFile(filefullpath);
 }
 //=================================================================================================//
 void BaseParticles::readParticleFromXmlForRestart(std::string &filefullpath)
 {
     restart_xml_parser_.loadXmlFile(filefullpath);
-    read_restart_variable_from_xml_(this);
+    read_restart_variable_from_xml_(variables_to_restart_, this);
 }
 //=================================================================================================//
 void BaseParticles::writeToXmlForReloadParticle(std::string &filefullpath)
 {
     resizeXmlDocForParticles(reload_xml_parser_);
-    write_reload_variable_to_xml_();
+    write_reload_variable_to_xml_(variables_to_reload_);
     reload_xml_parser_.writeToXmlFile(filefullpath);
 }
 //=================================================================================================//

--- a/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.cpp
+++ b/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.cpp
@@ -4,9 +4,9 @@ namespace SPH
 {
 //=================================================================================================//
 UpdateSortableVariables::UpdateSortableVariables(BaseParticles *particles)
-    : particles_(particles), initialize_temp_variables_(temp_variables_)
+    : initialize_temp_variables_()
 {
-    initialize_temp_variables_(particles_->ParticlesBound());
+    initialize_temp_variables_(temp_variables_, particles->ParticlesBound());
 }
 //=================================================================================================//
 QuickSort::SwapParticleIndex::SwapParticleIndex(UnsignedInt *sequence, UnsignedInt *index_permutation)

--- a/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.h
@@ -46,7 +46,6 @@ class UpdateSortableVariables
         void operator()(UniquePtr<DiscreteVariable<DataType>> &variable_ptr, UnsignedInt data_size);
     };
 
-    BaseParticles *particles_;
     TemporaryVariables temp_variables_;
     OperationOnDataAssemble<TemporaryVariables, InitializeTemporaryVariables> initialize_temp_variables_;
 
@@ -55,7 +54,7 @@ class UpdateSortableVariables
 
     template <class ExecutionPolicy, typename DataType>
     void operator()(DataContainerAddressKeeper<DiscreteVariable<DataType>> &variables,
-                    ExecutionPolicy &ex_policy, BaseParticles *particles,
+                    ExecutionPolicy &ex_policy, UnsignedInt total_real_particles,
                     DiscreteVariable<UnsignedInt> *dv_index_permutation);
 };
 
@@ -68,7 +67,7 @@ class QuickSort
 
       public:
         SwapParticleIndex(UnsignedInt *sequence, UnsignedInt *index_permutation);
-        ~SwapParticleIndex(){};
+        ~SwapParticleIndex() {};
 
         void operator()(UnsignedInt *a, UnsignedInt *b);
     };
@@ -98,7 +97,7 @@ class ParticleSortCK : public LocalDynamics, public BaseDynamics<void>
 {
   public:
     explicit ParticleSortCK(RealBody &real_body);
-    virtual ~ParticleSortCK(){};
+    virtual ~ParticleSortCK() {};
 
     class ComputingKernel
     {
@@ -131,8 +130,7 @@ class ParticleSortCK : public LocalDynamics, public BaseDynamics<void>
     DiscreteVariable<UnsignedInt> *dv_index_permutation_;
     DiscreteVariable<UnsignedInt> *dv_original_id_;
     DiscreteVariable<UnsignedInt> *dv_sorted_id_;
-    OperationOnDataAssemble<ParticleVariables, UpdateSortableVariables>
-        update_variables_to_sort_;
+    OperationOnDataAssemble<ParticleVariables, UpdateSortableVariables> update_variables_to_sort_;
     SortMethodType sort_method_;
     Implementation<ExecutionPolicy, LocalDynamicsType, ComputingKernel> kernel_implementation_;
 };

--- a/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.hpp
@@ -16,7 +16,7 @@ void UpdateSortableVariables::InitializeTemporaryVariables::operator()(
 template <class ExecutionPolicy, typename DataType>
 void UpdateSortableVariables::operator()(
     DataContainerAddressKeeper<DiscreteVariable<DataType>> &variables,
-    ExecutionPolicy &ex_policy, BaseParticles *particles,
+    ExecutionPolicy &ex_policy, UnsignedInt total_real_particles,
     DiscreteVariable<UnsignedInt> *dv_index_permutation)
 {
     constexpr int type_index = DataTypeIndex<DataType>::value;
@@ -24,7 +24,6 @@ void UpdateSortableVariables::operator()(
 
     UnsignedInt *index_permutation = dv_index_permutation->DelegatedData(ex_policy);
 
-    UnsignedInt total_real_particles = particles->TotalRealParticles();
     for (size_t k = 0; k != variables.size(); ++k)
     {
         DataType *sorted_data_field = variables[k]->DelegatedData(ex_policy);
@@ -60,7 +59,7 @@ ParticleSortCK<ExecutionPolicy, SortMethodType>::ParticleSortCK(RealBody &real_b
           "IndexPermutation", particles_->ParticlesBound())),
       dv_original_id_(particles_->getVariableByName<UnsignedInt>("OriginalID")),
       dv_sorted_id_(particles_->getVariableByName<UnsignedInt>("SortedID")),
-      update_variables_to_sort_(particles_->VariablesToSort(), particles_),
+      update_variables_to_sort_(particles_),
       sort_method_(ExecutionPolicy{}, dv_sequence_, dv_index_permutation_),
       kernel_implementation_(*this)
 {
@@ -103,7 +102,7 @@ void ParticleSortCK<ExecutionPolicy, SortMethodType>::exec(Real dt)
                  { computing_kernel->prepareSequence(i); });
 
     sort_method_.sort(ex_policy_, particles_);
-    update_variables_to_sort_(ex_policy_, particles_, dv_index_permutation_);
+    update_variables_to_sort_(particles_->VariablesToSort(), ex_policy_, total_real_particles, dv_index_permutation_);
 
     particle_for(ex_policy_, IndexRange(0, total_real_particles),
                  [=](size_t i)


### PR DESCRIPTION
So that easy on device.

Copilot summary:
This pull request includes significant changes to the handling of `OperationOnDataAssemble` and its usage across various classes and methods. The primary aim is to simplify and improve the clarity of the codebase by removing unnecessary member variables and adjusting method parameters.

### Changes to `OperationOnDataAssemble` usage:

* [`src/shared/common/base_data_package.h`](diffhunk://#diff-4aeec55cdd0e285aa2455eb48be47959f8be4b26b9be59281bc2faafcf6cebafL80-R95): Removed the `data_assemble_` member variable and updated the `operationSequence` method to take `data_assemble` as a parameter.

### Changes in IO operations:

* [`src/shared/io_system/io_base.cpp`](diffhunk://#diff-e0244fcab44ad1877b117de0f021069e3717b5b6bd474c67b6f7a4e3c0f67ef5R28-L36): Removed the initialization of `prepare_variable_to_write_`, `prepare_variable_to_restart_`, and `prepare_variable_to_reload_` in the constructors of `BodyStatesRecording`, `RestartIO`, and `ReloadParticleIO` respectively. [[1]](diffhunk://#diff-e0244fcab44ad1877b117de0f021069e3717b5b6bd474c67b6f7a4e3c0f67ef5R28-L36) [[2]](diffhunk://#diff-e0244fcab44ad1877b117de0f021069e3717b5b6bd474c67b6f7a4e3c0f67ef5L64-L75) [[3]](diffhunk://#diff-e0244fcab44ad1877b117de0f021069e3717b5b6bd474c67b6f7a4e3c0f67ef5L138-L148)
* [`src/shared/io_system/io_base.h`](diffhunk://#diff-af28fd6a8d3d73b5b978528d6dfdc63dd655f5becccf7ccbd088f5f959070effL114-R115): Adjusted the `prepare_variable_to_write_`, `prepare_variable_to_restart_`, and `prepare_variable_to_reload_` member variables to be single instances instead of vectors. Updated related methods to use these single instances. [[1]](diffhunk://#diff-af28fd6a8d3d73b5b978528d6dfdc63dd655f5becccf7ccbd088f5f959070effL114-R115) [[2]](diffhunk://#diff-af28fd6a8d3d73b5b978528d6dfdc63dd655f5becccf7ccbd088f5f959070effL171-R174) [[3]](diffhunk://#diff-af28fd6a8d3d73b5b978528d6dfdc63dd655f5becccf7ccbd088f5f959070effL192-R191) [[4]](diffhunk://#diff-af28fd6a8d3d73b5b978528d6dfdc63dd655f5becccf7ccbd088f5f959070effL208-R207) [[5]](diffhunk://#diff-af28fd6a8d3d73b5b978528d6dfdc63dd655f5becccf7ccbd088f5f959070effR229-L232) [[6]](diffhunk://#diff-af28fd6a8d3d73b5b978528d6dfdc63dd655f5becccf7ccbd088f5f959070effL263-R262)

### Changes in particle dynamics:

* [`src/shared/particle_dynamics/configuration_dynamics/particle_sorting.cpp`](diffhunk://#diff-c1c75b14dbd5da4ce18fa888069539e40bb006b55652513a77fe33c9f9173795L14-R22): Updated the `SwapSortableParticleData` constructor and `operator()` method to remove direct member initialization and pass required data as parameters.
* [`src/shared/particles/base_particles.cpp`](diffhunk://#diff-d7dc99d92f4fd7062b15aacdd54fc73984fe85ae9b0408fc5caead8de70bfa93L20-R23): Removed unnecessary member variables and updated methods to pass required data as parameters. [[1]](diffhunk://#diff-d7dc99d92f4fd7062b15aacdd54fc73984fe85ae9b0408fc5caead8de70bfa93L20-R23) [[2]](diffhunk://#diff-d7dc99d92f4fd7062b15aacdd54fc73984fe85ae9b0408fc5caead8de70bfa93L80-R80) [[3]](diffhunk://#diff-d7dc99d92f4fd7062b15aacdd54fc73984fe85ae9b0408fc5caead8de70bfa93L135-R148)

### Changes in mesh handling:

* [`src/shared/meshes/mesh_with_data_packages.h`](diffhunk://#diff-e924158bb38c7174d196b667351d9eaf10b65f5bc8228334d70edfbd03fdfb8cL125-R125): Updated the `resize_mesh_variable_data_` member variable initialization and method call to pass required data as parameters. [[1]](diffhunk://#diff-e924158bb38c7174d196b667351d9eaf10b65f5bc8228334d70edfbd03fdfb8cL125-R125) [[2]](diffhunk://#diff-e924158bb38c7174d196b667351d9eaf10b65f5bc8228334d70edfbd03fdfb8cL179-R179)

### Changes in particle sorting:

* [`src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.cpp`](diffhunk://#diff-1d79f0fff312542433b27dfd843f9657d467f81be9439a407999f49ff478e83dL7-R9): Updated the `UpdateSortableVariables` constructor and `operator()` method to remove direct member initialization and pass required data as parameters.
* [`src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.h`](diffhunk://#diff-eaf9069406bcd48c0345ea766059e1432f324105a0d5008c5c3d5f71709ac2cdL49): Removed unnecessary member variables and updated methods to pass required data as parameters. [[1]](diffhunk://#diff-eaf9069406bcd48c0345ea766059e1432f324105a0d5008c5c3d5f71709ac2cdL49) [[2]](diffhunk://#diff-eaf9069406bcd48c0345ea766059e1432f324105a0d5008c5c3d5f71709ac2cdL58-R57) [[3]](diffhunk://#diff-eaf9069406bcd48c0345ea766059e1432f324105a0d5008c5c3d5f71709ac2cdL134-R133)
* [`src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.hpp`](diffhunk://#diff-8e17328079f4b1f3e610c9b0a00d9b5a09c94de941b27773c276ed0174ee420dL19-L27): Updated the `ParticleSortCK` constructor and `exec` method to pass required data as parameters. [[1]](diffhunk://#diff-8e17328079f4b1f3e610c9b0a00d9b5a09c94de941b27773c276ed0174ee420dL19-L27) [[2]](diffhunk://#diff-8e17328079f4b1f3e610c9b0a00d9b5a09c94de941b27773c276ed0174ee420dL63-R62) [[3]](diffhunk://#diff-8e17328079f4b1f3e610c9b0a00d9b5a09c94de941b27773c276ed0174ee420dL106-R105)