### PR TITLE
add test ReduceDynamicsCK with vecd

### DIFF
--- a/src/shared/common/base_data_type.h
+++ b/src/shared/common/base_data_type.h
@@ -66,7 +66,7 @@ template <typename T>
 using AtomicRef = boost::atomic_ref<T>;
 namespace math = std;
 #endif // SPHINXSYS_USE_SYCL
-    
+
 #if SPHINXSYS_USE_FLOAT
 using Real = float;
 using UnsignedInt = u_int32_t;
@@ -114,6 +114,12 @@ template <>
 struct ZeroData<UnsignedInt>
 {
     static inline const UnsignedInt value = 0;
+};
+
+template <>
+struct ZeroData<Vec3d>
+{
+    static inline const Vec3d value = Vec3d::Zero();
 };
 
 template <typename FirstType, typename SecondType>

--- a/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -334,6 +334,8 @@ int main(int ac, char *av[])
         bidirectional_velocity_condition_left(left_emitter_by_cell, inlet_buffer);
     fluid_dynamics::PressureBidirectionalConditionCK<MainExecutionPolicy, NoKernelCorrectionCK, InletInflowPressureConditionRight>
         bidirectional_pressure_condition_right(right_emitter_by_cell, inlet_buffer);
+
+    ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::FlowrateCalculateCK> flowrate_calculate(right_emitter_by_cell);
     //----------------------------------------------------------------------
     //	Define the methods for I/O operations, observations
     //	and regression tests of the simulation.
@@ -429,12 +431,15 @@ int main(int ac, char *av[])
             /** inflow emitter injection*/
             bidirectional_velocity_condition_left.injectParticles();
             bidirectional_pressure_condition_right.injectParticles();
+
             bidirectional_velocity_condition_left.deleteParticles();
             bidirectional_pressure_condition_right.deleteParticles();
             /** Update cell linked list and configuration. */
             if (number_of_iterations % 100 == 0 && number_of_iterations != 1)
             {
                 particle_sort.exec();
+                // Vecd FR = flowrate_calculate.exec();
+                // std::cout << FR << std::endl;
             }
             water_cell_linked_list.exec();
             water_body_update_complex_relation.exec();


### PR DESCRIPTION
I try to work with ReduceDynamicsCK with 
class FlowrateCalculateCK
    : public BaseLocalDynamicsReduce<**ReduceSum<Vec3d**>, AlignedBoxPartByCell>
    
`    ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::FlowrateCalculateCK> flowrate_calculate(right_emitter_by_cell);`

however, i get the error like this

```
build] In file included from /home/ycliao/sphinxsys/SPHinXsys/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp:8:
[build] In file included from /home/ycliao/sphinxsys/SPHinXsys/src/src_sycl/shared/include/sphinxsys_sycl.h:32:
[build] In file included from /home/ycliao/sphinxsys/SPHinXsys/src/src_sycl/shared/particle_dynamics/particle_iterators_sycl.h:32:
[build] In file included from /home/ycliao/sphinxsys/SPHinXsys/src/src_sycl/shared/particle_dynamics/implementation_sycl.h:35:
[build] In file included from /home/ycliao/sphinxsys/SPHinXsys/src/shared/particle_dynamics/execution/implementation.h:36:
[build] /home/ycliao/sphinxsys/SPHinXsys/src/shared/shared_ck/particle_dynamics/loop_range.h:99:56: error: SYCL kernel cannot use a const static or global variable that is neither zero-initialized nor constant-initialized
[build]    99 |         ReturnType temp = ReduceReference<BinaryFunc>::value;
[build]       |                                                        ^
[build] 1 warning and 1 error generated.
[build] gmake[3]: *** [tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/CMakeFiles/test_3d_mixed_poiseuille_flow_sycl.dir/build.make:82: tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/CMakeFiles/test_3d_mixed_poiseuille_flow_sycl.dir/mixed_poiseuille_flow.cpp.o] Error 1
[build] gmake[2]: *** [CMakeFiles/Makefile2:8395: tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/CMakeFiles/test_3d_mixed_poiseuille_flow_sycl.dir/all] Error 2
[build] gmake[1]: *** [CMakeFiles/Makefile2:8402: tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/CMakeFiles/test_3d_mixed_poiseuille_flow_sycl.dir/rule] Error 2
[build] gmake: *** [Makefile:1682: test_3d_mixed_poiseuille_flow_sycl] Error 2
[proc] The command: /usr/bin/cmake --build /home/ycliao/sphinxsys/SPHinXsys/build --parallel 4 --target test_3d_mixed_poiseuille_flow_sycl "-j 8" -- exited with code: 2
[driver] Build completed: 00:10:31.738
[build] Build finished with exit code 2
```