### PR TITLE
using is base of

### DIFF
--- a/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.h
@@ -42,7 +42,7 @@ template <>
 class InteractionDynamicsCK<Base>
 {
   public:
-    InteractionDynamicsCK(){};
+    InteractionDynamicsCK() {};
     void addPreProcess(BaseDynamics<void> *pre_process) { pre_processes_.push_back(pre_process); };
     void addPostProcess(BaseDynamics<void> *post_process) { post_processes_.push_back(post_process); };
 
@@ -61,7 +61,7 @@ template <>
 class InteractionDynamicsCK<WithUpdate> : public InteractionDynamicsCK<Base>
 {
   public:
-    InteractionDynamicsCK() : InteractionDynamicsCK<Base>(){};
+    InteractionDynamicsCK() : InteractionDynamicsCK<Base>() {};
     virtual void runAllSteps(Real dt) override;
 
   protected:
@@ -72,7 +72,7 @@ template <>
 class InteractionDynamicsCK<WithInitialization> : public InteractionDynamicsCK<Base>
 {
   public:
-    InteractionDynamicsCK() : InteractionDynamicsCK<Base>(){};
+    InteractionDynamicsCK() : InteractionDynamicsCK<Base>() {};
     virtual void runAllSteps(Real dt) override;
 
   protected:
@@ -83,7 +83,7 @@ template <>
 class InteractionDynamicsCK<OneLevel> : public InteractionDynamicsCK<Base>
 {
   public:
-    InteractionDynamicsCK() : InteractionDynamicsCK<Base>(){};
+    InteractionDynamicsCK() : InteractionDynamicsCK<Base>() {};
     virtual void runAllSteps(Real dt) override;
 
   protected:
@@ -104,7 +104,7 @@ class InteractionDynamicsCK<ExecutionPolicy, Base, InteractionType<Inner<Paramet
   public:
     template <typename... Args>
     InteractionDynamicsCK(Args &&...args);
-    virtual ~InteractionDynamicsCK(){};
+    virtual ~InteractionDynamicsCK() {};
 
   protected:
     void runInteraction(Real dt);
@@ -124,7 +124,7 @@ class InteractionDynamicsCK<ExecutionPolicy, Base, InteractionType<Contact<Param
   public:
     template <typename... Args>
     InteractionDynamicsCK(Args &&...args);
-    virtual ~InteractionDynamicsCK(){};
+    virtual ~InteractionDynamicsCK() {};
 
   protected:
     void runInteraction(Real dt);
@@ -141,7 +141,7 @@ class InteractionDynamicsCK<ExecutionPolicy, InteractionType<RelationType<Parame
   public:
     template <typename... Args>
     InteractionDynamicsCK(Args &&...args);
-    virtual ~InteractionDynamicsCK(){};
+    virtual ~InteractionDynamicsCK() {};
 
     virtual void exec(Real dt = 0.0) override;
     virtual void runInteractionStep(Real dt = 0.0) override;
@@ -159,14 +159,14 @@ class InteractionDynamicsCK<
     using LocalDynamicsType = InteractionType<RelationType<WithUpdate, OtherParameters...>>;
     using Identifier = typename LocalDynamicsType::Identifier;
     using UpdateKernel = typename LocalDynamicsType::UpdateKernel;
-    using KernelImplementation =
-        Implementation<ExecutionPolicy, LocalDynamicsType, UpdateKernel>;
+    using BaseInteractKernel = typename LocalDynamicsType::BaseInteractKernel;
+    using KernelImplementation = Implementation<ExecutionPolicy, LocalDynamicsType, UpdateKernel>;
     KernelImplementation kernel_implementation_;
 
   public:
     template <typename... Args>
     InteractionDynamicsCK(Args &&...args);
-    virtual ~InteractionDynamicsCK(){};
+    virtual ~InteractionDynamicsCK() {};
     virtual void exec(Real dt = 0.0) override;
 
   protected:
@@ -187,6 +187,7 @@ class InteractionDynamicsCK<
     using Identifier = typename LocalDynamicsType::Identifier;
     using InitializeKernel = typename LocalDynamicsType::InitializeKernel;
     using UpdateKernel = typename LocalDynamicsType::UpdateKernel;
+    using BaseInteractKernel = typename LocalDynamicsType::BaseInteractKernel;
     using InitializeKernelImplementation =
         Implementation<ExecutionPolicy, LocalDynamicsType, InitializeKernel>;
     using UpdateKernelImplementation =
@@ -198,7 +199,7 @@ class InteractionDynamicsCK<
   public:
     template <typename... Args>
     InteractionDynamicsCK(Args &&...args);
-    virtual ~InteractionDynamicsCK(){};
+    virtual ~InteractionDynamicsCK() {};
     virtual void exec(Real dt = 0.0) override;
 
   protected:
@@ -211,8 +212,8 @@ template <class ExecutionPolicy, template <typename...> class InteractionType>
 class InteractionDynamicsCK<ExecutionPolicy, InteractionType<>>
 {
   public:
-    InteractionDynamicsCK(){};
-    void runInteractionStep(Real dt = 0.0){};
+    InteractionDynamicsCK() {};
+    void runInteractionStep(Real dt = 0.0) {};
 };
 
 template <class ExecutionPolicy, template <typename...> class InteractionType,

--- a/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.hpp
@@ -96,9 +96,7 @@ InteractionDynamicsCK<ExecutionPolicy, InteractionType<RelationType<WithUpdate, 
       BaseDynamics<void>(),
       kernel_implementation_(*this)
 {
-    if constexpr (
-        std::is_same_v<InteractionType<RelationType<WithUpdate, OtherParameters...>>,
-                       InteractionType<Inner<WithUpdate, OtherParameters...>>>)
+    if constexpr (std::is_base_of_v<BaseInteractKernel, UpdateKernel>)
     {
         this->registerComputingKernel(&kernel_implementation_);
     }
@@ -141,7 +139,18 @@ InteractionDynamicsCK<ExecutionPolicy, InteractionType<RelationType<OneLevel, Ot
     : InteractionDynamicsCK<ExecutionPolicy, Base, InteractionType<RelationType<OneLevel, OtherParameters...>>>(
           std::forward<Args>(args)...),
       InteractionDynamicsCK<OneLevel>(), BaseDynamics<void>(),
-      initialize_kernel_implementation_(*this), update_kernel_implementation_(*this) {}
+      initialize_kernel_implementation_(*this), update_kernel_implementation_(*this)
+{
+    if constexpr (std::is_base_of_v<BaseInteractKernel, InitializeKernel>)
+    {
+        this->registerComputingKernel(&initialize_kernel_implementation_);
+    }
+
+    if constexpr (std::is_base_of_v<BaseInteractKernel, UpdateKernel>)
+    {
+        this->registerComputingKernel(&update_kernel_implementation_);
+    }
+}
 //=================================================================================================//
 template <class ExecutionPolicy, template <typename...> class InteractionType,
           template <typename...> class RelationType, typename... OtherParameters>

--- a/src/shared/shared_ck/particle_dynamics/interaction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/interaction_ck.h
@@ -60,6 +60,7 @@ class Interaction<Inner<Parameters...>> : public LocalDynamics
                        Interaction<Inner<Parameters...>> &encloser);
     };
 
+    typedef InteractKernel BaseInteractKernel;
     void registerComputingKernel(Implementation<Base> *implementation);
     void resetComputingKernelUpdated();
 
@@ -89,6 +90,7 @@ class Interaction<Contact<SourceIdentifier, TargetIdentifier, Parameters...>>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt contact_index);
     };
 
+    typedef InteractKernel BaseInteractKernel;
     void registerComputingKernel(Implementation<Base> *implementation, UnsignedInt contact_index);
     void resetComputingKernelUpdated(UnsignedInt contact_index);
 


### PR DESCRIPTION
This pull request includes several changes to the `InteractionDynamicsCK` class and related files to improve kernel management and interaction dynamics. The most important changes involve adding a new type alias `BaseInteractKernel` and modifying the kernel registration logic.

Key changes:

### Kernel Management Improvements:
* [`src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.h`](diffhunk://#diff-e44d63afa3b67e5413bd9a90b978404ccfde2f1c3f8aa532c7c05b24f5f39756L162-R163): Added `BaseInteractKernel` type alias to `InteractionDynamicsCK` class for better kernel management. [[1]](diffhunk://#diff-e44d63afa3b67e5413bd9a90b978404ccfde2f1c3f8aa532c7c05b24f5f39756L162-R163) [[2]](diffhunk://#diff-e44d63afa3b67e5413bd9a90b978404ccfde2f1c3f8aa532c7c05b24f5f39756R190)

### Kernel Registration Logic:
* [`src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.hpp`](diffhunk://#diff-72266441c7ae459f80e2a8b8cccf7b6f949e9a441d0e0a080ef5acebaca0c173L99-R99): Modified `InteractionDynamicsCK` constructor to use `std::is_base_of_v` for checking kernel types and registering computing kernels. [[1]](diffhunk://#diff-72266441c7ae459f80e2a8b8cccf7b6f949e9a441d0e0a080ef5acebaca0c173L99-R99) [[2]](diffhunk://#diff-72266441c7ae459f80e2a8b8cccf7b6f949e9a441d0e0a080ef5acebaca0c173L144-R153)

### Type Alias Additions:
* [`src/shared/shared_ck/particle_dynamics/interaction_ck.h`](diffhunk://#diff-fb09046ca81862e54cf13c0704258ea8561246806e6ebfd3e524afd90237f574R63): Added `BaseInteractKernel` type alias to `Interaction<Inner<Parameters...>>` and `Interaction<Contact<SourceIdentifier, TargetIdentifier, Parameters...>>` classes. [[1]](diffhunk://#diff-fb09046ca81862e54cf13c0704258ea8561246806e6ebfd3e524afd90237f574R63) [[2]](diffhunk://#diff-fb09046ca81862e54cf13c0704258ea8561246806e6ebfd3e524afd90237f574R93)