### PR TITLE
reference passed as argument

### DIFF
--- a/src/shared/shared_ck/particle_dynamics/loop_range.h
+++ b/src/shared/shared_ck/particle_dynamics/loop_range.h
@@ -49,7 +49,7 @@ class LoopRangeCK<ExecutionPolicy, SPHBody>
     template <class UnaryFunc>
     void computeUnit(const UnaryFunc &f, UnsignedInt i) const { f(i); };
     template <class ReturnType, class BinaryFunc, class UnaryFunc>
-    ReturnType computeUnit(const BinaryFunc &bf, const UnaryFunc &uf, UnsignedInt i) const { return uf(i); };
+    ReturnType computeUnit(ReturnType temp, const BinaryFunc &bf, const UnaryFunc &uf, UnsignedInt i) const { return uf(i); };
     UnsignedInt LoopBound() const { return *loop_bound_; };
 
   protected:
@@ -66,7 +66,7 @@ class LoopRangeCK<ExecutionPolicy, BodyPartByParticle>
     template <class UnaryFunc>
     void computeUnit(const UnaryFunc &f, UnsignedInt i) const { f(index_list_[i]); };
     template <class ReturnType, class BinaryFunc, class UnaryFunc>
-    ReturnType computeUnit(const BinaryFunc &bf, const UnaryFunc &uf, UnsignedInt i) const { return uf(index_list_[i]); };
+    ReturnType computeUnit(ReturnType temp, const BinaryFunc &bf, const UnaryFunc &uf, UnsignedInt i) const { return uf(index_list_[i]); };
     UnsignedInt LoopBound() const { return *loop_bound_; };
 
   protected:
@@ -94,9 +94,8 @@ class LoopRangeCK<ExecutionPolicy, BodyPartByCell>
     };
 
     template <class ReturnType, class BinaryFunc, class UnaryFunc>
-    ReturnType computeUnit(const BinaryFunc &bf, const UnaryFunc &uf, UnsignedInt i) const
+    ReturnType computeUnit(ReturnType temp, const BinaryFunc &bf, const UnaryFunc &uf, UnsignedInt i) const
     {
-        ReturnType temp = ReduceReference<BinaryFunc>::value;
         UnsignedInt cell_index = index_list_[i];
         for (size_t k = cell_offset_[cell_index]; k != cell_offset_[cell_index + 1]; ++k)
         {

--- a/src/shared/shared_ck/particle_dynamics/particle_iterators_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/particle_iterators_ck.h
@@ -69,7 +69,7 @@ ReturnType particle_reduce(const LoopRangeCK<SequencedPolicy, DynamicsIdentifier
     Operation operation;
     for (size_t i = 0; i < loop_range.LoopBound(); ++i)
     {
-        temp = operation(temp, loop_range.template computeUnit<ReturnType>(operation, unary_func, i));
+        temp = operation(temp, loop_range.computeUnit(temp, operation, unary_func, i));
     }
     return temp;
 }
@@ -80,12 +80,12 @@ ReturnType particle_reduce(const LoopRangeCK<ParallelPolicy, DynamicsIdentifier>
 {
     Operation operation;
     return parallel_reduce(
-        IndexRange(0, loop_range.LoopBound()),
-        temp, [&](const IndexRange &r, ReturnType temp0) -> ReturnType
+        IndexRange(0, loop_range.LoopBound()), temp,
+        [&](const IndexRange &r, ReturnType temp0) -> ReturnType
         {
 				for (size_t i = r.begin(); i != r.end(); ++i)
 				{
-					temp0 = operation(temp0, loop_range.template computeUnit<ReturnType>(operation, unary_func, i));
+					temp0 = operation(temp0, loop_range.computeUnit(temp0, operation, unary_func, i));
 				}
 				return temp0; },
         [&](const ReturnType &x, const ReturnType &y) -> ReturnType


### PR DESCRIPTION
now. The static global constant is not used in sycl kernel. 
This pull request includes several changes to the `computeUnit` method in multiple classes within the `src/shared/shared_ck/particle_dynamics/loop_range.h` file and related files. The primary goal is to modify the method signature to include an additional `ReturnType temp` parameter, which is then used in subsequent calls to `computeUnit`.

Changes to `computeUnit` method:

* [`src/shared/shared_ck/particle_dynamics/loop_range.h`](diffhunk://#diff-23b27d3144bdacfcfec2bf4fe3c7081ae7961f16dd29340b70c86404dffdc1d2L52-R52): Modified the `computeUnit` method in the `LoopRangeCK<ExecutionPolicy, SPHBody>`, `LoopRangeCK<ExecutionPolicy, BodyPartByParticle>`, and `LoopRangeCK<ExecutionPolicy, BodyPartByCell>` classes to include an additional `ReturnType temp` parameter. [[1]](diffhunk://#diff-23b27d3144bdacfcfec2bf4fe3c7081ae7961f16dd29340b70c86404dffdc1d2L52-R52) [[2]](diffhunk://#diff-23b27d3144bdacfcfec2bf4fe3c7081ae7961f16dd29340b70c86404dffdc1d2L69-R69) [[3]](diffhunk://#diff-23b27d3144bdacfcfec2bf4fe3c7081ae7961f16dd29340b70c86404dffdc1d2L97-L99)

Updates to `particle_reduce` function:

* [`src/shared/shared_ck/particle_dynamics/particle_iterators_ck.h`](diffhunk://#diff-8021d2f8c78499359936475ef5a73745b86a749a2c4372a99241d072155f844cL72-R72): Updated the `particle_reduce` function to pass the additional `ReturnType temp` parameter when calling the `computeUnit` method for both `SequencedPolicy` and `ParallelPolicy` specializations. [[1]](diffhunk://#diff-8021d2f8c78499359936475ef5a73745b86a749a2c4372a99241d072155f844cL72-R72) [[2]](diffhunk://#diff-8021d2f8c78499359936475ef5a73745b86a749a2c4372a99241d072155f844cL83-R88)

* [`src/src_sycl/shared/particle_dynamics/particle_iterators_sycl.h`](diffhunk://#diff-d5448c97b4d4dcf0fb20c0a7dd3b513d4528f187618993b893c4bbfc178975aaR91-R98): Updated the `particle_reduce` function for the `ParallelDevicePolicy` specialization to pass the additional `ReturnType temp` parameter when calling the `computeUnit` method.