### PR TITLE
787 duplicate original id and inconsistent calculation with quantityaverage and reducesumstdpairvecd real

### DIFF
--- a/src/shared/particles/particle_operation.cpp
+++ b/src/shared/particles/particle_operation.cpp
@@ -14,7 +14,5 @@ RemoveRealParticle::RemoveRealParticle(BaseParticles *particles)
     : evolving_variables_(particles->EvolvingVariables()),
       copyable_states_(),
       dv_original_id_(particles->getVariableByName<UnsignedInt>("OriginalID")),
-      dv_sorted_id_(particles->getVariableByName<UnsignedInt>("SortedID")),
-      sv_total_real_particles_(particles->svTotalRealParticles()),
-      real_particles_bound_(particles->ParticlesBound()) {}
+      sv_total_real_particles_(particles->svTotalRealParticles()){}
 } // namespace SPH

--- a/src/shared/particles/particle_operation.h
+++ b/src/shared/particles/particle_operation.h
@@ -85,9 +85,8 @@ class RemoveRealParticle
 {
     ParticleVariables &evolving_variables_;
     DiscreteVariableArrays copyable_states_;
-    DiscreteVariable<UnsignedInt> *dv_original_id_, *dv_sorted_id_;
+    DiscreteVariable<UnsignedInt> *dv_original_id_;
     SingularVariable<UnsignedInt> *sv_total_real_particles_;
-    UnsignedInt real_particles_bound_;
 
   public:
     RemoveRealParticle(BaseParticles *particles);
@@ -113,14 +112,12 @@ class RemoveRealParticle
                 UnsignedInt old_original_id = original_id_[index_i];
                 copy_particle_state_(copyable_state_data_arrays_, index_i, last_real_particle_index);
                 original_id_[last_real_particle_index] = old_original_id; // swap the original id
-                sorted_id_[original_id_[index_i]] = index_i;
             }
         };
 
       protected:
         UnsignedInt *total_real_particles_;
-        UnsignedInt real_particles_bound_;
-        UnsignedInt *original_id_, *sorted_id_;
+        UnsignedInt *original_id_;
         VariableDataArrays copyable_state_data_arrays_;
         OperationOnDataAssemble<VariableDataArrays, CopyParticleStateCK> copy_particle_state_;
     };

--- a/src/shared/particles/particle_operation.hpp
+++ b/src/shared/particles/particle_operation.hpp
@@ -36,9 +36,7 @@ template <class ExecutionPolicy, class EncloserType>
 RemoveRealParticle::ComputingKernel::
     ComputingKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
     : total_real_particles_(encloser.sv_total_real_particles_->DelegatedData(ex_policy)),
-      real_particles_bound_(encloser.real_particles_bound_),
-      original_id_(encloser.dv_original_id_->DelegatedData(ex_policy)),
-      sorted_id_(encloser.dv_sorted_id_->DelegatedData(ex_policy))
+      original_id_(encloser.dv_original_id_->DelegatedData(ex_policy))
 {
     OperationBetweenDataAssembles<ParticleVariables, DiscreteVariableArrays, DiscreteVariableArraysInitialization>
         initialize_discrete_variable_array;


### PR DESCRIPTION
This pull request includes changes to the `src/shared/particles/particle_operation.h` file to improve the handling of particle IDs during particle operations. The most important changes include updates to the `SpawnRealParticle` and `RemoveRealParticle` classes to ensure the correct management of original particle IDs.

Improvements to particle ID management:

* [`src/shared/particles/particle_operation.h`](diffhunk://#diff-f2bb99cb8cf3624022cac413fb502b7ca2f0698e257630172a88e397fea63a7eL65-R72): Updated the `SpawnRealParticle` class to correctly manage original particle IDs by introducing a new variable `last_real_particle_index` and ensuring the original ID is preserved when copying particle states.
* [`src/shared/particles/particle_operation.h`](diffhunk://#diff-f2bb99cb8cf3624022cac413fb502b7ca2f0698e257630172a88e397fea63a7eR113-R115): Modified the `RemoveRealParticle` class to swap the original IDs correctly when removing particles, ensuring the integrity of particle ID management.