### PR TITLE
output singular variable

### DIFF
--- a/src/shared/io_system/io_observation.cpp
+++ b/src/shared/io_system/io_observation.cpp
@@ -1,0 +1,18 @@
+
+#include "io_observation.h"
+
+#include "sph_system.h"
+
+namespace SPH
+{
+//=================================================================================================//
+BaseQuantityRecording::BaseQuantityRecording(SPHSystem &sph_system,
+                                             const std::string &dynamics_identifier_name,
+                                             const std::string &quantity_name)
+    : BaseIO(sph_system), plt_engine_(),
+      dynamics_identifier_name_(dynamics_identifier_name),
+      quantity_name_(quantity_name),
+      filefullpath_output_(io_environment_.output_folder_ + "/" +
+                           dynamics_identifier_name_ + "_" + quantity_name + ".dat") {}
+//=================================================================================================//
+} // namespace SPH

--- a/src/shared/io_system/io_observation.h
+++ b/src/shared/io_system/io_observation.h
@@ -122,7 +122,7 @@ class ReducedQuantityRecording<LocalReduceMethodType> : public BaseQuantityRecor
     template <class DynamicsIdentifier, typename... Args>
     ReducedQuantityRecording(DynamicsIdentifier &identifier, Args &&...args)
         : BaseQuantityRecording(identifier.getSPHBody().getSPHSystem(),
-                                identifier.getSPHBody().getName(), ""),
+                                identifier.getName(), ""),
           reduce_method_(identifier, std::forward<Args>(args)...)
     {
         quantity_name_ = reduce_method_.QuantityName();

--- a/src/shared/io_system/io_observation.h
+++ b/src/shared/io_system/io_observation.h
@@ -22,52 +22,56 @@
  * ------------------------------------------------------------------------- */
 /**
  * @file 	io_observation.h
- * @brief 	Classes for input and output with vtk (Paraview) files.
+ * @brief 	Classes for observation recording.
  * @author	Chi Zhang, Shuoguo Zhang, Zhenxi Zhao and Xiangyu Hu
  */
 
 #ifndef IO_OBSERVATION_H
 #define IO_OBSERVATION_H
 
-#include "io_base.h"
-
 #include "io_plt.h"
 
 namespace SPH
 {
 
+class BaseQuantityRecording : public BaseIO
+{
+  public:
+    BaseQuantityRecording(SPHSystem &sph_system,
+                          const std::string &dynamics_identifier_name,
+                          const std::string &quantity_name);
+
+  protected:
+    PltEngine plt_engine_;
+    std::string dynamics_identifier_name_;
+    std::string quantity_name_;
+    std::string filefullpath_output_;
+};
+
 template <typename...>
 class ObservedQuantityRecording;
 
 template <typename VariableType>
-class ObservedQuantityRecording<VariableType> : public BodyStatesRecording,
+class ObservedQuantityRecording<VariableType> : public BaseQuantityRecording,
                                                 public ObservingAQuantity<VariableType>
 {
   protected:
     SPHBody &observer_;
-    PltEngine plt_engine_;
     BaseParticles &base_particles_;
-    std::string dynamics_identifier_name_;
-    const std::string quantity_name_;
-    std::string filefullpath_output_;
 
   public:
     VariableType type_indicator_; /*< this is an indicator to identify the variable type. */
 
   public:
     ObservedQuantityRecording(const std::string &quantity_name, BaseContactRelation &contact_relation)
-        : BodyStatesRecording(contact_relation.getSPHBody()),
+        : BaseQuantityRecording(contact_relation.getSPHBody().getSPHSystem(),
+                                contact_relation.getSPHBody().getName(), quantity_name),
           ObservingAQuantity<VariableType>(contact_relation, quantity_name),
-          observer_(contact_relation.getSPHBody()), plt_engine_(),
-          base_particles_(observer_.getBaseParticles()),
-          dynamics_identifier_name_(contact_relation.getSPHBody().getName()),
-          quantity_name_(quantity_name)
+          observer_(contact_relation.getSPHBody()),
+          base_particles_(observer_.getBaseParticles())
     {
-        /** Output for .dat file. */
-        filefullpath_output_ = io_environment_.output_folder_ + "/" + dynamics_identifier_name_ + "_" + quantity_name + ".dat";
         std::ofstream out_file(filefullpath_output_.c_str(), std::ios::app);
-        out_file << "run_time"
-                 << "   ";
+        out_file << "run_time" << "   ";
         for (size_t i = 0; i != base_particles_.TotalRealParticles(); ++i)
         {
             std::string quantity_name_i = quantity_name + "[" + std::to_string(i) + "]";
@@ -76,13 +80,13 @@ class ObservedQuantityRecording<VariableType> : public BodyStatesRecording,
         out_file << "\n";
         out_file.close();
     };
-    virtual ~ObservedQuantityRecording(){};
+    virtual ~ObservedQuantityRecording() {};
 
-    virtual void writeWithFileName(const std::string &sequence) override
+    virtual void writeToFile(size_t iteration_step = 0) override
     {
-        this->exec();
         std::ofstream out_file(filefullpath_output_.c_str(), std::ios::app);
         out_file << sv_physical_time_.getValue() << "   ";
+        this->exec();
         for (size_t i = 0; i != base_particles_.TotalRealParticles(); ++i)
         {
             plt_engine_.writeAQuantity(out_file, this->interpolated_quantities_[i]);
@@ -94,7 +98,7 @@ class ObservedQuantityRecording<VariableType> : public BodyStatesRecording,
     VariableType *getObservedQuantity()
     {
         return this->interpolated_quantities_;
-    }
+    };
 };
 
 template <typename...>
@@ -104,14 +108,10 @@ class ReducedQuantityRecording;
  * @brief write reduced quantity of a body
  */
 template <class LocalReduceMethodType>
-class ReducedQuantityRecording<LocalReduceMethodType> : public BaseIO
+class ReducedQuantityRecording<LocalReduceMethodType> : public BaseQuantityRecording
 {
   protected:
-    PltEngine plt_engine_;
     ReduceDynamics<LocalReduceMethodType> reduce_method_;
-    std::string dynamics_identifier_name_;
-    const std::string quantity_name_;
-    std::string filefullpath_output_;
 
   public:
     /*< deduce variable type from reduce method. */
@@ -121,27 +121,58 @@ class ReducedQuantityRecording<LocalReduceMethodType> : public BaseIO
   public:
     template <class DynamicsIdentifier, typename... Args>
     ReducedQuantityRecording(DynamicsIdentifier &identifier, Args &&...args)
-        : BaseIO(identifier.getSPHBody().getSPHSystem()), plt_engine_(),
-          reduce_method_(identifier, std::forward<Args>(args)...),
-          dynamics_identifier_name_(reduce_method_.DynamicsIdentifierName()),
-          quantity_name_(reduce_method_.QuantityName())
+        : BaseQuantityRecording(identifier.getSPHBody().getSPHSystem(),
+                                identifier.getSPHBody().getName(), ""),
+          reduce_method_(identifier, std::forward<Args>(args)...)
     {
-        /** output for .dat file. */
-        filefullpath_output_ = io_environment_.output_folder_ + "/" + dynamics_identifier_name_ + "_" + quantity_name_ + ".dat";
+        quantity_name_(reduce_method_.QuantityName());
         std::ofstream out_file(filefullpath_output_.c_str(), std::ios::app);
-        out_file << "\"run_time\""
-                 << "   ";
+        out_file << "\"run_time\"" << "   ";
         plt_engine_.writeAQuantityHeader(out_file, reduce_method_.Reference(), quantity_name_);
         out_file << "\n";
         out_file.close();
     };
-    virtual ~ReducedQuantityRecording(){};
+    virtual ~ReducedQuantityRecording() {};
 
     virtual void writeToFile(size_t iteration_step = 0) override
     {
         std::ofstream out_file(filefullpath_output_.c_str(), std::ios::app);
         out_file << sv_physical_time_.getValue() << "   ";
         plt_engine_.writeAQuantity(out_file, reduce_method_.exec());
+        out_file << "\n";
+        out_file.close();
+    };
+};
+
+template <typename DataType>
+class SingularVariableRecording : public BaseQuantityRecording
+{
+  protected:
+    SingularVariable<DataType> *variable_;
+
+  public:
+    typedef DataType VariableType;
+    VariableType type_indicator_; /*< this is an indicator to identify the variable type. */
+
+  public:
+    SingularVariableRecording(SPHSystem &sph_system, SingularVariable<DataType> *variable)
+        : BaseQuantityRecording(sph_system, "SingularVariable", variable->Name()),
+          variable_(variable)
+    {
+        std::ofstream out_file(filefullpath_output_.c_str(), std::ios::app);
+        out_file << "\"run_time\"" << "   ";
+        plt_engine_.writeAQuantityHeader(out_file, variable_->getValue(), quantity_name_);
+        out_file << "\n";
+        out_file.close();
+    };
+
+    virtual ~SingularVariableRecording() {};
+
+    virtual void writeToFile(size_t iteration_step = 0) override
+    {
+        std::ofstream out_file(filefullpath_output_.c_str(), std::ios::app);
+        out_file << sv_physical_time_.getValue() << "   ";
+        plt_engine_.writeAQuantity(out_file, variable_->getValue());
         out_file << "\n";
         out_file.close();
     };

--- a/src/shared/io_system/io_observation.h
+++ b/src/shared/io_system/io_observation.h
@@ -125,7 +125,7 @@ class ReducedQuantityRecording<LocalReduceMethodType> : public BaseQuantityRecor
                                 identifier.getSPHBody().getName(), ""),
           reduce_method_(identifier, std::forward<Args>(args)...)
     {
-        quantity_name_(reduce_method_.QuantityName());
+        quantity_name_ = reduce_method_.QuantityName();
         std::ofstream out_file(filefullpath_output_.c_str(), std::ios::app);
         out_file << "\"run_time\"" << "   ";
         plt_engine_.writeAQuantityHeader(out_file, reduce_method_.Reference(), quantity_name_);

--- a/src/shared/io_system/io_plt.cpp
+++ b/src/shared/io_system/io_plt.cpp
@@ -9,17 +9,29 @@
 namespace SPH
 {
 //=============================================================================================//
-void PltEngine::
-    writeAQuantityHeader(std::ofstream &out_file, const Real &quantity, const std::string &quantity_name)
+void PltEngine::writeAQuantityHeader(
+    std::ofstream &out_file, const Real &quantity, const std::string &quantity_name)
 {
     out_file << "\"" << quantity_name << "\"" << "   ";
 }
 //=============================================================================================//
-void PltEngine::
-    writeAQuantityHeader(std::ofstream &out_file, const Vecd &quantity, const std::string &quantity_name)
+void PltEngine::writeAQuantityHeader(
+    std::ofstream &out_file, const Vecd &quantity, const std::string &quantity_name)
 {
     for (int i = 0; i != Dimensions; ++i)
         out_file << "\"" << quantity_name << "[" << i << "]\"" << "   ";
+}
+//=============================================================================================//
+void PltEngine::writeAQuantityHeader(
+    std::ofstream &out_file, const SimTK::SpatialVec &quantity, const std::string &quantity_name)
+{
+    std::string torque = quantity_name + "Torque";
+    for (int i = 0; i != 3; ++i)
+        out_file << "\"" << torque << "[" << i << "]\"" << "   ";
+
+    std::string force = quantity_name + "Force";
+    for (int i = 0; i != 3; ++i)
+        out_file << "\"" << force << "[" << i << "]\"" << "   ";
 }
 //=============================================================================================//
 void PltEngine::writeAQuantity(std::ofstream &out_file, const Real &quantity)
@@ -32,6 +44,15 @@ void PltEngine::writeAQuantity(std::ofstream &out_file, const Vecd &quantity)
     for (int i = 0; i < Dimensions; ++i)
         out_file << std::fixed << std::setprecision(9) << quantity[i] << "   ";
 }
+//=============================================================================================//
+void PltEngine::writeAQuantity(std::ofstream &out_file, const SimTK::SpatialVec &quantity)
+{
+    for (int i = 0; i < 3; ++i)
+        out_file << std::fixed << std::setprecision(9) << quantity[0][i] << "   ";
+    for (int i = 0; i < 3; ++i)
+        out_file << std::fixed << std::setprecision(9) << quantity[1][i] << "   ";
+}
+
 //=================================================================================================//
 void BodyStatesRecordingToPlt::writePltFileHeader(
     std::ofstream &output_file, ParticleVariables &variables_to_write)

--- a/src/shared/io_system/io_plt.h
+++ b/src/shared/io_system/io_plt.h
@@ -40,13 +40,15 @@ namespace SPH
 class PltEngine
 {
   public:
-    PltEngine(){};
-    virtual ~PltEngine(){};
+    PltEngine() {};
+    virtual ~PltEngine() {};
 
     void writeAQuantityHeader(std::ofstream &out_file, const Real &quantity, const std::string &quantity_name);
     void writeAQuantityHeader(std::ofstream &out_file, const Vecd &quantity, const std::string &quantity_name);
+    void writeAQuantityHeader(std::ofstream &out_file, const SimTK::SpatialVec &quantity, const std::string &quantity_name);
     void writeAQuantity(std::ofstream &out_file, const Real &quantity);
     void writeAQuantity(std::ofstream &out_file, const Vecd &quantity);
+    void writeAQuantity(std::ofstream &out_file, const SimTK::SpatialVec &quantity);
 };
 
 /**
@@ -57,9 +59,9 @@ class PltEngine
 class BodyStatesRecordingToPlt : public BodyStatesRecording
 {
   public:
-    BodyStatesRecordingToPlt(SPHBody &body) : BodyStatesRecording(body){};
-    BodyStatesRecordingToPlt(SPHSystem &sph_system) : BodyStatesRecording(sph_system){};
-    virtual ~BodyStatesRecordingToPlt(){};
+    BodyStatesRecordingToPlt(SPHBody &body) : BodyStatesRecording(body) {};
+    BodyStatesRecordingToPlt(SPHSystem &sph_system) : BodyStatesRecording(sph_system) {};
+    virtual ~BodyStatesRecordingToPlt() {};
 
   protected:
     void writePltFileHeader(std::ofstream &output_file, ParticleVariables &variables_to_write);
@@ -79,7 +81,7 @@ class MeshRecordingToPlt : public BaseIO
 
   public:
     MeshRecordingToPlt(SPHSystem &sph_system, BaseMeshField &mesh_field);
-    virtual ~MeshRecordingToPlt(){};
+    virtual ~MeshRecordingToPlt() {};
     virtual void writeToFile(size_t iteration_step = 0) override;
 };
 } // namespace SPH

--- a/src/shared/particle_dynamics/dynamics_algorithms.h
+++ b/src/shared/particle_dynamics/dynamics_algorithms.h
@@ -135,9 +135,7 @@ class ReduceDynamics : public LocalDynamicsType,
         : LocalDynamicsType(identifier, std::forward<Args>(args)...),
           BaseDynamics<ReturnType>(){};
     virtual ~ReduceDynamics(){};
-
     std::string QuantityName() { return this->quantity_name_; };
-    std::string DynamicsIdentifierName() { return this->identifier_.getName(); };
 
     virtual ReturnType exec(Real dt = 0.0) override
     {

--- a/src/shared/shared_ck/io_system/io_observation_ck.h
+++ b/src/shared/shared_ck/io_system/io_observation_ck.h
@@ -33,42 +33,32 @@
 
 #include "execution_policy.h"
 #include "interpolation_dynamics.hpp"
-#include "io_plt.h"
 
 namespace SPH
 {
 template <class ExecutionPolicy, typename DataType>
 class ObservedQuantityRecording<ExecutionPolicy, DataType>
-    : public BodyStatesRecording,
+    : public BaseQuantityRecording,
       public ObservingAQuantityCK<ExecutionPolicy, DataType>
 {
   protected:
     SPHBody &observer_;
-    PltEngine plt_engine_;
     BaseParticles &base_particles_;
-    std::string dynamics_identifier_name_;
-    const std::string quantity_name_;
-    std::string filefullpath_output_;
 
   public:
     DataType type_indicator_; /*< this is an indicator to identify the variable type. */
 
   public:
     ObservedQuantityRecording(const std::string &quantity_name, Relation<Contact<>> &contact_relation)
-        : BodyStatesRecording(contact_relation.getSPHBody()),
+        : BaseQuantityRecording(contact_relation.getSPHBody().getSPHSystem(),
+                                contact_relation.getSPHBody().getName(), quantity_name),
           ObservingAQuantityCK<ExecutionPolicy, DataType>(contact_relation, quantity_name),
-          observer_(contact_relation.getSPHBody()), plt_engine_(),
-          base_particles_(observer_.getBaseParticles()),
-          dynamics_identifier_name_(contact_relation.getSPHBody().getName()),
-          quantity_name_(quantity_name)
+          observer_(contact_relation.getSPHBody()),
+          base_particles_(observer_.getBaseParticles())
     {
-        DataType *interpolated_quantities = this->dv_interpolated_quantities_->Data();
-        /** Output for .dat file. */
-        filefullpath_output_ = io_environment_.output_folder_ + "/" + dynamics_identifier_name_ + "_" + quantity_name + ".dat";
         std::ofstream out_file(filefullpath_output_.c_str(), std::ios::app);
-        out_file << "run_time"
-                 << "   ";
-
+        out_file << "run_time" << "   ";
+        DataType *interpolated_quantities = this->dv_interpolated_quantities_->Data();
         for (size_t i = 0; i != base_particles_.TotalRealParticles(); ++i)
         {
             std::string quantity_name_i = quantity_name + "[" + std::to_string(i) + "]";
@@ -79,13 +69,13 @@ class ObservedQuantityRecording<ExecutionPolicy, DataType>
     };
     virtual ~ObservedQuantityRecording() {};
 
-    virtual void writeWithFileName(const std::string &sequence) override
+    virtual void writeToFile(size_t iteration_step = 0) override
     {
+        std::ofstream out_file(filefullpath_output_.c_str(), std::ios::app);
+        out_file << sv_physical_time_.getValue() << "   ";
         this->exec();
         this->dv_interpolated_quantities_->prepareForOutput(ExecutionPolicy{});
         DataType *interpolated_quantities = this->dv_interpolated_quantities_->Data();
-        std::ofstream out_file(filefullpath_output_.c_str(), std::ios::app);
-        out_file << sv_physical_time_.getValue() << "   ";
         for (size_t i = 0; i != base_particles_.TotalRealParticles(); ++i)
         {
             plt_engine_.writeAQuantity(out_file, interpolated_quantities[i]);
@@ -101,14 +91,10 @@ class ObservedQuantityRecording<ExecutionPolicy, DataType>
 };
 
 template <class ExecutionPolicy, class LocalReduceMethodType>
-class ReducedQuantityRecording<ExecutionPolicy, LocalReduceMethodType> : public BaseIO
+class ReducedQuantityRecording<ExecutionPolicy, LocalReduceMethodType> : public BaseQuantityRecording
 {
   protected:
-    PltEngine plt_engine_;
     ReduceDynamicsCK<ExecutionPolicy, LocalReduceMethodType> reduce_method_;
-    std::string dynamics_identifier_name_;
-    const std::string quantity_name_;
-    std::string filefullpath_output_;
 
   public:
     /*< deduce variable type from reduce method. */
@@ -118,16 +104,13 @@ class ReducedQuantityRecording<ExecutionPolicy, LocalReduceMethodType> : public 
   public:
     template <class DynamicsIdentifier, typename... Args>
     ReducedQuantityRecording(DynamicsIdentifier &identifier, Args &&...args)
-        : BaseIO(identifier.getSPHBody().getSPHSystem()), plt_engine_(),
-          reduce_method_(identifier, std::forward<Args>(args)...),
-          dynamics_identifier_name_(reduce_method_.DynamicsIdentifierName()),
-          quantity_name_(reduce_method_.QuantityName())
+        : BaseQuantityRecording(identifier.getSPHBody().getSPHSystem(),
+                                identifier.getName(), ""),
+          reduce_method_(identifier, std::forward<Args>(args)...)
     {
-        /** output for .dat file. */
-        filefullpath_output_ = io_environment_.output_folder_ + "/" + dynamics_identifier_name_ + "_" + quantity_name_ + ".dat";
+        quantity_name_ = reduce_method_.QuantityName();
         std::ofstream out_file(filefullpath_output_.c_str(), std::ios::app);
-        out_file << "\"run_time\""
-                 << "   ";
+        out_file << "\"run_time\"" << "   ";
         plt_engine_.writeAQuantityHeader(out_file, ZeroData<VariableType>::value, quantity_name_);
         out_file << "\n";
         out_file.close();

--- a/src/shared/shared_ck/particle_dynamics/simple_algorithms_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/simple_algorithms_ck.h
@@ -88,9 +88,7 @@ class ReduceDynamicsCK : public ReduceType,
           BaseDynamics<OutputType>(), kernel_implementation_(*this),
           finish_dynamics_(*this){};
     virtual ~ReduceDynamicsCK() {};
-
     std::string QuantityName() { return this->quantity_name_; };
-    std::string DynamicsIdentifierName() { return this->identifier_.getName(); };
 
     virtual OutputType exec(Real dt = 0.0) override
     {

--- a/src/shared/sphinxsys_system/sph_system.h
+++ b/src/shared/sphinxsys_system/sph_system.h
@@ -73,7 +73,7 @@ class SPHSystem
 
     SPHSystem(BoundingBox system_domain_bounds, Real resolution_ref,
               size_t number_of_threads = std::thread::hardware_concurrency());
-    virtual ~SPHSystem(){};
+    virtual ~SPHSystem() {};
 
 #ifdef BOOST_AVAILABLE
     SPHSystem *handleCommandlineOptions(int ac, char *av[]);
@@ -101,8 +101,8 @@ class SPHSystem
     void addRealBody(SPHBody *sph_body) { real_bodies_.push_back(sph_body); };
 
     template <typename DataType>
-    SingularVariable<DataType> *registerSystemVariable(const std::string &name,
-                                                       DataType initial_value = ZeroData<DataType>::value);
+    SingularVariable<DataType> *registerSystemVariable(
+        const std::string &name, DataType initial_value = ZeroData<DataType>::value);
     template <typename DataType>
     SingularVariable<DataType> *getSystemVariableByName(const std::string &name);
 

--- a/tests/2d_examples/2d_examples_ck/test_2d_stfb_ck/stfb.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_stfb_ck/stfb.cpp
@@ -269,6 +269,8 @@ int main(int ac, char *av[])
         wave_gauge(wave_probe_buffer, "FreeSurfaceHeight");
     RegressionTestDynamicTimeWarping<ObservedQuantityRecording<MainExecutionPolicy, Vecd>>
         write_structure_position("Position", observer_contact);
+    SingularVariable<SimTK::SpatialVec> sv_action_on_structure("ActionOnStructure", SimTK::SpatialVec(0));
+    SingularVariableRecording<SimTK::SpatialVec> action_on_structure_recording(sph_system, &sv_action_on_structure);
     //----------------------------------------------------------------------
     //	Prepare the simulation with cell linked list, configuration
     //	and case specified initial condition if necessary.
@@ -329,7 +331,8 @@ int main(int ac, char *av[])
                 {
                     SimTK::State &state_for_update = integ.updAdvancedState();
                     force_on_bodies.clearAllBodyForces(state_for_update);
-                    force_on_bodies.setOneBodyForce(state_for_update, structure_mob, force_on_structure.exec());
+                    sv_action_on_structure.setValue(force_on_structure.exec());
+                    force_on_bodies.setOneBodyForce(state_for_update, structure_mob, sv_action_on_structure.getValue());
                     integ.stepBy(acoustic_dt);
                     constraint_on_structure.exec();
                 }
@@ -367,6 +370,7 @@ int main(int ac, char *av[])
             {
                 write_structure_position.writeToFile(number_of_iterations);
                 wave_gauge.writeToFile(number_of_iterations);
+                action_on_structure_recording.writeToFile(number_of_iterations);
             }
         }
 

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/regression_test_tool/VelocityObserver_Velocity_dtwdistance.xml
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/regression_test_tool/VelocityObserver_Velocity_dtwdistance.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <dtw_distance>
-    <DTWDistance Velocity_0="0.0019695095152534158" />
+    <DTWDistance Velocity_0="0.0025" />
 </dtw_distance>

--- a/tests/tests_sycl/2d_examples/test_2d_stfb_sycl/stfb.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_stfb_sycl/stfb.cpp
@@ -269,6 +269,8 @@ int main(int ac, char *av[])
         wave_gauge(wave_probe_buffer, "FreeSurfaceHeight");
     RegressionTestDynamicTimeWarping<ObservedQuantityRecording<MainExecutionPolicy, Vecd>>
         write_structure_position("Position", observer_contact);
+    SingularVariable<SimTK::SpatialVec> sv_action_on_structure("ActionOnStructure", SimTK::SpatialVec(0));
+    SingularVariableRecording<SimTK::SpatialVec> action_on_structure_recording(sph_system, &sv_action_on_structure);
     //----------------------------------------------------------------------
     //	Prepare the simulation with cell linked list, configuration
     //	and case specified initial condition if necessary.
@@ -329,7 +331,8 @@ int main(int ac, char *av[])
                 {
                     SimTK::State &state_for_update = integ.updAdvancedState();
                     force_on_bodies.clearAllBodyForces(state_for_update);
-                    force_on_bodies.setOneBodyForce(state_for_update, structure_mob, force_on_structure.exec());
+                    sv_action_on_structure.setValue(force_on_structure.exec());
+                    force_on_bodies.setOneBodyForce(state_for_update, structure_mob, sv_action_on_structure.getValue());
                     integ.stepBy(acoustic_dt);
                     constraint_on_structure.exec();
                 }
@@ -367,6 +370,7 @@ int main(int ac, char *av[])
             {
                 write_structure_position.writeToFile(number_of_iterations);
                 wave_gauge.writeToFile(number_of_iterations);
+                action_on_structure_recording.writeToFile(number_of_iterations);
             }
         }
 


### PR DESCRIPTION
Now, one can define a singular variable and output it to file.

Here is the summary from copilot:
This pull request includes several changes to the `io_system` and `sph_system` components, focusing on refactoring and extending the functionality of quantity recording classes. The most important changes include the introduction of a new base class for quantity recording, updates to existing recording classes to inherit from this new base class, and the addition of support for recording singular variables.

Refactoring and extending quantity recording:

* [`src/shared/io_system/io_observation.cpp`](diffhunk://#diff-a9bced3e1d8186368b111c4952366d0dc5fca3dd82d7569a8e8763ac4264fc5bR1-R18): Introduced a new base class `BaseQuantityRecording` for quantity recording, which initializes common properties like `plt_engine_`, `dynamics_identifier_name_`, and `quantity_name_`.
* [`src/shared/io_system/io_observation.h`](diffhunk://#diff-4eb311829765f8b4c91a150a62ae98c251d88868bbe11645c2f03f4c9b73f71dL25-R74): Updated `ObservedQuantityRecording` and `ReducedQuantityRecording` classes to inherit from `BaseQuantityRecording`, removing redundant initialization code. [[1]](diffhunk://#diff-4eb311829765f8b4c91a150a62ae98c251d88868bbe11645c2f03f4c9b73f71dL25-R74) [[2]](diffhunk://#diff-4eb311829765f8b4c91a150a62ae98c251d88868bbe11645c2f03f4c9b73f71dL107-L114)
* [`src/shared/io_system/io_observation.h`](diffhunk://#diff-4eb311829765f8b4c91a150a62ae98c251d88868bbe11645c2f03f4c9b73f71dR146-R179): Added a new class `SingularVariableRecording` to support recording singular variables, with methods for writing headers and quantities to files.

Enhancements to `PltEngine`:

* [`src/shared/io_system/io_plt.cpp`](diffhunk://#diff-156abdf87c92071d8f4fc853da3bb24c4645ba597ac9b676ea4b1aa6891da47bL12-R36): Added methods to `PltEngine` for writing headers and quantities of `SimTK::SpatialVec` type, enabling support for recording spatial vectors. [[1]](diffhunk://#diff-156abdf87c92071d8f4fc853da3bb24c4645ba597ac9b676ea4b1aa6891da47bL12-R36) [[2]](diffhunk://#diff-156abdf87c92071d8f4fc853da3bb24c4645ba597ac9b676ea4b1aa6891da47bR47-R55)
* [`src/shared/io_system/io_plt.h`](diffhunk://#diff-f9a02d687413067984ee596842fcbcf61de8056953e0e0203a31a13eb196c88dR48-R51): Declared the new methods for handling `SimTK::SpatialVec` in the `PltEngine` class.

Updates to tests:

* [`tests/2d_examples/2d_examples_ck/test_2d_stfb_ck/stfb.cpp`](diffhunk://#diff-c24da068b40021d39278a21262aa4d6112910e72018fc429b05e1bb02569e38bR272-R273): Added a `SingularVariable` and its recording in the test case, and updated the simulation loop to set and record the singular variable. [[1]](diffhunk://#diff-c24da068b40021d39278a21262aa4d6112910e72018fc429b05e1bb02569e38bR272-R273) [[2]](diffhunk://#diff-c24da068b40021d39278a21262aa4d6112910e72018fc429b05e1bb02569e38bL332-R335) [[3]](diffhunk://#diff-c24da068b40021d39278a21262aa4d6112910e72018fc429b05e1bb02569e38bR373)
* [`tests/tests_sycl/2d_examples/test_2d_stfb_sycl/stfb.cpp`](diffhunk://#diff-0852f09144a8384bbbe05a17cbf50bdebbf0bf92c8f706e400658dc51f498173R272-R273): Similar updates as above to include a `SingularVariable` and its recording in the SYCL test case. [[1]](diffhunk://#diff-0852f09144a8384bbbe05a17cbf50bdebbf0bf92c8f706e400658dc51f498173R272-R273) [[2]](diffhunk://#diff-0852f09144a8384bbbe05a17cbf50bdebbf0bf92c8f706e400658dc51f498173L332-R335) [[3]](diffhunk://#diff-0852f09144a8384bbbe05a17cbf50bdebbf0bf92c8f706e400658dc51f498173R373)