### PR TITLE
revise interpolation by using generalized scalar

### DIFF
--- a/src/for_2D_build/common/data_type.h
+++ b/src/for_2D_build/common/data_type.h
@@ -38,9 +38,6 @@ namespace SPH
 using Arrayi = Array2i;
 using Vecd = Vec2d;
 using Matd = Mat2d;
-using RestoreMatd = RestoreMat2d;
-template<typename DataType>
-using PredictVec = PredictVec2<DataType>;
 using AngularVecd = Real;
 using Rotation = Rotation2d;
 using BoundingBox = BaseBoundingBox<Vec2d>;

--- a/src/for_3D_build/common/data_type.h
+++ b/src/for_3D_build/common/data_type.h
@@ -37,9 +37,6 @@ namespace SPH
 using Arrayi = Array3i;
 using Vecd = Vec3d;
 using Matd = Mat3d;
-using RestoreMatd = RestoreMat3d;
-template <typename DataType>
-using PredictVec = PredictVec3<DataType>;
 using AngularVecd = Vec3d;
 using Rotation = Rotation3d;
 using BoundingBox = BaseBoundingBox<Vec3d>;

--- a/src/shared/common/base_data_type.h
+++ b/src/shared/common/base_data_type.h
@@ -81,19 +81,26 @@ using Array3i = Eigen::Array<int, 3, 1>;
 /** Vector with float point number.*/
 using Vec2d = Eigen::Matrix<Real, 2, 1>;
 using Vec3d = Eigen::Matrix<Real, 3, 1>;
-/** Small, 2*2 and 3*3, matrix with float point number. */
+using Vec6d = Eigen::Matrix<Real, 6, 1>;
+/** Small 2*2, 3*3, 4*4 and 6*6 matrix with float point number. */
 using Mat2d = Eigen::Matrix<Real, 2, 2>;
 using Mat3d = Eigen::Matrix<Real, 3, 3>;
-/** linear restoring matrix and vector for particle based linear reproducing interpolation. */
-using RestoreMat2d = Mat3d;
-using RestoreMat3d = Eigen::Matrix<Real, 4, 4>;
-template <typename DataType>
-using PredictVec2 = Eigen::Matrix<DataType, 3, 1>;
-
-template <typename DataType>
-using PredictVec3 = Eigen::Matrix<DataType, 4, 1>;
+using Mat6d = Eigen::Matrix<Real, 6, 6>;
 /** Dynamic matrix*/
 using MatXd = Eigen::Matrix<Real, Eigen::Dynamic, Eigen::Dynamic>;
+
+/** Unified initialize to unit for all float point types. */
+template <typename DataType>
+struct UnitData
+{
+    static inline const DataType value = DataType::Ones();
+};
+
+template <>
+struct UnitData<Real>
+{
+    static inline const Real value = Real(1);
+};
 
 /** Unified initialize to zero for all data type. */
 template <typename DataType>
@@ -130,21 +137,6 @@ struct ZeroData<std::pair<FirstType, SecondType>>
     using PairType = std::pair<FirstType, SecondType>;
     static inline const PairType value = PairType(
         ZeroData<FirstType>::value, ZeroData<SecondType>::value);
-};
-
-template <typename DataType>
-struct ZeroData<PredictVec2<DataType>>
-{
-    static inline const PredictVec2<DataType> value = PredictVec2<DataType>(
-        ZeroData<DataType>::value, ZeroData<DataType>::value, ZeroData<DataType>::value);
-};
-
-template <typename DataType>
-struct ZeroData<PredictVec3<DataType>>
-{
-    static inline const PredictVec3<DataType> value = PredictVec3<DataType>(
-        ZeroData<DataType>::value, ZeroData<DataType>::value,
-        ZeroData<DataType>::value, ZeroData<DataType>::value);
 };
 
 template <typename DataType>

--- a/src/shared/common/scalar_numerics.h
+++ b/src/shared/common/scalar_numerics.h
@@ -39,8 +39,20 @@ struct Scalar
 
     // Constructors
     Scalar() = default;
-    Scalar(const T &v) : value(v) {};
-    Scalar(const int &zero) : value(Real(zero) * UnitData<T>::value) {};
+    Scalar(const T &v) : value(v) {}
+    Scalar(int) : value(init_zero()) {}
+
+    static T init_zero()
+    {
+        if constexpr (std::is_floating_point_v<T>)
+        {
+            return 0.0;
+        }
+        else
+        {
+            return T::Zero(); // Assumes T has a static Zero() method
+        }
+    }
     // Implicit conversion
     operator const T &() const { return value; }
     operator T &() { return value; }

--- a/src/shared/common/scalar_numerics.h
+++ b/src/shared/common/scalar_numerics.h
@@ -39,8 +39,8 @@ struct Scalar
 
     // Constructors
     Scalar() = default;
-    Scalar(const T &v) : value(v) {}
-    Scalar(const Real &s) : value(s * UnitData<T>::value) {}
+    Scalar(const T &v) : value(v) {};
+    Scalar(const int &zero) : value(Real(zero) * UnitData<T>::value) {};
     // Implicit conversion
     operator const T &() const { return value; }
     operator T &() { return value; }

--- a/src/shared/common/scalar_numerics.h
+++ b/src/shared/common/scalar_numerics.h
@@ -35,14 +35,14 @@ namespace SPH
 template <typename T>
 struct Scalar
 {
-    T value;
+    T value_;
 
     // Constructors
     Scalar() = default;
-    Scalar(const T &v) : value(v) {}
-    Scalar(int) : value(init_zero()) {}
+    Scalar(const T &v) : value_(v) {}
+    Scalar(int) : value_(initZero()) {}
 
-    static T init_zero()
+    static T initZero()
     {
         if constexpr (std::is_floating_point_v<T>)
         {
@@ -54,34 +54,34 @@ struct Scalar
         }
     }
     // Implicit conversion
-    operator const T &() const { return value; }
-    operator T &() { return value; }
+    operator const T &() const { return value_; }
+    operator T &() { return value_; }
 
     // Access
-    T &ref() { return value; }
-    const T &get() const { return value; }
+    T &ref() { return value_; }
+    const T &get() const { return value_; }
 
     // Arithmetic (only if T supports it)
     Scalar &operator+=(const Scalar &rhs)
     {
-        value += rhs.value;
+        value_ += rhs.value_;
         return *this;
     }
     Scalar &operator-=(const Scalar &rhs)
     {
-        value -= rhs.value;
+        value_ -= rhs.value_;
         return *this;
     }
     template <typename ArithmeticType>
     Scalar &operator*=(const ArithmeticType &s)
     {
-        value *= s;
+        value_ *= s;
         return *this;
     }
     template <typename ArithmeticType>
     Scalar &operator/=(const ArithmeticType &s)
     {
-        value /= s;
+        value_ /= s;
         return *this;
     }
 
@@ -95,20 +95,20 @@ struct Scalar
     friend Scalar operator/(Scalar a, const ArithmeticType &s) { return a /= s; }
 
     // Comparison
-    bool operator==(const Scalar &rhs) const { return value == rhs.value; }
+    bool operator==(const Scalar &rhs) const { return value_ == rhs.value_; }
 
     // Output
     friend std::ostream &operator<<(std::ostream &os, const Scalar &s)
     {
 
-        return os << s.value;
+        return os << s.value_;
     }
 };
 
 template <typename T>
 struct ZeroData<Scalar<T>>
 {
-    static inline const Scalar<T> value = Scalar<T>(ZeroData<T>::value);
+    static inline const Scalar<T> value = Scalar<T>(ZeroData<T>::value_);
 };
 
 template <typename T, int N>

--- a/src/shared/common/scalar_numerics.h
+++ b/src/shared/common/scalar_numerics.h
@@ -1,0 +1,144 @@
+/* ------------------------------------------------------------------------- *
+ *                                SPHinXsys                                  *
+ * ------------------------------------------------------------------------- *
+ * SPHinXsys (pronunciation: s'finksis) is an acronym from Smoothed Particle *
+ * Hydrodynamics for industrial compleX systems. It provides C++ APIs for    *
+ * physical accurate simulation and aims to model coupled industrial dynamic *
+ * systems including fluid, solid, multi-body dynamics and beyond with SPH   *
+ * (smoothed particle hydrodynamics), a meshless computational method using  *
+ * particle discretization.                                                  *
+ *                                                                           *
+ * SPHinXsys is partially funded by German Research Foundation               *
+ * (Deutsche Forschungsgemeinschaft) DFG HU1527/6-1, HU1527/10-1,            *
+ *  HU1527/12-1 and HU1527/12-4.                                             *
+ *                                                                           *
+ * Portions copyright (c) 2017-2023 Technical University of Munich and       *
+ * the authors' affiliations.                                                *
+ *                                                                           *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may   *
+ * not use this file except in compliance with the License. You may obtain a *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.        *
+ *                                                                           *
+ * ------------------------------------------------------------------------- */
+/**
+ * @file 	scalar_numerics.h
+ * @brief 	Use as scalar for high-level computation using eigen library.
+ * @author	Xiangyu Hu
+ */
+#ifndef SCALAR_NUMERICS_H
+#define SCALAR_NUMERICS_H
+
+#include "base_data_type.h"
+
+namespace SPH
+{
+template <typename T>
+struct Scalar
+{
+    T value;
+
+    // Constructors
+    Scalar() = default;
+    Scalar(const T &v) : value(v) {}
+    Scalar(const Real &s) : value(s * UnitData<T>::value) {}
+    // Implicit conversion
+    operator const T &() const { return value; }
+    operator T &() { return value; }
+
+    // Access
+    T &ref() { return value; }
+    const T &get() const { return value; }
+
+    // Arithmetic (only if T supports it)
+    Scalar &operator+=(const Scalar &rhs)
+    {
+        value += rhs.value;
+        return *this;
+    }
+    Scalar &operator-=(const Scalar &rhs)
+    {
+        value -= rhs.value;
+        return *this;
+    }
+    Scalar &operator*=(const typename T::Scalar &s)
+    {
+        value *= s;
+        return *this;
+    }
+    Scalar &operator/=(const typename T::Scalar &s)
+    {
+        value /= s;
+        return *this;
+    }
+
+    friend Scalar operator+(Scalar a, const Scalar &b) { return a += b; }
+    friend Scalar operator-(Scalar a, const Scalar &b) { return a -= b; }
+    friend Scalar operator*(Scalar a, const typename T::Scalar &s) { return a *= s; }
+    friend Scalar operator*(const typename T::Scalar &s, Scalar a) { return a *= s; }
+    friend Scalar operator/(Scalar a, const typename T::Scalar &s) { return a /= s; }
+
+    // Comparison
+    bool operator==(const Scalar &rhs) const { return value == rhs.value; }
+
+    // Output
+    friend std::ostream &operator<<(std::ostream &os, const Scalar &s)
+    {
+
+        return os << s.value;
+    }
+};
+
+template <typename T>
+struct ZeroData<Scalar<T>>
+{
+    static inline const Scalar<T> value = Scalar<T>(ZeroData<T>::value);
+};
+
+template <typename T, int N>
+Scalar<T> dotProduct(const Eigen::Matrix<Real, N, 1> &real_vector, const Eigen::Matrix<Scalar<T>, N, 1> &scalar_vector)
+{
+    Scalar<T> scalar = Scalar<T>(0);
+    for (UnsignedInt i = 0; i < N; ++i)
+    {
+        scalar += real_vector[i] * scalar_vector[i];
+    }
+    return scalar;
+};
+
+template <typename T, int N, int M>
+Eigen::Matrix<Scalar<T>, N, M> scalarProduct(const Eigen::Matrix<Real, N, M> &real_matrix, const Scalar<T> &scalar)
+{
+    Eigen::Matrix<Scalar<T>, N, M> scalar_matrix = Eigen::Matrix<Scalar<T>, N, M>::Zero();
+    for (UnsignedInt i = 0; i < N; ++i)
+        for (UnsignedInt j = 0; j < M; ++j)
+        {
+            scalar_matrix(i, j) = real_matrix(i, j) * scalar;
+        }
+
+    return scalar_matrix;
+};
+
+} // namespace SPH
+
+namespace Eigen
+{
+template <typename T>
+struct NumTraits<SPH::Scalar<T>> : GenericNumTraits<SPH::Scalar<T>>
+{
+    using Real = SPH::Real;
+    using NonInteger = SPH::Real;
+    using Nested = SPH::Real;
+
+    enum
+    {
+        IsComplex = 0,
+        IsInteger = 0,
+        IsSigned = 1,
+        RequireInitialization = 1,
+        ReadCost = 1,
+        AddCost = 1,
+        MulCost = 1
+    };
+};
+} // namespace Eigen
+#endif // SCALAR_NUMERICS_H

--- a/src/shared/common/scalar_numerics.h
+++ b/src/shared/common/scalar_numerics.h
@@ -60,12 +60,14 @@ struct Scalar
         value -= rhs.value;
         return *this;
     }
-    Scalar &operator*=(const typename T::Scalar &s)
+    template <typename ArithmeticType>
+    Scalar &operator*=(const ArithmeticType &s)
     {
         value *= s;
         return *this;
     }
-    Scalar &operator/=(const typename T::Scalar &s)
+    template <typename ArithmeticType>
+    Scalar &operator/=(const ArithmeticType &s)
     {
         value /= s;
         return *this;
@@ -73,9 +75,12 @@ struct Scalar
 
     friend Scalar operator+(Scalar a, const Scalar &b) { return a += b; }
     friend Scalar operator-(Scalar a, const Scalar &b) { return a -= b; }
-    friend Scalar operator*(Scalar a, const typename T::Scalar &s) { return a *= s; }
-    friend Scalar operator*(const typename T::Scalar &s, Scalar a) { return a *= s; }
-    friend Scalar operator/(Scalar a, const typename T::Scalar &s) { return a /= s; }
+    template <typename ArithmeticType>
+    friend Scalar operator*(Scalar a, const ArithmeticType &s) { return a *= s; }
+    template <typename ArithmeticType>
+    friend Scalar operator*(const ArithmeticType &s, Scalar a) { return a *= s; }
+    template <typename ArithmeticType>
+    friend Scalar operator/(Scalar a, const ArithmeticType &s) { return a /= s; }
 
     // Comparison
     bool operator==(const Scalar &rhs) const { return value == rhs.value; }

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.h
@@ -30,6 +30,7 @@
 #define INTERPOLATION_DYNAMICS_H
 
 #include "interaction_algorithms_ck.hpp"
+#include "scalar_numerics.h"
 
 namespace SPH
 {
@@ -91,10 +92,23 @@ class Interpolation<Contact<DataType, Parameters...>> : public Interpolation<Con
  * doi.org/10.1007/s11831-010-9040-7
  */
 class RestoringCorrection;
+
+template <typename DataType, int N>
+using PredictVec = Eigen::Matrix<Scalar<DataType>, N, 1>;
+template <typename DataType, int N>
+struct ZeroData<PredictVec<DataType, N>>
+{
+    static inline const PredictVec<DataType, N> value = PredictVec<DataType, N>::Zero();
+};
+
 template <typename DataType, typename... Parameters>
 class Interpolation<Contact<DataType, RestoringCorrection, Parameters...>> : public Interpolation<Contact<Base, DataType, Parameters...>>
 {
     using BaseDynamicsType = Interpolation<Contact<Base, DataType, Parameters...>>;
+    static constexpr int RestoringSize = Dimensions + 1;
+    using RestoreMatd = Eigen::Matrix<Real, RestoringSize, RestoringSize>;
+    using RestoreVecd = Eigen::Matrix<Real, RestoringSize, 1>;
+    using PredictVecd = PredictVec<DataType, RestoringSize>;
 
   public:
     template <typename... Args>
@@ -108,8 +122,8 @@ class Interpolation<Contact<DataType, RestoringCorrection, Parameters...>> : pub
         void interact(size_t index_i, Real dt = 0.0);
 
       protected:
-        DataType zero_value_;
-        PredictVec<DataType> zero_prediction_;
+        Scalar<DataType> zero_value_;
+        PredictVecd zero_prediction_;
         DataType *interpolated_quantities_;
         Real *contact_Vol_;
         DataType *contact_data_;

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.h
@@ -122,7 +122,6 @@ class Interpolation<Contact<DataType, RestoringCorrection, Parameters...>> : pub
         void interact(size_t index_i, Real dt = 0.0);
 
       protected:
-        Scalar<DataType> zero_value_;
         PredictVecd zero_prediction_;
         DataType *interpolated_quantities_;
         Real *contact_Vol_;

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.hpp
@@ -77,7 +77,7 @@ void Interpolation<Contact<DataType, RestoringCorrection, Parameters...>>::Inter
         approximation_matrix(0, 0) = W_ijV_j;
         approximation_matrix.block(0, 1, 1, Dimensions) = -W_ijV_j * r_ij.transpose();
         approximation_matrix.block(1, 0, Dimensions, 1) = dW_ijV_j * e_ij;
-        approximation_matrix.block(1, 1, Dimensions, Dimensions) = -dW_ijV_j * e_ij * e_ij.transpose();
+        approximation_matrix.block(1, 1, Dimensions, Dimensions) = -dW_ijV_j * r_ij * e_ij.transpose();
 
         RestoreVecd approximation_vector = approximation_matrix.col(0);
         prediction += scalarProduct(approximation_vector, Scalar<DataType>(contact_data_[index_j]));

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.hpp
@@ -54,7 +54,7 @@ template <class ExecutionPolicy, class EncloserType>
 Interpolation<Contact<DataType, RestoringCorrection, Parameters...>>::InteractKernel::
     InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt contact_index)
     : BaseDynamicsType::InteractKernel(ex_policy, encloser, contact_index),
-      zero_value_(ZeroData<DataType>::value), zero_prediction_(ZeroData<PredictVec<DataType>>::value),
+      zero_value_(ZeroData<DataType>::value), zero_prediction_(ZeroData<PredictVecd>::value),
       interpolated_quantities_(encloser.dv_interpolated_quantities_->DelegatedData(ex_policy)),
       contact_Vol_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)),
       contact_data_(encloser.dv_contact_data_[contact_index]->DelegatedData(ex_policy)) {}
@@ -62,8 +62,7 @@ Interpolation<Contact<DataType, RestoringCorrection, Parameters...>>::InteractKe
 template <typename DataType, typename... Parameters>
 void Interpolation<Contact<DataType, RestoringCorrection, Parameters...>>::InteractKernel::interact(size_t index_i, Real dt)
 {
-    DataType interpolated_quantity = zero_value_;
-    PredictVec<DataType> prediction = zero_prediction_;
+    PredictVecd prediction = zero_prediction_;
     RestoreMatd restoring_matrix = Eps * RestoreMatd::Identity();
 
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -74,30 +73,19 @@ void Interpolation<Contact<DataType, RestoringCorrection, Parameters...>>::Inter
         Real W_ijV_j = this->W_ij(index_i, index_j) * contact_Vol_[index_j];
         Real dW_ijV_j = this->dW_ij(index_i, index_j) * contact_Vol_[index_j];
 
-        Real element1 = W_ijV_j;
-        Vecd element2 = W_ijV_j * r_ij;
-        Vecd element3 = dW_ijV_j * e_ij;
-        Matd element4 = dW_ijV_j * r_ij * e_ij.transpose();
+        RestoreMatd approximation_matrix = RestoreMatd::Zero();
+        approximation_matrix(0, 0) = W_ijV_j;
+        approximation_matrix.block(0, 1, 1, Dimensions) = -W_ijV_j * r_ij.transpose();
+        approximation_matrix.block(1, 0, Dimensions, 1) = dW_ijV_j * e_ij;
+        approximation_matrix.block(1, 1, Dimensions, Dimensions) = -dW_ijV_j * e_ij * e_ij.transpose();
 
-        prediction[0] += element1 * contact_data_[index_j];
-        for (UnsignedInt i = 0; i < Dimensions; ++i)
-        {
-            prediction[i + 1] += element3[i] * contact_data_[index_j];
-        }
-
-        restoring_matrix(0, 0) += element1;
-        restoring_matrix.block(0, 1, 1, Dimensions) -= element2.transpose();
-        restoring_matrix.block(1, 0, Dimensions, 1) += element3;
-        restoring_matrix.block(1, 1, Dimensions, Dimensions) -= element4;
+        RestoreVecd approximation_vector = approximation_matrix.col(0);
+        prediction += scalarProduct(approximation_vector, Scalar<DataType>(contact_data_[index_j]));
+        restoring_matrix += approximation_matrix;
     }
 
-    RestoreMatd restoring_matrix_inverse = restoring_matrix.inverse();
-    for (UnsignedInt i = 0; i < Dimensions + 1; ++i)
-    {
-        interpolated_quantity += restoring_matrix_inverse(0, i) * prediction[i];
-    }
-
-    interpolated_quantities_[index_i] = interpolated_quantity;
+    RestoreVecd restoring_vector = restoring_matrix.inverse().row(0).transpose();
+    interpolated_quantities_[index_i] = dotProduct(restoring_vector, prediction).get();
 }
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.hpp
@@ -54,7 +54,7 @@ template <class ExecutionPolicy, class EncloserType>
 Interpolation<Contact<DataType, RestoringCorrection, Parameters...>>::InteractKernel::
     InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt contact_index)
     : BaseDynamicsType::InteractKernel(ex_policy, encloser, contact_index),
-      zero_value_(ZeroData<DataType>::value), zero_prediction_(ZeroData<PredictVecd>::value),
+      zero_prediction_(ZeroData<PredictVecd>::value),
       interpolated_quantities_(encloser.dv_interpolated_quantities_->DelegatedData(ex_policy)),
       contact_Vol_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)),
       contact_data_(encloser.dv_contact_data_[contact_index]->DelegatedData(ex_policy)) {}


### PR DESCRIPTION
This pull request includes significant changes to the data type definitions and introduces a new `Scalar` template for high-level computation. The most important changes include removing unnecessary type aliases, adding a new `Scalar` template, and updating the interpolation dynamics to use the new `Scalar` template.

Data type definition updates:
* [`src/for_2D_build/common/data_type.h`](diffhunk://#diff-58263bb8054a7419e71723fc528c4a7689b445bb0b8c1f303af1376b642b1cadL41-L43): Removed `RestoreMatd` and `PredictVec` type aliases.
* [`src/for_3D_build/common/data_type.h`](diffhunk://#diff-957ca71aa42a9f9753f8749798fd9cf7f06301ae2daf86c4e13aded4cfc8b6dfL40-L42): Removed `RestoreMatd` and `PredictVec` type aliases.
* [`src/shared/common/base_data_type.h`](diffhunk://#diff-886e53dd8dc9f5c97cdb0aac61d7be24fbfc798d9129916ac91df553913e22d5L84-R104): Added new type aliases `Vec6d` and `Mat6d`, and removed `RestoreMat2d`, `RestoreMat3d`, `PredictVec2`, and `PredictVec3` type aliases.

Introduction of `Scalar` template:
* [`src/shared/common/scalar_numerics.h`](diffhunk://#diff-2f20a730ee6521d16199b9ab8192df2df5578a3c3a7b8aa560bf88a6b25d5a54R1-R144): Added a new `Scalar` template for high-level computation using the Eigen library, along with necessary arithmetic operations, comparison operators, and output stream support.

Interpolation dynamics updates:
* [`src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.h`](diffhunk://#diff-b9b161ae1adec055a2f428f9859a1d477ed2a4caad48dec7c3a51b7f4b1ec0acR95-R111): Updated the `Interpolation` class to use the new `Scalar` template and added new type aliases `RestoreMatd`, `RestoreVecd`, and `PredictVec`. [[1]](diffhunk://#diff-b9b161ae1adec055a2f428f9859a1d477ed2a4caad48dec7c3a51b7f4b1ec0acR95-R111) [[2]](diffhunk://#diff-b9b161ae1adec055a2f428f9859a1d477ed2a4caad48dec7c3a51b7f4b1ec0acL111-R126)
* [`src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.hpp`](diffhunk://#diff-da1219267cce81fce78582965eff9aeec0f420e98d17e077839bfa72aa37c60bL57-R65): Updated the `InteractKernel` constructor and `interact` method to use the new `Scalar` template and the updated type aliases. [[1]](diffhunk://#diff-da1219267cce81fce78582965eff9aeec0f420e98d17e077839bfa72aa37c60bL57-R65) [[2]](diffhunk://#diff-da1219267cce81fce78582965eff9aeec0f420e98d17e077839bfa72aa37c60bL77-R88)