### PR TITLE
using tabulated smoothing kernel to fit different analytical ones

### DIFF
--- a/src/shared/shared_ck/neighborhood/neighborhood_ck.h
+++ b/src/shared/shared_ck/neighborhood/neighborhood_ck.h
@@ -31,7 +31,7 @@
 #ifndef NEIGHBORHOOD_CK_H
 #define NEIGHBORHOOD_CK_H
 
-#include "kernel_wendland_c2_ck.h"
+#include "kernel_tabulated_ck.h"
 #include "neighborhood.h"
 
 namespace SPH
@@ -50,7 +50,7 @@ class Neighbor<>
     Neighbor(const ExecutionPolicy &ex_policy, SPHAdaptation *sph_adaptation, SPHAdaptation *contact_adaptation,
              DiscreteVariable<Vecd> *dv_pos, DiscreteVariable<Vecd> *dv_target_pos);
 
-    KernelWendlandC2CK &getKernel() { return kernel_; }
+    KernelTabulatedCK &getKernel() { return kernel_; }
 
     inline Vecd vec_r_ij(size_t i, size_t j) const { return source_pos_[i] - target_pos_[j]; };
     inline Real W_ij(size_t i, size_t j) const { return kernel_.W(vec_r_ij(i, j)); }
@@ -78,7 +78,7 @@ class Neighbor<>
     };
 
   protected:
-    KernelWendlandC2CK kernel_;
+    KernelTabulatedCK kernel_;
     Vecd *source_pos_;
     Vecd *target_pos_;
 };

--- a/src/shared/shared_ck/neighborhood/neighborhood_ck.hpp
+++ b/src/shared/shared_ck/neighborhood/neighborhood_ck.hpp
@@ -21,7 +21,7 @@ Neighbor<>::Neighbor(const ExecutionPolicy &ex_policy,
       source_pos_(dv_pos->DelegatedData(ex_policy)),
       target_pos_(dv_contact_pos->DelegatedData(ex_policy))
 {
-    KernelWendlandC2CK contact_kernel(*contact_adaptation->getKernel());
+    KernelTabulatedCK contact_kernel(*contact_adaptation->getKernel());
     if (kernel_.CutOffRadius() < contact_kernel.CutOffRadius())
     {
         kernel_ = contact_kernel;

--- a/src/shared/shared_ck/smoothing_kernel/kernel_tabulated_ck.cpp
+++ b/src/shared/shared_ck/smoothing_kernel/kernel_tabulated_ck.cpp
@@ -1,0 +1,36 @@
+#include "kernel_tabulated_ck.h"
+
+namespace SPH
+{
+//=================================================================================================//
+KernelTabulatedCK::KernelTabulatedCK(Kernel &kernel)
+{
+    inv_h_ = 1.0 / kernel.SmoothingLength();
+    factor_W_1D_ = kernel.FactorW1D();
+    factor_W_2D_ = kernel.FactorW2D();
+    factor_W_3D_ = kernel.FactorW3D();
+    factor_dW_1D_ = inv_h_ * factor_W_1D_;
+    factor_dW_2D_ = inv_h_ * factor_W_2D_;
+    factor_dW_3D_ = inv_h_ * factor_W_3D_;
+    rc_ref_ = kernel.CutOffRadius();
+    rc_ref_sqr_ = kernel.CutOffRadiusSqr();
+
+    dq_ = kernel.KernelSize() / Real(kernel_resolution_);
+    for (int i = 0; i < kernel_resolution_; i++)
+    {
+        w_1d[i] = kernel.W_1D(Real(i - 1) * dq_);
+        dw_1d[i] = kernel.dW_1D(Real(i - 1) * dq_);
+    }
+    // kernel trailing zeros
+    for (int i = kernel_resolution_; i < tabulated_array_size_; i++)
+    {
+        w_1d[i] = 0.0;
+        dw_1d[i] = 0.0;
+    }
+
+    delta_q_0_ = (-1.0 * dq_) * (-2.0 * dq_) * (-3.0 * dq_);
+    delta_q_1_ = dq_ * (-1.0 * dq_) * (-2.0 * dq_);
+    delta_q_2_ = (2.0 * dq_) * dq_ * (-1.0 * dq_);
+    delta_q_3_ = (3.0 * dq_) * (2.0 * dq_) * dq_;
+} //=================================================================================================//
+} // namespace SPH

--- a/src/shared/shared_ck/smoothing_kernel/kernel_tabulated_ck.cpp
+++ b/src/shared/shared_ck/smoothing_kernel/kernel_tabulated_ck.cpp
@@ -28,9 +28,9 @@ KernelTabulatedCK::KernelTabulatedCK(Kernel &kernel)
         dw_1d[i] = 0.0;
     }
 
-    delta_q_0_ = (-1.0 * dq_) * (-2.0 * dq_) * (-3.0 * dq_);
-    delta_q_1_ = dq_ * (-1.0 * dq_) * (-2.0 * dq_);
-    delta_q_2_ = (2.0 * dq_) * dq_ * (-1.0 * dq_);
-    delta_q_3_ = (3.0 * dq_) * (2.0 * dq_) * dq_;
+    inv_delta_q_0_ = 1.0 / ((-1.0 * dq_) * (-2.0 * dq_) * (-3.0 * dq_));
+    inv_delta_q_1_ = 1.0 / (dq_ * (-1.0 * dq_) * (-2.0 * dq_));
+    inv_delta_q_2_ = 1.0 / ((2.0 * dq_) * dq_ * (-1.0 * dq_));
+    inv_delta_q_3_ = 1.0 / ((3.0 * dq_) * (2.0 * dq_) * dq_);
 } //=================================================================================================//
 } // namespace SPH

--- a/src/shared/shared_ck/smoothing_kernel/kernel_tabulated_ck.cpp
+++ b/src/shared/shared_ck/smoothing_kernel/kernel_tabulated_ck.cpp
@@ -28,9 +28,9 @@ KernelTabulatedCK::KernelTabulatedCK(Kernel &kernel)
         dw_1d[i] = 0.0;
     }
 
-    inv_delta_q_0_ = 1.0 / ((-1.0 * dq_) * (-2.0 * dq_) * (-3.0 * dq_));
-    inv_delta_q_1_ = 1.0 / (dq_ * (-1.0 * dq_) * (-2.0 * dq_));
-    inv_delta_q_2_ = 1.0 / ((2.0 * dq_) * dq_ * (-1.0 * dq_));
-    inv_delta_q_3_ = 1.0 / ((3.0 * dq_) * (2.0 * dq_) * dq_);
+    delta_q_0_ = (-1.0 * dq_) * (-2.0 * dq_) * (-3.0 * dq_);
+    delta_q_1_ = dq_ * (-1.0 * dq_) * (-2.0 * dq_);
+    delta_q_2_ = (2.0 * dq_) * dq_ * (-1.0 * dq_);
+    delta_q_3_ = (3.0 * dq_) * (2.0 * dq_) * dq_;
 } //=================================================================================================//
 } // namespace SPH

--- a/src/shared/shared_ck/smoothing_kernel/kernel_tabulated_ck.h
+++ b/src/shared/shared_ck/smoothing_kernel/kernel_tabulated_ck.h
@@ -51,10 +51,10 @@ class KernelTabulatedCK
         Real fraction_2 = fraction_1 - dq_;         // fraction_2 correspond to i+1
         Real fraction_3 = fraction_1 - 2 * dq_;     ////fraction_3 correspond to i+2
 
-        return fraction_1 * fraction_2 * fraction_3 * inv_delta_q_0_ * data[i - 1] +
-               fraction_0 * fraction_2 * fraction_3 * inv_delta_q_1_ * data[i] +
-               fraction_0 * fraction_1 * fraction_3 * inv_delta_q_2_ * data[i + 1] +
-               fraction_0 * fraction_1 * fraction_2 * inv_delta_q_3_ * data[i + 2];
+        return (fraction_1 * fraction_2 * fraction_3) / delta_q_0_ * data[i - 1] +
+               (fraction_0 * fraction_2 * fraction_3) / delta_q_1_ * data[i] +
+               (fraction_0 * fraction_1 * fraction_3) / delta_q_2_ * data[i + 1] +
+               (fraction_0 * fraction_1 * fraction_2) / delta_q_3_ * data[i + 2];
     };
 
     Real W(const Real &displacement) const
@@ -98,7 +98,7 @@ class KernelTabulatedCK
     Real inv_h_, rc_ref_, rc_ref_sqr_;
     Real factor_W_1D_, factor_W_2D_, factor_W_3D_;
     Real factor_dW_1D_, factor_dW_2D_, factor_dW_3D_;
-    Real dq_, inv_delta_q_0_, inv_delta_q_1_, inv_delta_q_2_, inv_delta_q_3_;
+    Real dq_, delta_q_0_, delta_q_1_, delta_q_2_, delta_q_3_;
     Real w_1d[tabulated_array_size_], dw_1d[tabulated_array_size_];
 };
 } // namespace SPH

--- a/src/shared/shared_ck/smoothing_kernel/kernel_tabulated_ck.h
+++ b/src/shared/shared_ck/smoothing_kernel/kernel_tabulated_ck.h
@@ -51,10 +51,10 @@ class KernelTabulatedCK
         Real fraction_2 = fraction_1 - dq_;         // fraction_2 correspond to i+1
         Real fraction_3 = fraction_1 - 2 * dq_;     ////fraction_3 correspond to i+2
 
-        return (fraction_1 * fraction_2 * fraction_3) / delta_q_0_ * data[i - 1] +
-               (fraction_0 * fraction_2 * fraction_3) / delta_q_1_ * data[i] +
-               (fraction_0 * fraction_1 * fraction_3) / delta_q_2_ * data[i + 1] +
-               (fraction_0 * fraction_1 * fraction_2) / delta_q_3_ * data[i + 2];
+        return fraction_1 * fraction_2 * fraction_3 * inv_delta_q_0_ * data[i - 1] +
+               fraction_0 * fraction_2 * fraction_3 * inv_delta_q_1_ * data[i] +
+               fraction_0 * fraction_1 * fraction_3 * inv_delta_q_2_ * data[i + 1] +
+               fraction_0 * fraction_1 * fraction_2 * inv_delta_q_3_ * data[i + 2];
     };
 
     Real W(const Real &displacement) const
@@ -98,7 +98,7 @@ class KernelTabulatedCK
     Real inv_h_, rc_ref_, rc_ref_sqr_;
     Real factor_W_1D_, factor_W_2D_, factor_W_3D_;
     Real factor_dW_1D_, factor_dW_2D_, factor_dW_3D_;
-    Real dq_, delta_q_0_, delta_q_1_, delta_q_2_, delta_q_3_;
+    Real dq_, inv_delta_q_0_, inv_delta_q_1_, inv_delta_q_2_, inv_delta_q_3_;
     Real w_1d[tabulated_array_size_], dw_1d[tabulated_array_size_];
 };
 } // namespace SPH


### PR DESCRIPTION
This pull request involves significant changes to the kernel used in the `Neighbor` class, transitioning from `KernelWendlandC2CK` to `KernelTabulatedCK`. This includes updates to header files, implementation files, and the `Neighbor` class itself to accommodate the new kernel. 

Key changes include:

### Kernel Transition:
* Replaced the inclusion of `kernel_wendland_c2_ck.h` with `kernel_tabulated_ck.h` in `neighborhood_ck.h`.
* Updated the `Neighbor` class to use `KernelTabulatedCK` instead of `KernelWendlandC2CK` for the `getKernel` method and the `kernel_` member variable. [[1]](diffhunk://#diff-451a026a23ef2595269801b3916dc900838eace6a45d51fb8c6ff4621ab784f4L53-R53) [[2]](diffhunk://#diff-451a026a23ef2595269801b3916dc900838eace6a45d51fb8c6ff4621ab784f4L81-R81)
* Modified the constructor of `Neighbor` to initialize `contact_kernel` as `KernelTabulatedCK` instead of `KernelWendlandC2CK`.

### Implementation of KernelTabulatedCK:
* Added the implementation of `KernelTabulatedCK` in `kernel_tabulated_ck.cpp`, including methods for initializing kernel factors and interpolating cubic values.

### Header File Update:
* Renamed and updated `kernel_wendland_c2_ck.h` to `kernel_tabulated_ck.h`, reflecting the new kernel class and its methods.