### PR TITLE
Add missing kernel for Inner relation

### DIFF
--- a/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.hpp
@@ -94,7 +94,10 @@ InteractionDynamicsCK<ExecutionPolicy, InteractionType<RelationType<WithUpdate, 
           std::forward<Args>(args)...),
       InteractionDynamicsCK<WithUpdate>(),
       BaseDynamics<void>(),
-      kernel_implementation_(*this) {}
+      kernel_implementation_(*this)
+{
+    this->registerComputingKernel(&kernel_implementation_);
+}
 //=================================================================================================//
 template <class ExecutionPolicy, template <typename...> class InteractionType,
           template <typename...> class RelationType, typename... OtherParameters>

--- a/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.hpp
@@ -96,7 +96,12 @@ InteractionDynamicsCK<ExecutionPolicy, InteractionType<RelationType<WithUpdate, 
       BaseDynamics<void>(),
       kernel_implementation_(*this)
 {
-    this->registerComputingKernel(&kernel_implementation_);
+    if constexpr (
+        std::is_same_v<InteractionType<RelationType<WithUpdate, OtherParameters...>>,
+                       InteractionType<Inner<WithUpdate, OtherParameters...>>>)
+    {
+        this->registerComputingKernel(&kernel_implementation_);
+    }
 }
 //=================================================================================================//
 template <class ExecutionPolicy, template <typename...> class InteractionType,


### PR DESCRIPTION
This PR is related #749, and the findings there. It patches the InteractionDynamicsCK class, such that for types with InteractionType with Inner<WithUpdate>, the computing kernel is registered. 