### PR TITLE
Despawn particles parallel policy

### DIFF
--- a/src/shared/common/base_data_type.h
+++ b/src/shared/common/base_data_type.h
@@ -43,6 +43,8 @@
 #if SPHINXSYS_USE_SYCL
 #include <CL/sycl.hpp>
 #define SYCL_DEVICE_ONLY
+#else
+#include <boost/atomic/atomic_ref.hpp>
 #endif // SPHINXSYS_USE_SYCL
 
 #include <Eigen/Cholesky>
@@ -53,14 +55,24 @@
 
 namespace SPH
 {
+#if SPHINXSYS_USE_SYCL
+template <typename T>
+using AtomicRef = sycl::atomic_ref<
+    T, sycl::memory_order_relaxed, sycl::memory_scope_device,
+    sycl::access::address_space::global_space>;
+namespace math = sycl;
+#else
+template <typename T>
+using AtomicRef = boost::atomic_ref<T>;
+namespace math = std;
+#endif // SPHINXSYS_USE_SYCL
+    
 #if SPHINXSYS_USE_FLOAT
 using Real = float;
 using UnsignedInt = u_int32_t;
-namespace math = sycl;
 #else
 using Real = double;
 using UnsignedInt = size_t;
-namespace math = std;
 #endif // SPHINXSYS_USE_FLOAT
 
 /** Vector with integers. */

--- a/src/shared/particle_dynamics/configuration_dynamics/base_configuration_dynamics.h
+++ b/src/shared/particle_dynamics/configuration_dynamics/base_configuration_dynamics.h
@@ -32,27 +32,11 @@
 #include "base_data_package.h"
 #include "execution_policy.h"
 
-#include <boost/atomic/atomic_ref.hpp>
 #include <functional>
 
 namespace SPH
 {
 using namespace execution;
-
-template <typename... T>
-struct AtomicUnsignedIntRef;
-
-template <>
-struct AtomicUnsignedIntRef<SequencedPolicy>
-{
-    typedef UnsignedInt &type;
-};
-
-template <>
-struct AtomicUnsignedIntRef<ParallelPolicy>
-{
-    typedef boost::atomic_ref<UnsignedInt> type;
-};
 
 template <typename... T>
 struct PlusUnsignedInt;

--- a/src/shared/particles/particle_operation.h
+++ b/src/shared/particles/particle_operation.h
@@ -100,14 +100,17 @@ class DespawnRealParticle
 
         UnsignedInt operator()(UnsignedInt index_i)
         {
-            UnsignedInt last_real_particle_index = *total_real_particles_ - 1;
+            AtomicRef<UnsignedInt> total_real_particles_ref(*total_real_particles_);
+
+            UnsignedInt last_real_particle_index = total_real_particles_ref.fetch_sub(1) - 1;
+
             if (index_i < last_real_particle_index)
             {
                 const UnsignedInt temp_original_id_index_i = original_id_[index_i];
+
                 copy_particle_state_(copyable_state_data_arrays_, index_i, last_real_particle_index);
-                original_id_[last_real_particle_index] = temp_original_id_index_i;
+                original_id_[index_i] = temp_original_id_index_i;
             }
-            *total_real_particles_ -= 1;
             return last_real_particle_index;
         };
 

--- a/src/shared/particles/particle_operation.h
+++ b/src/shared/particles/particle_operation.h
@@ -61,14 +61,12 @@ class SpawnRealParticle
 
         UnsignedInt operator()(UnsignedInt index_i)
         {
-            UnsignedInt new_original_id = *total_real_particles_;
+            AtomicRef<UnsignedInt> total_real_particles_ref(*total_real_particles_);
+            UnsignedInt new_original_id = total_real_particles_ref.fetch_add(1);
             if (new_original_id < particles_bound_)
             {
-                const UnsignedInt temp_original_new_original_id = original_id_[new_original_id];
                 copy_particle_state_(copyable_state_data_arrays_, new_original_id, index_i);
-                original_id_[new_original_id] = temp_original_new_original_id;
-                /** Realize the buffer particle by increasing the number of real particle by one.  */
-                *total_real_particles_ += 1;
+                original_id_[new_original_id] = new_original_id;
             }
 
             return new_original_id;

--- a/src/shared/particles/particle_operation.hpp
+++ b/src/shared/particles/particle_operation.hpp
@@ -24,8 +24,6 @@ SpawnRealParticle::ComputingKernel::
       particles_bound_(encloser.particles_bound_),
       original_id_(encloser.dv_original_id_->DelegatedData(ex_policy))
 {
-    static_assert(std::is_base_of<SequencedPolicy, ExecutionPolicy>::value,
-                  "SequencedPolicy is not the base of ExecutionPolicy!");
     OperationBetweenDataAssembles<ParticleVariables, DiscreteVariableArrays, DiscreteVariableArraysInitialization>
         initialize_discrete_variable_array;
     initialize_discrete_variable_array(encloser.evolving_variables_, encloser.copyable_states_);

--- a/src/shared/particles/particle_operation.hpp
+++ b/src/shared/particles/particle_operation.hpp
@@ -39,8 +39,6 @@ DespawnRealParticle::ComputingKernel::
       real_particles_bound_(encloser.real_particles_bound_),
       original_id_(encloser.dv_original_id_->DelegatedData(ex_policy))
 {
-    static_assert(std::is_base_of<SequencedPolicy, ExecutionPolicy>::value,
-                  "SequencedPolicy is not the base of ExecutionPolicy!");
     OperationBetweenDataAssembles<ParticleVariables, DiscreteVariableArrays, DiscreteVariableArraysInitialization>
         initialize_discrete_variable_array;
     initialize_discrete_variable_array(encloser.evolving_variables_, encloser.copyable_states_);

--- a/src/shared/shared_ck/particle_dynamics/configuration_dynamics/update_cell_linked_list.hpp
+++ b/src/shared/shared_ck/particle_dynamics/configuration_dynamics/update_cell_linked_list.hpp
@@ -21,7 +21,7 @@ UpdateCellLinkedList<ExecutionPolicy, CellLinkedListType>::UpdateCellLinkedList(
       dv_particle_index_(cell_linked_list_.getParticleIndex()),
       dv_cell_offset_(cell_linked_list_.getCellOffset()),
       dv_current_cell_size_(DiscreteVariable<UnsignedInt>("CurrentCellSize", cell_offset_list_size_)),
-      ex_policy_(ExecutionPolicy{}), kernel_implementation_(*this){}
+      ex_policy_(ExecutionPolicy{}), kernel_implementation_(*this) {}
 //=================================================================================================//
 template <class ExecutionPolicy, typename CellLinkedListType>
 UpdateCellLinkedList<ExecutionPolicy, CellLinkedListType>::ComputingKernel::
@@ -49,8 +49,7 @@ void UpdateCellLinkedList<ExecutionPolicy, CellLinkedListType>::ComputingKernel:
 {
     // Here, particle_index_ takes role of current_cell_size_list_.
     const UnsignedInt linear_index = mesh_.LinearCellIndexFromPosition(pos_[index_i]);
-    typename AtomicUnsignedIntRef<ExecutionPolicy>::type
-        atomic_cell_size(particle_index_[linear_index]);
+    AtomicRef<UnsignedInt> atomic_cell_size(particle_index_[linear_index]);
     ++atomic_cell_size;
 }
 //=================================================================================================//
@@ -60,8 +59,7 @@ void UpdateCellLinkedList<ExecutionPolicy, CellLinkedListType>::ComputingKernel:
 {
     // Here, particle_index_ takes its original role.
     const UnsignedInt linear_index = mesh_.LinearCellIndexFromPosition(pos_[index_i]);
-    typename AtomicUnsignedIntRef<ExecutionPolicy>::type
-        atomic_current_cell_size(current_cell_size_[linear_index]);
+    AtomicRef<UnsignedInt> atomic_current_cell_size(current_cell_size_[linear_index]);
     particle_index_[cell_offset_[linear_index] + atomic_current_cell_size++] = index_i;
 }
 //=================================================================================================//

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary_ck.h
@@ -356,7 +356,7 @@ class PressureConditionCK<AlignedBoxPartType, KernelCorrectionType, ConditionFun
     DiscreteVariable<Real> *dv_rho_;
 };
 
-template <typename ParallelExecutionPolicy, typename SequencedExecutionPolicy, class KernelCorrectionType, class PressureConditionFunction>
+template <typename ParallelExecutionPolicy, class KernelCorrectionType, class PressureConditionFunction>
 class PressureBidirectionalConditionCK
 {
   public:
@@ -366,9 +366,9 @@ class PressureBidirectionalConditionCK
                   PressureConditionCK<AlignedBoxPartByCell, KernelCorrectionType, PressureConditionFunction>>
         pressure_condition_;
 
-    StateDynamics<SequencedExecutionPolicy, BufferEmitterInflowInjectionCK<AlignedBoxPartByCell, PressureConditionFunction>> emitter_injection_;
+    StateDynamics<ParallelExecutionPolicy, BufferEmitterInflowInjectionCK<AlignedBoxPartByCell, PressureConditionFunction>> emitter_injection_;
 
-    StateDynamics<SequencedExecutionPolicy, DisposerOutflowDeletionCK> disposer_outflow_deletion_;
+    StateDynamics<ParallelExecutionPolicy, DisposerOutflowDeletionCK> disposer_outflow_deletion_;
 
     PressureBidirectionalConditionCK(AlignedBoxPartByCell &emitter_by_cell,
                                      ParticleBuffer<Base> &inlet_buffer)
@@ -436,7 +436,7 @@ class DummyPressure : public BaseStateCondition
     };
 };
 
-template <typename ParallelExecutionPolicy, typename SequencedExecutionPolicy, class KernelCorrectionType, class VelocityConditionFunction>
+template <typename ParallelExecutionPolicy, class KernelCorrectionType, class VelocityConditionFunction>
 class VelocityBidirectionalConditionCK
 {
   public:
@@ -447,9 +447,9 @@ class VelocityBidirectionalConditionCK
     StateDynamics<ParallelExecutionPolicy, PressureConditionCK<AlignedBoxPartByCell, KernelCorrectionType, DummyPressure>>
         pressure_condition_;
 
-    StateDynamics<SequencedExecutionPolicy, BufferEmitterInflowInjectionCK<AlignedBoxPartByCell, NonPrescribedPressure>> emitter_injection_; // Using NonPrescribedPressure as we do not change pressure
+    StateDynamics<ParallelExecutionPolicy, BufferEmitterInflowInjectionCK<AlignedBoxPartByCell, NonPrescribedPressure>> emitter_injection_; // Using NonPrescribedPressure as we do not change pressure
 
-    StateDynamics<SequencedExecutionPolicy, DisposerOutflowDeletionCK> disposer_outflow_deletion_;
+    StateDynamics<ParallelExecutionPolicy, DisposerOutflowDeletionCK> disposer_outflow_deletion_;
 
     VelocityBidirectionalConditionCK(AlignedBoxPartByCell &emitter_by_cell,
                                      ParticleBuffer<Base> &inlet_buffer)

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary_ck.hpp
@@ -158,7 +158,8 @@ void PressureConditionCK<AlignedBoxPartType, KernelCorrectionType, ConditionFunc
         if (aligned_box_->checkInBounds(pos_[index_i]))
         {
             Real pressure = condition_(index_i, *physical_time_);
-            vel_[index_i] -= correction_(index_i) * this->zero_gradient_residue_[index_i] * pressure / rho_[index_i] * dt;
+            Vecd zero_gradient_residue = this->zero_gradient_residue_[index_i];
+            vel_[index_i] -= correction_(index_i) * zero_gradient_residue * pressure / rho_[index_i] * dt;
 
             Vecd frame_velocity = Vecd::Zero();
             frame_velocity[xAxis] = this->transform_->xformBaseVecToFrame(vel_[index_i])[xAxis];

--- a/src/src_sycl/shared/particle_dynamics/configuration_dynamics/base_configuration_dynamics_sycl.h
+++ b/src/src_sycl/shared/particle_dynamics/configuration_dynamics/base_configuration_dynamics_sycl.h
@@ -36,15 +36,6 @@
 namespace SPH
 {
 template <>
-struct AtomicUnsignedIntRef<ParallelDevicePolicy>
-{
-    typedef sycl::atomic_ref<
-        UnsignedInt, sycl::memory_order_relaxed, sycl::memory_scope_device,
-        sycl::access::address_space::global_space>
-        type;
-};
-
-template <>
 struct PlusUnsignedInt<ParallelDevicePolicy>
 {
     typedef sycl::plus<UnsignedInt> type;

--- a/tests/2d_examples/2d_examples_ck/test_2d_filling_tank_ck/filling_tank_ck.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_filling_tank_ck/filling_tank_ck.cpp
@@ -166,7 +166,7 @@ int main(int ac, char *av[])
         fluid_boundary_indicator(water_body_inner, water_wall_contact);
 
     StateDynamics<MainExecutionPolicy, fluid_dynamics::InflowConditionCK<AlignedBoxPartByParticle, InletInflowCondition>> inflow_condition(emitter);
-    StateDynamics<MainExecutionPolicy, fluid_dynamics::EmitterInflowInjectionCK> emitter_injection(emitter, inlet_buffer);
+    StateDynamics<MainExecutionPolicy, fluid_dynamics::EmitterInflowInjectionCK<AlignedBoxPartByParticle>> emitter_injection(emitter, inlet_buffer);
     //----------------------------------------------------------------------
     //	Define the methods for I/O operations, observations
     //	and regression tests of the simulation.

--- a/tests/2d_examples/2d_examples_ck/test_2d_filling_tank_ck/filling_tank_ck.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_filling_tank_ck/filling_tank_ck.cpp
@@ -129,7 +129,6 @@ int main(int ac, char *av[])
     // Define the main execution policy for this case.
     //----------------------------------------------------------------------
     using MainExecutionPolicy = execution::ParallelPolicy;
-    using SequencedExecutionPolicy = execution::SequencedPolicy;
     //----------------------------------------------------------------------
     // Define the numerical methods used in the simulation.
     // Note that there may be data dependence on the sequence of constructions.
@@ -167,8 +166,7 @@ int main(int ac, char *av[])
         fluid_boundary_indicator(water_body_inner, water_wall_contact);
 
     StateDynamics<MainExecutionPolicy, fluid_dynamics::InflowConditionCK<AlignedBoxPartByParticle, InletInflowCondition>> inflow_condition(emitter);
-    StateDynamics<SequencedExecutionPolicy, fluid_dynamics::EmitterInflowInjectionCK<AlignedBoxPartByParticle>> emitter_injection(emitter, inlet_buffer);
-
+    StateDynamics<MainExecutionPolicy, fluid_dynamics::EmitterInflowInjectionCK> emitter_injection(emitter, inlet_buffer);
     //----------------------------------------------------------------------
     //	Define the methods for I/O operations, observations
     //	and regression tests of the simulation.

--- a/tests/2d_examples/2d_examples_ck/test_2d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
@@ -308,7 +308,6 @@ int main(int ac, char *av[])
     // Define the main execution policy for this case.
     //----------------------------------------------------------------------
     using MainExecutionPolicy = execution::ParallelPolicy;
-    using SequencedExecutionPolicy = execution::SequencedPolicy;
     //----------------------------------------------------------------------
     // Combined relations built from basic relations
     // which is only used for update configuration.
@@ -348,9 +347,9 @@ int main(int ac, char *av[])
         fluid_viscous_force(water_body_inner, water_wall_contact);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityLimitedCorrectionCorrectedComplexBulkParticlesCKWithoutUpdate>
         zero_gradient_ck(water_body_inner, water_wall_contact);
-    fluid_dynamics::VelocityBidirectionalConditionCK<MainExecutionPolicy, SequencedExecutionPolicy, NoKernelCorrectionCK, InletInflowConditionLeft>
+    fluid_dynamics::VelocityBidirectionalConditionCK<MainExecutionPolicy, NoKernelCorrectionCK, InletInflowConditionLeft>
         bidirectional_velocity_condition_left(left_emitter_by_cell, inlet_buffer);
-    fluid_dynamics::PressureBidirectionalConditionCK<MainExecutionPolicy, SequencedExecutionPolicy, NoKernelCorrectionCK, InletInflowPressureConditionRight>
+    fluid_dynamics::PressureBidirectionalConditionCK<MainExecutionPolicy, NoKernelCorrectionCK, InletInflowPressureConditionRight>
         bidirectional_pressure_condition_right(right_emitter_by_cell, inlet_buffer);
     //----------------------------------------------------------------------
     //	Define the methods for I/O operations, observations

--- a/tests/2d_examples/2d_examples_ck/test_2d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
@@ -343,7 +343,7 @@ int main(int ac, char *av[])
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityCorrectionWallNoCorrectionBulkParticlesCK>
         transport_correction_ck(water_body_inner, water_wall_contact);
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AdvectionTimeStepCK> fluid_advection_time_step(water_body, U_f);
-    ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK> fluid_acoustic_time_step(water_body);
+    ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK<>> fluid_acoustic_time_step(water_body);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::ViscousForceWithWallCK>
         fluid_viscous_force(water_body_inner, water_wall_contact);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityLimitedCorrectionCorrectedComplexBulkParticlesCKWithoutUpdate>

--- a/tests/3d_examples/3d_examples_ck/test_3d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
+++ b/tests/3d_examples/3d_examples_ck/test_3d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
@@ -289,7 +289,6 @@ int main(int ac, char *av[])
     // Define the main execution policy for this case.
     //----------------------------------------------------------------------
     using MainExecutionPolicy = execution::ParallelPolicy;
-    using SequencedExecutionPolicy = execution::SequencedPolicy;
     //----------------------------------------------------------------------
     // Combined relations built from basic relations
     // which is only used for update configuration.
@@ -329,9 +328,9 @@ int main(int ac, char *av[])
         fluid_viscous_force(water_body_inner, water_wall_contact);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityLimitedCorrectionCorrectedComplexBulkParticlesCKWithoutUpdate>
         zero_gradient_ck(water_body_inner, water_wall_contact);
-    fluid_dynamics::VelocityBidirectionalConditionCK<MainExecutionPolicy, SequencedExecutionPolicy, NoKernelCorrectionCK, InletInflowConditionLeft>
+    fluid_dynamics::VelocityBidirectionalConditionCK<MainExecutionPolicy, NoKernelCorrectionCK, InletInflowConditionLeft>
         bidirectional_velocity_condition_left(left_emitter_by_cell, inlet_buffer);
-    fluid_dynamics::PressureBidirectionalConditionCK<MainExecutionPolicy, SequencedExecutionPolicy, NoKernelCorrectionCK, InletInflowPressureConditionRight>
+    fluid_dynamics::PressureBidirectionalConditionCK<MainExecutionPolicy, NoKernelCorrectionCK, InletInflowPressureConditionRight>
         bidirectional_pressure_condition_right(right_emitter_by_cell, inlet_buffer);
     //----------------------------------------------------------------------
     //	Define the methods for I/O operations, observations

--- a/tests/3d_examples/3d_examples_ck/test_3d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
+++ b/tests/3d_examples/3d_examples_ck/test_3d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
@@ -324,7 +324,7 @@ int main(int ac, char *av[])
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityCorrectionWallNoCorrectionBulkParticlesCK>
         transport_correction_ck(water_body_inner, water_wall_contact);
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AdvectionTimeStepCK> fluid_advection_time_step(water_body, U_f);
-    ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK> fluid_acoustic_time_step(water_body);
+    ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK<>> fluid_acoustic_time_step(water_body);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::ViscousForceWithWallCK>
         fluid_viscous_force(water_body_inner, water_wall_contact);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityLimitedCorrectionCorrectedComplexBulkParticlesCKWithoutUpdate>

--- a/tests/tests_sycl/2d_examples/test_2d_filling_tank_sycl/filling_tank_sycl.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_filling_tank_sycl/filling_tank_sycl.cpp
@@ -12,7 +12,7 @@ using namespace SPH;
 //----------------------------------------------------------------------
 Real DL = 5.366;              /**< Tank length. */
 Real DH = 5.366;              /**< Tank height. */
-Real resolution_ref = 0.025;  /**< Initial reference particle spacing. */
+Real resolution_ref = 0.0025; /**< Initial reference particle spacing. */
 Real BW = resolution_ref * 4; /**< Extending width for wall boundary. */
 Real LL = 2.0 * BW;           /**< Inflow region length. */
 Real LH = 0.125;              /**< Inflows region height. */

--- a/tests/tests_sycl/2d_examples/test_2d_filling_tank_sycl/filling_tank_sycl.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_filling_tank_sycl/filling_tank_sycl.cpp
@@ -163,7 +163,7 @@ int main(int ac, char *av[])
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK<>> fluid_acoustic_time_step(water_body);
 
     StateDynamics<MainExecutionPolicy, fluid_dynamics::InflowConditionCK<AlignedBoxPartByParticle, InletInflowCondition>> inflow_condition(emitter);
-    StateDynamics<MainExecutionPolicy, fluid_dynamics::EmitterInflowInjectionCK> emitter_injection(emitter, inlet_buffer);
+    StateDynamics<MainExecutionPolicy, fluid_dynamics::EmitterInflowInjectionCK<AlignedBoxPartByParticle>> emitter_injection(emitter, inlet_buffer);
     //----------------------------------------------------------------------
     //	Define the methods for I/O operations, observations
     //	and regression tests of the simulation.

--- a/tests/tests_sycl/2d_examples/test_2d_filling_tank_sycl/filling_tank_sycl.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_filling_tank_sycl/filling_tank_sycl.cpp
@@ -129,7 +129,6 @@ int main(int ac, char *av[])
     // Define the main execution policy for this case.
     //----------------------------------------------------------------------
     using MainExecutionPolicy = execution::ParallelDevicePolicy;
-    using SequencedExecutionPolicy = execution::SequencedDevicePolicy;
     //----------------------------------------------------------------------
     // Define the numerical methods used in the simulation.
     // Note that there may be data dependence on the sequence of constructions.
@@ -164,7 +163,7 @@ int main(int ac, char *av[])
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK<>> fluid_acoustic_time_step(water_body);
 
     StateDynamics<MainExecutionPolicy, fluid_dynamics::InflowConditionCK<AlignedBoxPartByParticle, InletInflowCondition>> inflow_condition(emitter);
-    StateDynamics<SequencedExecutionPolicy, fluid_dynamics::EmitterInflowInjectionCK<AlignedBoxPartByParticle>> emitter_injection(emitter, inlet_buffer);
+    StateDynamics<MainExecutionPolicy, fluid_dynamics::EmitterInflowInjectionCK> emitter_injection(emitter, inlet_buffer);
     //----------------------------------------------------------------------
     //	Define the methods for I/O operations, observations
     //	and regression tests of the simulation.

--- a/tests/tests_sycl/2d_examples/test_2d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -308,7 +308,6 @@ int main(int ac, char *av[])
     // Define the main execution policy for this case.
     //----------------------------------------------------------------------
     using MainExecutionPolicy = execution::ParallelDevicePolicy;
-    using SequencedExecutionPolicy = execution::SequencedDevicePolicy;
     //----------------------------------------------------------------------
     // Combined relations built from basic relations
     // which is only used for update configuration.
@@ -348,9 +347,9 @@ int main(int ac, char *av[])
         fluid_viscous_force(water_body_inner, water_wall_contact);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityLimitedCorrectionCorrectedComplexBulkParticlesCKWithoutUpdate>
         zero_gradient_ck(water_body_inner, water_wall_contact);
-    fluid_dynamics::VelocityBidirectionalConditionCK<MainExecutionPolicy, SequencedExecutionPolicy, NoKernelCorrectionCK, InletInflowConditionLeft>
+    fluid_dynamics::VelocityBidirectionalConditionCK<MainExecutionPolicy, NoKernelCorrectionCK, InletInflowConditionLeft>
         bidirectional_velocity_condition_left(left_emitter_by_cell, inlet_buffer);
-    fluid_dynamics::PressureBidirectionalConditionCK<MainExecutionPolicy, SequencedExecutionPolicy, NoKernelCorrectionCK, InletInflowPressureConditionRight>
+    fluid_dynamics::PressureBidirectionalConditionCK<MainExecutionPolicy, NoKernelCorrectionCK, InletInflowPressureConditionRight>
         bidirectional_pressure_condition_right(right_emitter_by_cell, inlet_buffer);
     //----------------------------------------------------------------------
     //	Define the methods for I/O operations, observations

--- a/tests/tests_sycl/2d_examples/test_2d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -343,7 +343,7 @@ int main(int ac, char *av[])
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityCorrectionWallNoCorrectionBulkParticlesCK>
         transport_correction_ck(water_body_inner, water_wall_contact);
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AdvectionTimeStepCK> fluid_advection_time_step(water_body, U_f);
-    ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK> fluid_acoustic_time_step(water_body);
+    ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK<>> fluid_acoustic_time_step(water_body);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::ViscousForceWithWallCK>
         fluid_viscous_force(water_body_inner, water_wall_contact);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityLimitedCorrectionCorrectedComplexBulkParticlesCKWithoutUpdate>

--- a/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -289,7 +289,6 @@ int main(int ac, char *av[])
     // Define the main execution policy for this case.
     //----------------------------------------------------------------------
     using MainExecutionPolicy = execution::ParallelDevicePolicy;
-    using SequencedPolicy = execution::SequencedDevicePolicy;
     //----------------------------------------------------------------------
     // Combined relations built from basic relations
     // which is only used for update configuration.
@@ -329,9 +328,9 @@ int main(int ac, char *av[])
         fluid_viscous_force(water_body_inner, water_wall_contact);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityLimitedCorrectionCorrectedComplexBulkParticlesCKWithoutUpdate>
         zero_gradient_ck(water_body_inner, water_wall_contact);
-    fluid_dynamics::VelocityBidirectionalConditionCK<SequencedPolicy, NoKernelCorrectionCK, InletInflowConditionLeft>
+    fluid_dynamics::VelocityBidirectionalConditionCK<MainExecutionPolicy, NoKernelCorrectionCK, InletInflowConditionLeft>
         bidirectional_velocity_condition_left(left_emitter_by_cell, inlet_buffer);
-    fluid_dynamics::PressureBidirectionalConditionCK<SequencedPolicy, NoKernelCorrectionCK, InletInflowPressureConditionRight>
+    fluid_dynamics::PressureBidirectionalConditionCK<MainExecutionPolicy, NoKernelCorrectionCK, InletInflowPressureConditionRight>
         bidirectional_pressure_condition_right(right_emitter_by_cell, inlet_buffer);
     //----------------------------------------------------------------------
     //	Define the methods for I/O operations, observations

--- a/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -325,7 +325,7 @@ int main(int ac, char *av[])
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityCorrectionWallNoCorrectionBulkParticlesCK>
         transport_correction_ck(water_body_inner, water_wall_contact);
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AdvectionTimeStepCK> fluid_advection_time_step(water_body, U_f);
-    ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK> fluid_acoustic_time_step(water_body);
+    ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK<>> fluid_acoustic_time_step(water_body);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::ViscousForceWithWallCK>
         fluid_viscous_force(water_body_inner, water_wall_contact);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityLimitedCorrectionCorrectedComplexBulkParticlesCKWithoutUpdate>

--- a/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -289,7 +289,7 @@ int main(int ac, char *av[])
     // Define the main execution policy for this case.
     //----------------------------------------------------------------------
     using MainExecutionPolicy = execution::ParallelDevicePolicy;
-    using SequencedExecutionPolicy = execution::SequencedDevicePolicy;
+    using SequencedPolicy = execution::SequencedDevicePolicy;
     //----------------------------------------------------------------------
     // Combined relations built from basic relations
     // which is only used for update configuration.
@@ -329,9 +329,9 @@ int main(int ac, char *av[])
         fluid_viscous_force(water_body_inner, water_wall_contact);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityLimitedCorrectionCorrectedComplexBulkParticlesCKWithoutUpdate>
         zero_gradient_ck(water_body_inner, water_wall_contact);
-    fluid_dynamics::VelocityBidirectionalConditionCK<MainExecutionPolicy, SequencedExecutionPolicy, NoKernelCorrectionCK, InletInflowConditionLeft>
+    fluid_dynamics::VelocityBidirectionalConditionCK<SequencedPolicy, NoKernelCorrectionCK, InletInflowConditionLeft>
         bidirectional_velocity_condition_left(left_emitter_by_cell, inlet_buffer);
-    fluid_dynamics::PressureBidirectionalConditionCK<MainExecutionPolicy, SequencedExecutionPolicy, NoKernelCorrectionCK, InletInflowPressureConditionRight>
+    fluid_dynamics::PressureBidirectionalConditionCK<SequencedPolicy, NoKernelCorrectionCK, InletInflowPressureConditionRight>
         bidirectional_pressure_condition_right(right_emitter_by_cell, inlet_buffer);
     //----------------------------------------------------------------------
     //	Define the methods for I/O operations, observations

--- a/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -15,7 +15,7 @@ using namespace SPH;
 //----------------------------------------------------------------------
 Real DL = 0.0075;                /**< Channel length. */
 Real DH = 0.001;                 /**< Channel height. */
-Real resolution_ref = DH / 10.0; /**< Reference particle spacing. */
+Real resolution_ref = DH / 20.0; /**< Reference particle spacing. */
 Real error_tolerance = 5 * 0.01; // Less than 3 percent when resolution is DH/20 and DL/DH = 20
 
 Real BW = resolution_ref * 4; /**< Extending width for BCs. */
@@ -224,7 +224,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating bodies with corresponding materials and particles.
     //----------------------------------------------------------------------
-    size_t SimTK_resolution = 12;
+    size_t SimTK_resolution = 20;
     auto water_body_shape = makeShared<ComplexShape>("WaterBody");
     water_body_shape->add<TriangleMeshShapeCylinder>(SimTK::UnitVec3(1., 0., 0.), DH * 0.5,
                                                      DL * 0.5, SimTK_resolution,
@@ -240,15 +240,12 @@ int main(int ac, char *av[])
 
     FluidBody water_body(sph_system, water_body_shape);
     water_body.defineClosure<WeaklyCompressibleFluid, Viscosity>(ConstructArgs(rho0_f, c_f), mu_f);
-    std::cout << "with viscosity\n";
-    // water_body.defineMaterial<WeaklyCompressibleFluid>(rho0_f, c_f);
     ParticleBuffer<ReserveSizeFactor> inlet_buffer(0.5);
     water_body.generateParticlesWithReserve<BaseParticles, Lattice>(inlet_buffer);
 
     SolidBody wall(sph_system, wall_body_shape);
     wall.defineMaterial<Solid>();
     wall.generateParticles<BaseParticles, Lattice>();
-    std::cout << "249\n";
     // Add observer
     {
         int num_points = 15;
@@ -265,10 +262,9 @@ int main(int ac, char *av[])
             observer_location.push_back(Vec3d(0.5 * DL, y_i, z));
         }
     }
-    std::cout << "265\n";
+
     ObserverBody velocity_observer(sph_system, "VelocityObserver");
     velocity_observer.generateParticles<ObserverParticles>(observer_location);
-    std::cout << "270\n";
     // //----------------------------------------------------------------------
     // //	Creating body parts.
     // //----------------------------------------------------------------------
@@ -277,9 +273,7 @@ int main(int ac, char *av[])
     auto rotated_normal = -1 * Vec3d::UnitX();
     auto rotation_axis = Vec3d::UnitY();
     auto rot3d = Rotation3d(std::acos(defulat_normal.dot(rotated_normal)), rotation_axis);
-    std::cout << "278\n";
     AlignedBoxPartByCell right_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(rot3d, right_bidirectional_translation), bidirectional_buffer_halfsize));
-    std::cout << "280\n";
     // AlignedBoxPartByCell right_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(left_bidirectional_translation), bidirectional_buffer_halfsize));
     //----------------------------------------------------------------------
     //	Define body relation map.
@@ -287,33 +281,24 @@ int main(int ac, char *av[])
     //	Basically the the range of bodies to build neighbor particle lists.
     //  Generally, we first define all the inner relations, then the contact relations.
     // ----------------------------------------------------------------------
-    Relation<Inner<>> water_body_inner(water_body);
-    std::cout << "289\n";
+    Relation<Inner<>>
+        water_body_inner(water_body);
     Relation<Contact<>> water_wall_contact(water_body, {&wall});
-    std::cout << "290\n";
     Relation<Contact<>> velocity_observer_contact(velocity_observer, {&water_body});
-    std::cout << "292\n";
     //----------------------------------------------------------------------
     // Define the main execution policy for this case.
     //----------------------------------------------------------------------
     using MainExecutionPolicy = execution::ParallelDevicePolicy;
-    std::cout << "297\n";
     using SequencedExecutionPolicy = execution::SequencedDevicePolicy;
-    std::cout << "299\n";
     //----------------------------------------------------------------------
     // Combined relations built from basic relations
     // which is only used for update configuration.
     //----------------------------------------------------------------------
     UpdateCellLinkedList<MainExecutionPolicy, CellLinkedList> water_cell_linked_list(water_body);
-    std::cout << "306\n";
     UpdateCellLinkedList<MainExecutionPolicy, CellLinkedList> wall_cell_linked_list(wall);
-    std::cout << "308\n";
     UpdateRelation<MainExecutionPolicy, Inner<>, Contact<>> water_body_update_complex_relation(water_body_inner, water_wall_contact);
-    std::cout << "310\n";
     UpdateRelation<MainExecutionPolicy, Contact<>> fluid_observer_contact_relation(velocity_observer_contact);
-    std::cout << "312\n";
     ParticleSortCK<MainExecutionPolicy, RadixSort> particle_sort(water_body);
-    std::cout << "314\n";
     //----------------------------------------------------------------------
     // Define the numerical methods used in the simulation.
     // Note that there may be data dependence on the sequence of constructions.
@@ -326,72 +311,50 @@ int main(int ac, char *av[])
     StateDynamics<execution::ParallelPolicy, NormalFromBodyShapeCK> wall_normal_direction(wall); // run on CPU
     StateDynamics<MainExecutionPolicy, fluid_dynamics::AdvectionStepSetup> water_advection_step_setup(water_body);
     StateDynamics<MainExecutionPolicy, fluid_dynamics::AdvectionStepClose> water_advection_step_close(water_body);
-    std::cout << "327\n";
     InteractionDynamicsCK<MainExecutionPolicy, LinearCorrectionMatrixComplex>
         fluid_linear_correction_matrix(DynamicsArgs(water_body_inner, 0.5), water_wall_contact);
-    std::cout << "329\n";
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticStep1stHalfWithWallRiemannCK>
         fluid_acoustic_step_1st_half(water_body_inner, water_wall_contact);
-    std::cout << "331\n";
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticStep2ndHalfWithWallRiemannCK>
         fluid_acoustic_step_2nd_half(water_body_inner, water_wall_contact);
-    std::cout << "333\n";
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::DensityRegularizationComplexInternalPressureBoundary>
         fluid_density_regularization(water_body_inner, water_wall_contact);
-    std::cout << "335\n";
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::FreeSurfaceIndicationComplexSpatialTemporalCK>
         fluid_boundary_indicator(water_body_inner, water_wall_contact);
-    std::cout << "338\n";
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityCorrectionWallNoCorrectionBulkParticlesCK>
         transport_correction_ck(water_body_inner, water_wall_contact);
-    std::cout << "340\n";
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AdvectionTimeStepCK> fluid_advection_time_step(water_body, U_f);
-    std::cout << "343\n";
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK<>> fluid_acoustic_time_step(water_body);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::ViscousForceWithWallCK>
         fluid_viscous_force(water_body_inner, water_wall_contact);
-    std::cout << "346\n";
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityLimitedCorrectionCorrectedComplexBulkParticlesCKWithoutUpdate>
         zero_gradient_ck(water_body_inner, water_wall_contact);
-    std::cout << "350\n";
     fluid_dynamics::VelocityBidirectionalConditionCK<MainExecutionPolicy, SequencedExecutionPolicy, NoKernelCorrectionCK, InletInflowConditionLeft>
         bidirectional_velocity_condition_left(left_emitter_by_cell, inlet_buffer);
-    std::cout << "353\n";
     fluid_dynamics::PressureBidirectionalConditionCK<MainExecutionPolicy, SequencedExecutionPolicy, NoKernelCorrectionCK, InletInflowPressureConditionRight>
         bidirectional_pressure_condition_right(right_emitter_by_cell, inlet_buffer);
-    std::cout << "356\n";
     //----------------------------------------------------------------------
     //	Define the methods for I/O operations, observations
     //	and regression tests of the simulation.
     //----------------------------------------------------------------------
     IOEnvironment io_environment(sph_system);
-    std::cout << "362\n";
     BodyStatesRecordingToVtp body_states_recording(sph_system);
-    std::cout << "364\n";
     body_states_recording.addToWrite<Real>(water_body, "Pressure");
     body_states_recording.addToWrite<int>(water_body, "BufferParticleIndicator");
     body_states_recording.addToWrite<int>(water_body, "Indicator");
     ObservedQuantityRecording<MainExecutionPolicy, Vec3d> write_centerline_velocity("Velocity", velocity_observer_contact);
-    std::cout << "369\n";
     //----------------------------------------------------------------------
     //	Prepare the simulation with cell linked list, configuration
     //	and case specified initial condition if necessary.
     //----------------------------------------------------------------------
     wall_normal_direction.exec();
-    std::cout << "375\n";
     water_cell_linked_list.exec();
-    std::cout << "Before wall_cell_linked_list.exec()" << std::endl;
     wall_cell_linked_list.exec();
-    std::cout << "After wall_cell_linked_list.exec()" << std::endl;
     water_body_update_complex_relation.exec();
-    std::cout << "After water_body_update_complex_relation.exec()" << std::endl;
     fluid_observer_contact_relation.exec();
     fluid_boundary_indicator.exec();
     bidirectional_velocity_condition_left.tagBufferParticles();
     bidirectional_pressure_condition_right.tagBufferParticles();
-    std::cout << "387\n"
-              << std::endl;
-
     //----------------------------------------------------------------------
     //	Setup for time-stepping control
     //----------------------------------------------------------------------
@@ -410,15 +373,11 @@ int main(int ac, char *av[])
     TimeInterval interval_computing_pressure_relaxation;
     TimeInterval interval_updating_configuration;
     TickCount time_instance;
-    std::cout << "406\n"
-              << std::endl;
     //----------------------------------------------------------------------
     //	First output before the main loop.
     //----------------------------------------------------------------------
     body_states_recording.writeToFile(MainExecutionPolicy{});
     write_centerline_velocity.writeToFile(number_of_iterations);
-    std::cout << "413\n"
-              << std::endl;
     //----------------------------------------------------------------------
     //	Main loop starts here.
     //----------------------------------------------------------------------
@@ -430,18 +389,10 @@ int main(int ac, char *av[])
         {
             fluid_density_regularization.exec();
             water_advection_step_setup.exec();
-            std::cout << "424\n"
-                      << std::endl;
-            std::cout << "with viscosity\n";
             fluid_viscous_force.exec();
-            std::cout << "with viscosity\n";
             transport_correction_ck.exec();
-            std::cout << "428\n"
-                      << std::endl;
             Real advection_dt = fluid_advection_time_step.exec();
             fluid_linear_correction_matrix.exec();
-            std::cout << "430\n"
-                      << std::endl;
             interval_computing_time_step += TickCount::now() - time_instance;
 
             /** Dynamics including pressure relaxation. */
@@ -452,18 +403,9 @@ int main(int ac, char *av[])
                 acoustic_dt = SMIN(fluid_acoustic_time_step.exec(), advection_dt);
                 fluid_acoustic_step_1st_half.exec(acoustic_dt);
                 zero_gradient_ck.exec();
-                std::cout << "441\n"
-                          << std::endl;
-
                 bidirectional_velocity_condition_left.applyPressureCondition(acoustic_dt);
-                std::cout << "445\n"
-                          << std::endl;
                 bidirectional_velocity_condition_left.applyVelocityCondition();
-                std::cout << "447\n"
-                          << std::endl;
                 bidirectional_pressure_condition_right.applyPressureCondition(acoustic_dt);
-                std::cout << "449\n"
-                          << std::endl;
                 fluid_acoustic_step_2nd_half.exec(acoustic_dt);
                 relaxation_time += acoustic_dt;
                 integration_time += acoustic_dt;
@@ -485,45 +427,21 @@ int main(int ac, char *av[])
             number_of_iterations++;
             /** inflow emitter injection*/
             bidirectional_velocity_condition_left.injectParticles();
-            std::cout << "470\n"
-                      << std::endl;
             bidirectional_pressure_condition_right.injectParticles();
-            std::cout << "473\n"
-                      << std::endl;
             bidirectional_velocity_condition_left.deleteParticles();
-            std::cout << "475\n"
-                      << std::endl;
             bidirectional_pressure_condition_right.deleteParticles();
-            std::cout << "477\n"
-                      << std::endl;
             /** Update cell linked list and configuration. */
             if (number_of_iterations % 100 == 0 && number_of_iterations != 1)
             {
-                std::cout << "481\n"
-                          << std::endl;
                 particle_sort.exec();
-                std::cout << "483\n"
-                          << std::endl;
             }
             water_cell_linked_list.exec();
-            std::cout << "485\n"
-                      << std::endl;
             water_body_update_complex_relation.exec();
-            std::cout << "488\n"
-                      << std::endl;
             fluid_observer_contact_relation.exec();
-            std::cout << "490\n"
-                      << std::endl;
             interval_updating_configuration += TickCount::now() - time_instance;
             fluid_boundary_indicator.exec();
-            std::cout << "493\n"
-                      << std::endl;
             bidirectional_velocity_condition_left.tagBufferParticles();
-            std::cout << "494\n"
-                      << std::endl;
             bidirectional_pressure_condition_right.tagBufferParticles();
-            std::cout << "497\n"
-                      << std::endl;
         }
 
         TickCount t2 = TickCount::now();


### PR DESCRIPTION
This PR builds upon #775 (Following spawn particles parallel policy) by implementing a parallel execution policy for despawning particles.

Previously, BidirectionalConditionCK required both ParallelExecutionPolicy and SequencedExecutionPolicy—the former applied to non-spawn and non-despawn features, while the latter applied to spawn and despawn features.

Since parallel execution is now available for both spawn and despawn, SequencedExecutionPolicy in BidirectionalConditionCK has been removed.