### PR TITLE
Fix/register get variables

### DIFF
--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -167,6 +167,10 @@ class BaseParticles
     DiscreteVariable<DataType> *registerStateVariableOnlyFrom(const std::string &name, const StdLargeVec<DataType> &geometric_data);
     template <typename DataType>
     DiscreteVariable<DataType> *registerStateVariableOnlyFromReload(const std::string &name);
+    template <typename DataType>
+    StdVec<DiscreteVariable<DataType> *> registerStateVariables(const StdVec<std::string> &names, const std::string &suffix);
+    template <typename DataType>
+    StdVec<DiscreteVariable<DataType> *> getVariablesByName(const StdVec<std::string> &names, const std::string &suffix);
 
     template <typename DataType>
     SingularVariable<DataType> *addUniqueSingularVariableOnly(const std::string &name, DataType initial_value = ZeroData<DataType>::value);

--- a/src/shared/particles/base_particles.hpp
+++ b/src/shared/particles/base_particles.hpp
@@ -262,6 +262,32 @@ DataType *BaseParticles::getVariableDataByName(const std::string &name)
     return variable->Data();
 }
 //=================================================================================================//
+template <typename DataType>
+StdVec<DiscreteVariable<DataType> *> BaseParticles::registerStateVariables(
+    const StdVec<std::string> &names, const std::string &suffix)
+{
+    StdVec<DiscreteVariable<DataType> *> variables;
+    for (auto &name : names)
+    {
+        std::string variable_name = name + suffix;
+        variables.push_back(registerStateVariableOnly<DataType>(variable_name));
+    }
+    return variables;
+}
+//=================================================================================================//
+template <typename DataType>
+StdVec<DiscreteVariable<DataType> *> BaseParticles::getVariablesByName(
+    const StdVec<std::string> &names, const std::string &suffix)
+{
+    StdVec<DiscreteVariable<DataType> *> variables;
+    for (auto &name : names)
+    {
+        std::string variable_name = name + suffix;
+        variables.push_back(getVariableByName<DataType>(variable_name));
+    }
+    return variables;
+}
+//=================================================================================================//
 template <class DataType>
 SingularVariable<DataType> *BaseParticles::
     addUniqueSingularVariableOnly(const std::string &name, DataType initial_value)

--- a/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.h
@@ -127,9 +127,9 @@ template <class DiffusionType, class BaseInteractionType>
 class DiffusionRelaxationCK<DiffusionType, BaseInteractionType>
     : public BaseInteractionType
 {
-    StdVec<DiffusionType *> getConcreteDiffusions(AbstractDiffusion &abstract_diffusion);
-    StdVec<std::string> getDiffusionSpeciesNames(StdVec<DiffusionType *> &diffusions);
-    StdVec<std::string> getGradientSpeciesNames(StdVec<DiffusionType *> &diffusions);
+    StdVec<DiffusionType *> obtainConcreteDiffusions(AbstractDiffusion &abstract_diffusion);
+    StdVec<std::string> obtainDiffusionSpeciesNames(StdVec<DiffusionType *> &diffusions);
+    StdVec<std::string> obtainGradientSpeciesNames(StdVec<DiffusionType *> &diffusions);
 
   public:
     template <class DynamicsIdentifier>

--- a/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.h
@@ -31,8 +31,8 @@
 
 #include "diffusion_reaction.h"
 #include "interaction_ck.hpp"
-#include "sphinxsys_variable_array.h"
 #include "sphinxsys_constant.h"
+#include "sphinxsys_variable_array.h"
 
 namespace SPH
 {
@@ -128,6 +128,8 @@ class DiffusionRelaxationCK<DiffusionType, BaseInteractionType>
     : public BaseInteractionType
 {
     StdVec<DiffusionType *> getConcreteDiffusions(AbstractDiffusion &abstract_diffusion);
+    StdVec<std::string> getDiffusionSpeciesNames(StdVec<DiffusionType *> &diffusions);
+    StdVec<std::string> getGradientSpeciesNames(StdVec<DiffusionType *> &diffusions);
 
   public:
     template <class DynamicsIdentifier>
@@ -139,9 +141,9 @@ class DiffusionRelaxationCK<DiffusionType, BaseInteractionType>
         : DiffusionRelaxationCK(parameters.identifier_, std::get<0>(parameters.others_)){};
     virtual ~DiffusionRelaxationCK() {};
     StdVec<DiffusionType *> &getDiffusions() { return diffusions_; };
+    StdVec<std::string> &getDiffusionSpeciesNames() { return diffusion_species_names_; };
+    StdVec<std::string> &getGradientSpeciesNames() { return gradient_species_names_; };
     DiscreteVariableArray<Real> &dvGradientSpeciesArray() { return dv_gradient_species_array_; };
-    StdVec<DiscreteVariable<Real> *> getDiffusionVariables(BaseParticles *particles, const std::string &suffix);
-    StdVec<DiscreteVariable<Real> *> getGradientVariables(BaseParticles *particles, const std::string &suffix);
 
     class InteractKernel : public BaseInteractionType::InteractKernel
     {
@@ -156,6 +158,8 @@ class DiffusionRelaxationCK<DiffusionType, BaseInteractionType>
 
   protected:
     StdVec<DiffusionType *> diffusions_;
+    StdVec<std::string> diffusion_species_names_;
+    StdVec<std::string> gradient_species_names_;
     DiscreteVariableArray<Real> dv_diffusion_species_array_;
     DiscreteVariableArray<Real> dv_gradient_species_array_;
     DiscreteVariableArray<Real> dv_diffusion_dt_array_;

--- a/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.hpp
@@ -17,9 +17,9 @@ template <class DynamicsIdentifier>
 DiffusionRelaxationCK<DiffusionType, BaseInteractionType>::
     DiffusionRelaxationCK(DynamicsIdentifier &identifier, AbstractDiffusion *abstract_diffusion)
     : BaseInteractionType(identifier),
-      diffusions_(this->getConcreteDiffusions(*abstract_diffusion)),
-      diffusion_species_names_(this->getDiffusionSpeciesNames()),
-      gradient_species_names_(this->getGradientSpeciesNames()),
+      diffusions_(this->obtainConcreteDiffusions(*abstract_diffusion)),
+      diffusion_species_names_(this->obtainDiffusionSpeciesNames(diffusions_)),
+      gradient_species_names_(this->obtainGradientSpeciesNames(diffusions_)),
       dv_diffusion_species_array_(this->particles_->template getVariablesByName<Real>(
           diffusion_species_names_, "")),
       dv_gradient_species_array_(this->particles_->template getVariablesByName<Real>(
@@ -42,7 +42,7 @@ DiffusionRelaxationCK<DiffusionType, BaseInteractionType>::
 //=================================================================================================//
 template <class DiffusionType, class BaseInteractionType>
 StdVec<DiffusionType *> DiffusionRelaxationCK<DiffusionType, BaseInteractionType>::
-    getConcreteDiffusions(AbstractDiffusion &abstract_diffusion)
+    obtainConcreteDiffusions(AbstractDiffusion &abstract_diffusion)
 {
     StdVec<AbstractDiffusion *> all_diffusions = abstract_diffusion.AllDiffusions();
     StdVec<DiffusionType *> diffusions;
@@ -55,7 +55,7 @@ StdVec<DiffusionType *> DiffusionRelaxationCK<DiffusionType, BaseInteractionType
 //=================================================================================================//
 template <class DiffusionType, class BaseInteractionType>
 StdVec<std::string> DiffusionRelaxationCK<DiffusionType, BaseInteractionType>::
-    getDiffusionSpeciesNames(StdVec<DiffusionType *> &diffusions)
+    obtainDiffusionSpeciesNames(StdVec<DiffusionType *> &diffusions)
 {
     StdVec<std::string> diffusion_species_names;
     for (auto &diffusion : diffusions)
@@ -67,7 +67,7 @@ StdVec<std::string> DiffusionRelaxationCK<DiffusionType, BaseInteractionType>::
 //=================================================================================================//
 template <class DiffusionType, class BaseInteractionType>
 StdVec<std::string> DiffusionRelaxationCK<DiffusionType, BaseInteractionType>::
-    getGradientSpeciesNames(StdVec<DiffusionType *> &diffusions)
+    obtainGradientSpeciesNames(StdVec<DiffusionType *> &diffusions)
 {
     StdVec<std::string> gradient_species_names;
     for (auto &diffusion : diffusions)
@@ -254,7 +254,7 @@ template <typename... Args>
 DiffusionRelaxationCK<RelationType<OneLevel, RungeKutta2ndStage, InteractionParameters...>>::
     DiffusionRelaxationCK(Args &&...args)
     : BaseDynamicsType(std::forward<Args>(args)...),
-      dv_diffusion_species_array_s_(this->particles_->template registerStateVariables<Real>(
+      dv_diffusion_species_array_s_(this->particles_->template getVariablesByName<Real>(
           this->diffusion_species_names_, "Intermediate")) {}
 //=================================================================================================//
 template <template <typename...> class RelationType, class... InteractionParameters>

--- a/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.hpp
@@ -18,9 +18,14 @@ DiffusionRelaxationCK<DiffusionType, BaseInteractionType>::
     DiffusionRelaxationCK(DynamicsIdentifier &identifier, AbstractDiffusion *abstract_diffusion)
     : BaseInteractionType(identifier),
       diffusions_(this->getConcreteDiffusions(*abstract_diffusion)),
-      dv_diffusion_species_array_(this->getDiffusionVariables(this->particles_, "")),
-      dv_gradient_species_array_(this->getGradientVariables(this->particles_, "")),
-      dv_diffusion_dt_array_(this->getDiffusionVariables(this->particles_, "ChangeRate"))
+      diffusion_species_names_(this->getDiffusionSpeciesNames()),
+      gradient_species_names_(this->getGradientSpeciesNames()),
+      dv_diffusion_species_array_(this->particles_->template getVariablesByName<Real>(
+          diffusion_species_names_, "")),
+      dv_gradient_species_array_(this->particles_->template getVariablesByName<Real>(
+          gradient_species_names_, "")),
+      dv_diffusion_dt_array_(this->particles_->template registerStateVariables<Real>(
+          diffusion_species_names_, "ChangeRate"))
 {
     this->particles_->template addVariableToWrite<Real>(&dv_diffusion_species_array_);
     this->particles_->template addVariableToWrite<Real>(&dv_gradient_species_array_);
@@ -49,31 +54,27 @@ StdVec<DiffusionType *> DiffusionRelaxationCK<DiffusionType, BaseInteractionType
 }
 //=================================================================================================//
 template <class DiffusionType, class BaseInteractionType>
-StdVec<DiscreteVariable<Real> *> DiffusionRelaxationCK<DiffusionType, BaseInteractionType>::
-    getDiffusionVariables(BaseParticles *particles, const std::string &suffix)
+StdVec<std::string> DiffusionRelaxationCK<DiffusionType, BaseInteractionType>::
+    getDiffusionSpeciesNames(StdVec<DiffusionType *> &diffusions)
 {
-    StdVec<DiscreteVariable<Real> *> diffusion_variables;
-    for (auto &diffusion : diffusions_)
+    StdVec<std::string> diffusion_species_names;
+    for (auto &diffusion : diffusions)
     {
-        std::string variable_name = diffusion->DiffusionSpeciesName() + suffix;
-        diffusion_variables.push_back(
-            particles->template registerStateVariableOnly<Real>(variable_name));
+        diffusion_species_names.push_back(diffusion->DiffusionSpeciesName());
     }
-    return diffusion_variables;
+    return diffusion_species_names;
 }
 //=================================================================================================//
 template <class DiffusionType, class BaseInteractionType>
-StdVec<DiscreteVariable<Real> *> DiffusionRelaxationCK<DiffusionType, BaseInteractionType>::
-    getGradientVariables(BaseParticles *particles, const std::string &suffix)
+StdVec<std::string> DiffusionRelaxationCK<DiffusionType, BaseInteractionType>::
+    getGradientSpeciesNames(StdVec<DiffusionType *> &diffusions)
 {
-    StdVec<DiscreteVariable<Real> *> diffusion_variables;
-    for (auto &diffusion : diffusions_)
+    StdVec<std::string> gradient_species_names;
+    for (auto &diffusion : diffusions)
     {
-        std::string variable_name = diffusion->GradientSpeciesName() + suffix;
-        diffusion_variables.push_back(
-            particles->template registerStateVariableOnly<Real>(variable_name));
+        gradient_species_names.push_back(diffusion->GradientSpeciesName());
     }
-    return diffusion_variables;
+    return gradient_species_names;
 }
 //=================================================================================================//
 template <class DiffusionType, class BaseInteractionType>
@@ -142,7 +143,8 @@ DiffusionRelaxationCK<Contact<InteractionOnly, BoundaryType<DiffusionType>, Kern
             this->contact_particles_[k]->template getVariableByName<Real>("VolumetricMeasure"));
         contact_dv_transfer_array_.push_back(
             contact_transfer_array_ptrs_keeper_.createPtr<DiscreteVariableArray<Real>>(
-                this->getDiffusionVariables(this->particles_, "TransferWith" + this->sph_body_.getName())));
+                this->particles_->template registerStateVariables<Real>(
+                    this->diffusion_species_names_, "TransferWith" + this->sph_body_.getName())));
         contact_kernel_gradient_method_.push_back(
             kernel_gradient_ptrs_keeper_.template createPtr<KernelGradientType>(
                 this->particles_, this->contact_particles_[k]));
@@ -224,7 +226,8 @@ template <typename... Args>
 DiffusionRelaxationCK<RelationType<OneLevel, RungeKutta1stStage, InteractionParameters...>>::
     DiffusionRelaxationCK(Args &&...args)
     : BaseDynamicsType(std::forward<Args>(args)...),
-      dv_diffusion_species_array_s_(this->getDiffusionVariables(this->particles_, "Intermediate")) {}
+      dv_diffusion_species_array_s_(this->particles_->template registerStateVariables<Real>(
+          this->diffusion_species_names_, "Intermediate")) {}
 //=================================================================================================//
 template <template <typename...> class RelationType, class... InteractionParameters>
 template <class ExecutionPolicy, class EncloserType>
@@ -251,7 +254,8 @@ template <typename... Args>
 DiffusionRelaxationCK<RelationType<OneLevel, RungeKutta2ndStage, InteractionParameters...>>::
     DiffusionRelaxationCK(Args &&...args)
     : BaseDynamicsType(std::forward<Args>(args)...),
-      dv_diffusion_species_array_s_(this->getDiffusionVariables(this->particles_, "Intermediate")) {}
+      dv_diffusion_species_array_s_(this->particles_->template registerStateVariables<Real>(
+          this->diffusion_species_names_, "Intermediate")) {}
 //=================================================================================================//
 template <template <typename...> class RelationType, class... InteractionParameters>
 template <class ExecutionPolicy, class EncloserType>
@@ -278,7 +282,8 @@ Dirichlet<DiffusionType>::Dirichlet(DiffusionDynamics &diffusion_dynamics, BaseP
     : smoothing_length_sq_(
           pow(diffusion_dynamics.getSPHAdaptation()->ReferenceSmoothingLength(), 2)),
       dv_gradient_species_array_(diffusion_dynamics.dvGradientSpeciesArray()),
-      contact_dv_gradient_species_array_(diffusion_dynamics.getGradientVariables(contact_particles, "")),
+      contact_dv_gradient_species_array_(contact_particles->template registerStateVariables<Real>(
+          diffusion_dynamics.getGradientSpeciesNames(), "")),
       ca_inter_particle_diffusion_coeff_(diffusion_dynamics.getDiffusions())
 {
     contact_particles->template addVariableToWrite<Real>(&contact_dv_gradient_species_array_);
@@ -310,7 +315,8 @@ template <class DiffusionType>
 template <class DiffusionDynamics>
 Neumann<DiffusionType>::Neumann(DiffusionDynamics &diffusion_dynamics, BaseParticles *contact_particles)
     : dv_contact_n_(contact_particles->getVariableByName<Vecd>("NormalDirection")),
-      contact_dv_species_flux_array_(diffusion_dynamics.getDiffusionVariables(contact_particles, "Flux")) {}
+      contact_dv_species_flux_array_(contact_particles->template getVariablesByName<Real>(
+          diffusion_dynamics.getDiffusionSpeciesNames(), "Flux")) {}
 //=================================================================================================//
 template <class DiffusionType>
 template <class ExecutionPolicy, class EncloserType>


### PR DESCRIPTION
so that the time evolving variable should be defined before the method is constructed.

Copilot summary:
This pull request introduces several enhancements and refactoring changes to the particle dynamics codebase, particularly focusing on the `DiffusionRelaxationCK` class and related functionalities. The main improvements include the addition of new methods for handling state variables and the renaming of existing methods for better clarity. Below are the most important changes:

### Enhancements to State Variable Handling:

* Added `registerStateVariables` and `getVariablesByName` methods to the `BaseParticles` class for registering and retrieving multiple state variables by name. (`src/shared/particles/base_particles.h`, `src/shared/particles/base_particles.hpp`) [[1]](diffhunk://#diff-429fe4c2d7d343634cb6b8f381e45b91cecbd79fa65b86c343c0b0318c70606eR170-R173) [[2]](diffhunk://#diff-16ad8c0941eb1e568b8f4282768a4a7d6c18972873003e6e539d4f3756078777R265-R290)

### Refactoring for Clarity:

* Renamed methods in `DiffusionRelaxationCK` class from `getConcreteDiffusions`, `getDiffusionVariables`, and `getGradientVariables` to `obtainConcreteDiffusions`, `obtainDiffusionSpeciesNames`, and `obtainGradientSpeciesNames` respectively. (`src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.h`, `src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.hpp`) [[1]](diffhunk://#diff-a4b262bf02d6d07d62e3656c70201511a56118a2acd8948e40d536c12c8040f8L130-R132) [[2]](diffhunk://#diff-6cb488e70e2deacf4d79c3e64804ce38058ec7744239a2e08689eb6a118a3d78L40-R45) [[3]](diffhunk://#diff-6cb488e70e2deacf4d79c3e64804ce38058ec7744239a2e08689eb6a118a3d78L52-R77)

### Codebase Simplification:

* Replaced calls to `getDiffusionVariables` and `getGradientVariables` with the new methods `registerStateVariables` and `getVariablesByName` in the `DiffusionRelaxationCK` class constructor and related methods. (`src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.hpp`) [[1]](diffhunk://#diff-6cb488e70e2deacf4d79c3e64804ce38058ec7744239a2e08689eb6a118a3d78L20-R28) [[2]](diffhunk://#diff-6cb488e70e2deacf4d79c3e64804ce38058ec7744239a2e08689eb6a118a3d78L145-R147) [[3]](diffhunk://#diff-6cb488e70e2deacf4d79c3e64804ce38058ec7744239a2e08689eb6a118a3d78L227-R230) [[4]](diffhunk://#diff-6cb488e70e2deacf4d79c3e64804ce38058ec7744239a2e08689eb6a118a3d78L254-R258) [[5]](diffhunk://#diff-6cb488e70e2deacf4d79c3e64804ce38058ec7744239a2e08689eb6a118a3d78L281-R286) [[6]](diffhunk://#diff-6cb488e70e2deacf4d79c3e64804ce38058ec7744239a2e08689eb6a118a3d78L313-R319)

### Minor Code Cleanup:

* Reordered includes in `diffusion_dynamics_ck.h` for better organization. (`src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.h`)

These changes collectively enhance the readability, maintainability, and functionality of the particle dynamics codebase.