### PR TITLE
add a function to reset the file path by update the quantity name, to…

### DIFF
--- a/src/shared/io_system/io_observation.cpp
+++ b/src/shared/io_system/io_observation.cpp
@@ -7,12 +7,11 @@ namespace SPH
 {
 //=================================================================================================//
 BaseQuantityRecording::BaseQuantityRecording(SPHSystem &sph_system,
-                                             const std::string &dynamics_identifier_name,
-                                             const std::string &quantity_name)
-    : BaseIO(sph_system), plt_engine_(),
+                                             const std::string &dynamics_identifier_name)
+    : BaseIO(sph_system), plt_engine_(), 
+      quantity_name_("NeedAQuantityName"),
       dynamics_identifier_name_(dynamics_identifier_name),
-      quantity_name_(quantity_name),
       filefullpath_output_(io_environment_.output_folder_ + "/" +
-                           dynamics_identifier_name_ + "_" + quantity_name + ".dat") {}
+                           dynamics_identifier_name_ + "_" + "NeedAQuantityName" + ".dat") {}
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/io_system/io_observation.h
+++ b/src/shared/io_system/io_observation.h
@@ -48,9 +48,9 @@ class BaseQuantityRecording : public BaseIO
 
   protected:
     PltEngine plt_engine_;
+    std::string quantity_name_;
     std::string dynamics_identifier_name_;
     std::string filefullpath_output_;
-    std::string quantity_name_;
 };
 
 template <typename...>

--- a/src/shared/io_system/io_observation.h
+++ b/src/shared/io_system/io_observation.h
@@ -41,6 +41,13 @@ class BaseQuantityRecording : public BaseIO
                           const std::string &dynamics_identifier_name,
                           const std::string &quantity_name);
 
+    void setQuantityName(const std::string &quantity_name)
+    {
+        quantity_name_ = quantity_name;
+        filefullpath_output_ = io_environment_.output_folder_ + "/" +
+                               dynamics_identifier_name_ + "_" + quantity_name + ".dat";
+    };
+
   protected:
     PltEngine plt_engine_;
     std::string dynamics_identifier_name_;
@@ -138,6 +145,7 @@ class ReducedQuantityRecording<LocalReduceMethodType> : public BaseQuantityRecor
           reduced_quantity_(ZeroData<VariableType>::value)
     {
         quantity_name_ = reduce_method_.QuantityName();
+        setQuantityName(quantity_name_);
         std::ofstream out_file(filefullpath_output_.c_str(), std::ios::app);
         out_file << "\"run_time\"" << "   ";
         plt_engine_.writeAQuantityHeader(out_file, reduced_quantity_, quantity_name_);

--- a/src/shared/shared_ck/io_system/io_observation_ck.h
+++ b/src/shared/shared_ck/io_system/io_observation_ck.h
@@ -53,13 +53,14 @@ class ObservedQuantityRecording<ExecutionPolicy, DataType>
   public:
     ObservedQuantityRecording(const std::string &quantity_name, Relation<Contact<>> &contact_relation)
         : BaseQuantityRecording(contact_relation.getSPHBody().getSPHSystem(),
-                                contact_relation.getSPHBody().getName(), quantity_name),
+                                contact_relation.getSPHBody().getName()),
           observer_(contact_relation.getSPHBody()),
           base_particles_(observer_.getBaseParticles()),
           observation_method_(contact_relation, quantity_name),
           dv_interpolated_quantities_(observation_method_.dvInterpolatedQuantities()),
           number_of_observe_(base_particles_.TotalRealParticles())
     {
+        setFullPath(quantity_name);
         std::ofstream out_file(filefullpath_output_.c_str(), std::ios::app);
         out_file << "run_time" << "   ";
         DataType *interpolated_quantities = getObservedQuantity();
@@ -115,11 +116,12 @@ class ReducedQuantityRecording<ExecutionPolicy, LocalReduceMethodType> : public 
     template <class DynamicsIdentifier, typename... Args>
     ReducedQuantityRecording(DynamicsIdentifier &identifier, Args &&...args)
         : BaseQuantityRecording(identifier.getSPHBody().getSPHSystem(),
-                                identifier.getName(), ""),
+                                identifier.getName()),
           reduce_method_(identifier, std::forward<Args>(args)...),
           reduced_quantity_(ZeroData<VariableType>::value)
     {
         quantity_name_ = reduce_method_.QuantityName();
+        setFullPath(quantity_name_);
         std::ofstream out_file(filefullpath_output_.c_str(), std::ios::app);
         out_file << "\"run_time\"" << "   ";
         plt_engine_.writeAQuantityHeader(out_file, reduced_quantity_, quantity_name_);

--- a/tests/extra_source_and_tests/test_2d_turbulent_channel/regression_test_tool/ObserverCenterPoint_TurbulentViscosity_dtwdistance.xml
+++ b/tests/extra_source_and_tests/test_2d_turbulent_channel/regression_test_tool/ObserverCenterPoint_TurbulentViscosity_dtwdistance.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <dtw_distance>
-    <DTWDistance TurbulentViscosity_0="0.00025226234477784219" />
+    <DTWDistance TurbulentViscosity_0="0.0005" />
 </dtw_distance>


### PR DESCRIPTION
Add a function in BaseQuantityRecording to reset the file path by updating the quantity name, which can prevent different quantity names from using the same file path when there are several quantities using ReducedQuantityRecording to record the values. This update also has no impact to other classes based on BaseQuantityRecording .

For example:
It was like this in flow around cylinder when you want to record total viscous force and total pressure force together:
In the file, it looks like this:
"run_time"   "TotalViscousForceFromFluid[0]"   "TotalViscousForceFromFluid[1]"   
"run_time"   "TotalPressureForceFromFluid[0]"   "TotalPressureForceFromFluid[1]"   
1.06736   0.129035062   -0.001386581   
1.06736   2.447225204   -0.023816057   
2.07325   0.638323563   -0.006861182   
