### PR TITLE
Xiangyu/body part by indication

### DIFF
--- a/modules/opencascade/tests/test_3d_aortic_valve/aortic_valve.cpp
+++ b/modules/opencascade/tests/test_3d_aortic_valve/aortic_valve.cpp
@@ -36,8 +36,7 @@ namespace SPH
 class BoundaryGeometry : public BodyPartByParticle
 {
   public:
-    BoundaryGeometry(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    BoundaryGeometry(SPHBody &body) : BodyPartByParticle(body)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&BoundaryGeometry::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -154,7 +153,7 @@ int main(int ac, char *av[])
     RelaxationStepInnerFirstHalf leaflet_relaxation_first_half(leaflet_inner);
     RelaxationStepInnerSecondHalf leaflet_relaxation_second_half(leaflet_inner);
     /** Constrain the boundary. */
-    BoundaryGeometry boundary_geometry(leaflet, "BoundaryGeometry");
+    BoundaryGeometry boundary_geometry(leaflet);
     SimpleDynamics<SurfaceNormalDirection> surface_normal_direction(leaflet);
     //----------------------------------------------------------------------
     //	Particle relaxation starts here.

--- a/src/shared/bodies/base_body_part.cpp
+++ b/src/shared/bodies/base_body_part.cpp
@@ -50,7 +50,7 @@ void BodyPartByParticle::tagParticles(TaggingParticleMethod &tagging_particle_me
     }
 
     dv_particle_list_ = unique_variable_ptrs_.createPtr<DiscreteVariable<UnsignedInt>>(
-        part_name_, body_part_particles_.size(), [&](size_t i) -> Real
+        part_name_, body_part_particles_.size(), [&](size_t i)
         { return body_part_particles_[i]; });
     sv_range_size_ = unique_variable_ptrs_.createPtr<SingularVariable<UnsignedInt>>(
         part_name_ + "_Size", body_part_particles_.size());
@@ -86,7 +86,7 @@ void BodyPartByCell::tagCells(TaggingCellMethod &tagging_cell_method)
         }
     }
     dv_cell_list_ = unique_variable_ptrs_.createPtr<DiscreteVariable<UnsignedInt>>(
-        part_name_, cell_indexes.size(), [&](size_t i) -> Real
+        part_name_, cell_indexes.size(), [&](size_t i)
         { return cell_indexes[i]; });
     sv_range_size_ = unique_variable_ptrs_.createPtr<SingularVariable<UnsignedInt>>(
         part_name_ + "_Size", cell_indexes.size());

--- a/src/shared/bodies/base_body_part.cpp
+++ b/src/shared/bodies/base_body_part.cpp
@@ -59,8 +59,8 @@ void BodyPartByParticle::tagParticles(TaggingParticleMethod &tagging_particle_me
 BodyPartByCell::BodyPartByCell(RealBody &real_body)
     : BodyPart(real_body), cell_linked_list_(real_body.getCellLinkedList()),
       dv_cell_list_(nullptr),
-      dv_particle_index_(cell_linked_list_.getParticleIndex()),
-      dv_cell_offset_(cell_linked_list_.getCellOffset()) {}
+      dv_particle_index_(cell_linked_list_.dvParticleIndex()),
+      dv_cell_offset_(cell_linked_list_.dvCellOffset()) {}
 //=============================================================================================//
 size_t BodyPartByCell::SizeOfLoopRange()
 {

--- a/src/shared/bodies/base_body_part.cpp
+++ b/src/shared/bodies/base_body_part.cpp
@@ -96,6 +96,7 @@ BodyRegionByParticle::
     BodyRegionByParticle(SPHBody &sph_body, Shape &body_part_shape)
     : BodyPartByParticle(sph_body), body_part_shape_(body_part_shape)
 {
+    alias_ = body_part_shape_.getName();
     TaggingParticleMethod tagging_particle_method = std::bind(&BodyRegionByParticle::tagByContain, this, _1);
     tagParticles(tagging_particle_method);
 }
@@ -115,6 +116,7 @@ BodySurface::BodySurface(SPHBody &sph_body)
     : BodyPartByParticle(sph_body),
       particle_spacing_min_(sph_body.getSPHAdaptation().MinimumSpacing())
 {
+    alias_ = "BodySurface";
     TaggingParticleMethod tagging_particle_method = std::bind(&BodySurface::tagNearSurface, this, _1);
     tagParticles(tagging_particle_method);
     std::cout << "Number of surface particles : " << body_part_particles_.size() << std::endl;
@@ -130,6 +132,7 @@ BodySurfaceLayer::BodySurfaceLayer(SPHBody &sph_body, Real layer_thickness)
     : BodyPartByParticle(sph_body),
       thickness_threshold_(sph_body.getSPHAdaptation().ReferenceSpacing() * layer_thickness)
 {
+    alias_ = "InnerLayers";
     TaggingParticleMethod tagging_particle_method = std::bind(&BodySurfaceLayer::tagSurfaceLayer, this, _1);
     tagParticles(tagging_particle_method);
     std::cout << "Number of inner layers particles : " << body_part_particles_.size() << std::endl;
@@ -144,6 +147,7 @@ bool BodySurfaceLayer::tagSurfaceLayer(size_t particle_index)
 BodyRegionByCell::BodyRegionByCell(RealBody &real_body, Shape &body_part_shape)
     : BodyPartByCell(real_body), body_part_shape_(body_part_shape)
 {
+    alias_ = body_part_shape_.getName();
     TaggingCellMethod tagging_cell_method = std::bind(&BodyRegionByCell::checkNotFar, this, _1, _2);
     tagCells(tagging_cell_method);
 }
@@ -162,6 +166,7 @@ bool BodyRegionByCell::checkNotFar(Vecd cell_position, Real threshold)
 NearShapeSurface::NearShapeSurface(RealBody &real_body, LevelSetShape &level_set_shape)
     : BodyPartByCell(real_body), level_set_shape_(level_set_shape)
 {
+    alias_ = level_set_shape.getName();
     TaggingCellMethod tagging_cell_method = std::bind(&NearShapeSurface::checkNearSurface, this, _1, _2);
     tagCells(tagging_cell_method);
 }
@@ -170,6 +175,7 @@ NearShapeSurface::NearShapeSurface(RealBody &real_body, SharedPtr<Shape> shape_p
     : BodyPartByCell(real_body),
       level_set_shape_(level_set_shape_keeper_.createRef<LevelSetShape>(real_body, *shape_ptr.get(), true))
 {
+    alias_ = level_set_shape_.getName();
     TaggingCellMethod tagging_cell_method = std::bind(&NearShapeSurface::checkNearSurface, this, _1, _2);
     tagCells(tagging_cell_method);
 }
@@ -188,6 +194,7 @@ NearShapeSurface::NearShapeSurface(RealBody &real_body, const std::string &sub_s
           DynamicCast<LevelSetShape>(this, *DynamicCast<ComplexShape>(this, real_body.getInitialShape())
                                                 .getSubShapeByName(sub_shape_name)))
 {
+    alias_ = sub_shape_name;
     TaggingCellMethod tagging_cell_method = std::bind(&NearShapeSurface::checkNearSurface, this, _1, _2);
     tagCells(tagging_cell_method);
 }

--- a/src/shared/bodies/base_body_part.cpp
+++ b/src/shared/bodies/base_body_part.cpp
@@ -5,22 +5,24 @@
 namespace SPH
 {
 //=================================================================================================//
-BodyPart::BodyPart(SPHBody &sph_body, const std::string &body_part_name)
+BodyPart::BodyPart(SPHBody &sph_body)
     : sph_body_(sph_body), part_id_(sph_body.getNewBodyPartID()),
-      body_part_name_(body_part_name),
-      base_particles_(sph_body.getBaseParticles()),
-      dv_index_list_(nullptr), sv_range_size_(nullptr),
-      dv_body_part_indicator_(nullptr),
+      part_name_(sph_body.getName() + "Part" + std::to_string(part_id_)),
+      base_particles_(sph_body.getBaseParticles()), sv_range_size_(nullptr),
+      dv_body_part_id_(base_particles_.registerStateVariableOnly<int>(part_name_ + "ID")),
       pos_(base_particles_.getVariableDataByName<Vecd>("Position")) {}
 //=================================================================================================//
-BodyPartByParticle::BodyPartByParticle(SPHBody &sph_body, const std::string &body_part_name)
-    : BodyPart(sph_body, body_part_name),
-      body_part_bounds_(Vecd::Zero(), Vecd::Zero()), body_part_bounds_set_(false)
+BodyPartByID::BodyPartByID(SPHBody &sph_body) : BodyPart(sph_body)
+{
+    sv_range_size_ = base_particles_.svTotalRealParticles();
+}
+//=================================================================================================//
+BodyPartByParticle::BodyPartByParticle(SPHBody &sph_body)
+    : BodyPart(sph_body), body_part_bounds_(Vecd::Zero(), Vecd::Zero()),
+      body_part_bounds_set_(false)
 {
     sph_body.addBodyPartByParticle(this);
-    dv_body_part_indicator_ =
-        base_particles_.registerStateVariableOnly<int>(body_part_name + "Indicator");
-    base_particles_.addEvolvingVariable<int>(dv_body_part_indicator_);
+    base_particles_.addEvolvingVariable<int>(dv_body_part_id_);
 }
 //=================================================================================================//
 void BodyPartByParticle::setBodyPartBounds(BoundingBox bbox)
@@ -42,26 +44,23 @@ void BodyPartByParticle::tagParticles(TaggingParticleMethod &tagging_particle_me
     {
         if (tagging_particle_method(i))
         {
-            dv_body_part_indicator_->setValue(i, part_id_);
+            dv_body_part_id_->setValue(i, part_id_);
             body_part_particles_.push_back(i);
         }
     }
 
-    dv_index_list_ = unique_variable_ptrs_.createPtr<DiscreteVariable<UnsignedInt>>(
-        body_part_name_, body_part_particles_.size(), [&](size_t i) -> Real
+    dv_particle_list_ = unique_variable_ptrs_.createPtr<DiscreteVariable<UnsignedInt>>(
+        part_name_, body_part_particles_.size(), [&](size_t i) -> Real
         { return body_part_particles_[i]; });
     sv_range_size_ = unique_variable_ptrs_.createPtr<SingularVariable<UnsignedInt>>(
-        body_part_name_ + "_Size", body_part_particles_.size());
+        part_name_ + "_Size", body_part_particles_.size());
 }
 //=================================================================================================//
-BodyPartByCell::BodyPartByCell(RealBody &real_body, const std::string &body_part_name)
-    : BodyPart(real_body, body_part_name), cell_linked_list_(real_body.getCellLinkedList()),
+BodyPartByCell::BodyPartByCell(RealBody &real_body)
+    : BodyPart(real_body), cell_linked_list_(real_body.getCellLinkedList()),
+      dv_cell_list_(nullptr),
       dv_particle_index_(cell_linked_list_.getParticleIndex()),
-      dv_cell_offset_(cell_linked_list_.getCellOffset())
-{
-    dv_body_part_indicator_ = unique_variable_ptrs_.createPtr<DiscreteVariable<int>>(
-        body_part_name + "Indicator", cell_linked_list_.TotalNumberOfCells());
-}
+      dv_cell_offset_(cell_linked_list_.getCellOffset()) {}
 //=============================================================================================//
 size_t BodyPartByCell::SizeOfLoopRange()
 {
@@ -78,21 +77,24 @@ void BodyPartByCell::tagCells(TaggingCellMethod &tagging_cell_method)
     ConcurrentIndexVector cell_indexes;
     cell_linked_list_.tagBodyPartByCell(body_part_cells_, cell_indexes, tagging_cell_method);
 
-    for (size_t i = 0; i != cell_indexes.size(); ++i)
+    for (size_t i = 0; i != body_part_cells_.size(); ++i)
     {
-        dv_body_part_indicator_->setValue(cell_indexes[i], part_id_);
+        ConcurrentIndexVector &particle_indexes = *body_part_cells_[i];
+        for (size_t num = 0; num < particle_indexes.size(); ++num)
+        {
+            dv_body_part_id_->setValue(particle_indexes[num], part_id_);
+        }
     }
-    dv_index_list_ = unique_variable_ptrs_.createPtr<DiscreteVariable<UnsignedInt>>(
-        body_part_name_, cell_indexes.size(), [&](size_t i) -> Real
+    dv_cell_list_ = unique_variable_ptrs_.createPtr<DiscreteVariable<UnsignedInt>>(
+        part_name_, cell_indexes.size(), [&](size_t i) -> Real
         { return cell_indexes[i]; });
     sv_range_size_ = unique_variable_ptrs_.createPtr<SingularVariable<UnsignedInt>>(
-        body_part_name_ + "_Size", cell_indexes.size());
+        part_name_ + "_Size", cell_indexes.size());
 }
 //=================================================================================================//
 BodyRegionByParticle::
     BodyRegionByParticle(SPHBody &sph_body, Shape &body_part_shape)
-    : BodyPartByParticle(sph_body, body_part_shape.getName()),
-      body_part_shape_(body_part_shape)
+    : BodyPartByParticle(sph_body), body_part_shape_(body_part_shape)
 {
     TaggingParticleMethod tagging_particle_method = std::bind(&BodyRegionByParticle::tagByContain, this, _1);
     tagParticles(tagging_particle_method);
@@ -110,7 +112,7 @@ bool BodyRegionByParticle::tagByContain(size_t particle_index)
 }
 //=================================================================================================//
 BodySurface::BodySurface(SPHBody &sph_body)
-    : BodyPartByParticle(sph_body, "BodySurface"),
+    : BodyPartByParticle(sph_body),
       particle_spacing_min_(sph_body.getSPHAdaptation().MinimumSpacing())
 {
     TaggingParticleMethod tagging_particle_method = std::bind(&BodySurface::tagNearSurface, this, _1);
@@ -125,7 +127,7 @@ bool BodySurface::tagNearSurface(size_t particle_index)
 }
 //=================================================================================================//
 BodySurfaceLayer::BodySurfaceLayer(SPHBody &sph_body, Real layer_thickness)
-    : BodyPartByParticle(sph_body, "InnerLayers"),
+    : BodyPartByParticle(sph_body),
       thickness_threshold_(sph_body.getSPHAdaptation().ReferenceSpacing() * layer_thickness)
 {
     TaggingParticleMethod tagging_particle_method = std::bind(&BodySurfaceLayer::tagSurfaceLayer, this, _1);
@@ -140,8 +142,7 @@ bool BodySurfaceLayer::tagSurfaceLayer(size_t particle_index)
 }
 //=================================================================================================//
 BodyRegionByCell::BodyRegionByCell(RealBody &real_body, Shape &body_part_shape)
-    : BodyPartByCell(real_body, body_part_shape.getName()),
-      body_part_shape_(body_part_shape)
+    : BodyPartByCell(real_body), body_part_shape_(body_part_shape)
 {
     TaggingCellMethod tagging_cell_method = std::bind(&BodyRegionByCell::checkNotFar, this, _1, _2);
     tagCells(tagging_cell_method);
@@ -159,14 +160,14 @@ bool BodyRegionByCell::checkNotFar(Vecd cell_position, Real threshold)
 }
 //=================================================================================================//
 NearShapeSurface::NearShapeSurface(RealBody &real_body, LevelSetShape &level_set_shape)
-    : BodyPartByCell(real_body, level_set_shape.getName()), level_set_shape_(level_set_shape)
+    : BodyPartByCell(real_body), level_set_shape_(level_set_shape)
 {
     TaggingCellMethod tagging_cell_method = std::bind(&NearShapeSurface::checkNearSurface, this, _1, _2);
     tagCells(tagging_cell_method);
 }
 //=================================================================================================//
 NearShapeSurface::NearShapeSurface(RealBody &real_body, SharedPtr<Shape> shape_ptr)
-    : BodyPartByCell(real_body, shape_ptr->getName()),
+    : BodyPartByCell(real_body),
       level_set_shape_(level_set_shape_keeper_.createRef<LevelSetShape>(real_body, *shape_ptr.get(), true))
 {
     TaggingCellMethod tagging_cell_method = std::bind(&NearShapeSurface::checkNearSurface, this, _1, _2);
@@ -174,7 +175,7 @@ NearShapeSurface::NearShapeSurface(RealBody &real_body, SharedPtr<Shape> shape_p
 }
 //=================================================================================================//
 NearShapeSurface::NearShapeSurface(RealBody &real_body)
-    : BodyPartByCell(real_body, "NearShapeSurface"),
+    : BodyPartByCell(real_body),
       level_set_shape_(DynamicCast<LevelSetShape>(this, real_body.getInitialShape()))
 {
     TaggingCellMethod tagging_cell_method = std::bind(&NearShapeSurface::checkNearSurface, this, _1, _2);
@@ -182,7 +183,7 @@ NearShapeSurface::NearShapeSurface(RealBody &real_body)
 }
 //=================================================================================================//
 NearShapeSurface::NearShapeSurface(RealBody &real_body, const std::string &sub_shape_name)
-    : BodyPartByCell(real_body, sub_shape_name),
+    : BodyPartByCell(real_body),
       level_set_shape_(
           DynamicCast<LevelSetShape>(this, *DynamicCast<ComplexShape>(this, real_body.getInitialShape())
                                                 .getSubShapeByName(sub_shape_name)))
@@ -196,35 +197,33 @@ bool NearShapeSurface::checkNearSurface(Vecd cell_position, Real threshold)
     return level_set_shape_.checkNearSurface(cell_position, threshold);
 }
 //=================================================================================================//
-AlignedBoxPart::AlignedBoxPart(const std::string &name, const AlignedBox &aligned_box)
+AlignedBoxPart::AlignedBoxPart(const std::string &part_name, const AlignedBox &aligned_box)
     : aligned_box_(*sv_aligned_box_keeper_
-                        .createPtr<SingularVariable<AlignedBox>>("AlignedBox" + name, aligned_box)
+                        .createPtr<SingularVariable<AlignedBox>>(part_name, aligned_box)
                         ->Data()) {}
 //=================================================================================================//
-AlignedBoxPartByParticle::AlignedBoxPartByParticle(RealBody &real_body, const AlignedBox &aligned_box)
-    : BodyPartByParticle(real_body, "AlignedBoxByParticle"),
-      AlignedBoxPart(body_part_name_, aligned_box)
+AlignedBoxByParticle::AlignedBoxByParticle(RealBody &real_body, const AlignedBox &aligned_box)
+    : BodyPartByParticle(real_body), AlignedBoxPart(part_name_, aligned_box)
 {
     TaggingParticleMethod tagging_particle_method =
-        std::bind(&AlignedBoxPartByParticle::tagByContain, this, _1);
+        std::bind(&AlignedBoxByParticle::tagByContain, this, _1);
     tagParticles(tagging_particle_method);
 }
 //=================================================================================================//
-bool AlignedBoxPartByParticle::tagByContain(size_t particle_index)
+bool AlignedBoxByParticle::tagByContain(size_t particle_index)
 {
     return aligned_box_.checkContain(pos_[particle_index]);
 }
 //=================================================================================================//
-AlignedBoxPartByCell::AlignedBoxPartByCell(RealBody &real_body, const AlignedBox &aligned_box)
-    : BodyPartByCell(real_body, "AlignedBoxByCell"),
-      AlignedBoxPart(body_part_name_, aligned_box)
+AlignedBoxByCell::AlignedBoxByCell(RealBody &real_body, const AlignedBox &aligned_box)
+    : BodyPartByCell(real_body), AlignedBoxPart(part_name_, aligned_box)
 {
     TaggingCellMethod tagging_cell_method =
-        std::bind(&AlignedBoxPartByCell::checkNotFar, this, _1, _2);
+        std::bind(&AlignedBoxByCell::checkNotFar, this, _1, _2);
     tagCells(tagging_cell_method);
 }
 //=================================================================================================//
-bool AlignedBoxPartByCell::checkNotFar(Vecd cell_position, Real threshold)
+bool AlignedBoxByCell::checkNotFar(Vecd cell_position, Real threshold)
 {
     return aligned_box_.checkNotFar(cell_position, threshold);
 }

--- a/src/shared/bodies/base_body_part.h
+++ b/src/shared/bodies/base_body_part.h
@@ -32,6 +32,7 @@
 
 #include "base_body.h"
 
+#include <optional>
 #include <string>
 
 namespace SPH
@@ -51,7 +52,7 @@ class BodyPart
     virtual ~BodyPart() {};
     SPHBody &getSPHBody() { return sph_body_; };
     SPHSystem &getSPHSystem() { return sph_body_.getSPHSystem(); };
-    std::string getName() { return part_name_; };
+    std::string getName() const { return alias_.value_or(part_name_); };
     int getPartID() { return part_id_; };
     SingularVariable<UnsignedInt> *svRangeSize() { return sv_range_size_; };
 
@@ -81,6 +82,7 @@ class BodyPart
     SPHBody &sph_body_;
     int part_id_;
     std::string part_name_;
+    std::optional<std::string> alias_;
     BaseParticles &base_particles_;
     SingularVariable<UnsignedInt> *sv_range_size_;
     DiscreteVariable<int> *dv_body_part_id_;

--- a/src/shared/bodies/base_body_part.h
+++ b/src/shared/bodies/base_body_part.h
@@ -136,8 +136,8 @@ class BodyPartByCell : public BodyPart
     BodyPartByCell(RealBody &real_body);
     virtual ~BodyPartByCell() {};
     DiscreteVariable<UnsignedInt> *dvCellList() { return dv_cell_list_; };
-    DiscreteVariable<UnsignedInt> *getParticleIndex() { return dv_particle_index_; };
-    DiscreteVariable<UnsignedInt> *getCellOffset() { return dv_cell_offset_; };
+    DiscreteVariable<UnsignedInt> *dvParticleIndex() { return dv_particle_index_; };
+    DiscreteVariable<UnsignedInt> *dvCellOffset() { return dv_cell_offset_; };
 
   protected:
     BaseCellLinkedList &cell_linked_list_;

--- a/src/shared/bodies/base_body_part.h
+++ b/src/shared/bodies/base_body_part.h
@@ -47,24 +47,52 @@ class BodyPart
     UniquePtrsKeeper<Entity> unique_variable_ptrs_;
 
   public:
-    BodyPart(SPHBody &sph_body, const std::string &body_part_name);
+    BodyPart(SPHBody &sph_body);
     virtual ~BodyPart() {};
     SPHBody &getSPHBody() { return sph_body_; };
     SPHSystem &getSPHSystem() { return sph_body_.getSPHSystem(); };
-    std::string getName() { return body_part_name_; };
+    std::string getName() { return part_name_; };
     int getPartID() { return part_id_; };
-    DiscreteVariable<UnsignedInt> *dvIndexList() { return dv_index_list_; };
     SingularVariable<UnsignedInt> *svRangeSize() { return sv_range_size_; };
+
+    template <typename TargetCriterion>
+    class TargetParticleMask : public TargetCriterion
+    {
+      public:
+        template <class ExecutionPolicy, typename EnclosureType, typename... Args>
+        TargetParticleMask(ExecutionPolicy &ex_policy, EnclosureType &encloser, Args &&...args)
+            : TargetCriterion(std::forward<Args>(args)...), part_id_(encloser.part_id_),
+              body_part_id_(encloser.dv_body_part_id_->DelegatedData(ex_policy)) {}
+        virtual ~TargetParticleMask() {}
+
+        template <typename... Args>
+        bool operator()(UnsignedInt target_index, Args &&...args)
+        {
+            return (body_part_id_[target_index] == part_id_) &&
+                   TargetCriterion::operator()(target_index, std::forward<Args>(args)...);
+        }
+
+      protected:
+        int part_id_;
+        int *body_part_id_;
+    };
 
   protected:
     SPHBody &sph_body_;
     int part_id_;
-    std::string body_part_name_;
+    std::string part_name_;
     BaseParticles &base_particles_;
-    DiscreteVariable<UnsignedInt> *dv_index_list_;
     SingularVariable<UnsignedInt> *sv_range_size_;
-    DiscreteVariable<int> *dv_body_part_indicator_;
+    DiscreteVariable<int> *dv_body_part_id_;
     Vecd *pos_;
+};
+
+class BodyPartByID : public BodyPart
+{
+  public:
+    typedef BodyPartByID BaseIdentifier;
+    BodyPartByID(SPHBody &sph_body);
+    virtual ~BodyPartByID() {};
 };
 
 /**
@@ -77,39 +105,18 @@ class BodyPartByParticle : public BodyPart
     typedef BodyPartByParticle BaseIdentifier;
     IndexVector body_part_particles_; /**< Collection particle in this body part. */
     BaseParticles &getBaseParticles() { return base_particles_; };
+    DiscreteVariable<UnsignedInt> *dvParticleList() { return dv_particle_list_; };
     IndexVector &LoopRange() { return body_part_particles_; };
     size_t SizeOfLoopRange() { return body_part_particles_.size(); };
-    BodyPartByParticle(SPHBody &sph_body, const std::string &body_part_name);
+    BodyPartByParticle(SPHBody &sph_body);
     virtual ~BodyPartByParticle() {};
     void setBodyPartBounds(BoundingBox bbox);
     BoundingBox getBodyPartBounds();
 
-    template <typename TargetCriterion>
-    class TargetParticleMask : public TargetCriterion
-    {
-      public:
-        template <class ExecutionPolicy, typename EnclosureType, typename... Args>
-        TargetParticleMask(ExecutionPolicy &ex_policy, EnclosureType &encloser, Args &&...args)
-            : TargetCriterion(std::forward<Args>(args)...), part_id_(encloser.part_id_),
-              body_part_indicator_(encloser.dv_body_part_indicator_->DelegatedData(ex_policy)) {}
-        virtual ~TargetParticleMask() {}
-
-        template <typename... Args>
-        bool operator()(UnsignedInt target_index, Args &&...args)
-        {
-            return (body_part_indicator_[target_index] == part_id_) &&
-                   TargetCriterion::operator()(target_index, std::forward<Args>(args)...);
-        }
-
-      protected:
-        int part_id_;
-        int *body_part_indicator_;
-    };
-
   protected:
+    DiscreteVariable<UnsignedInt> *dv_particle_list_;
     BoundingBox body_part_bounds_;
     bool body_part_bounds_set_;
-
     typedef std::function<bool(size_t)> TaggingParticleMethod;
     void tagParticles(TaggingParticleMethod &tagging_particle_method);
 };
@@ -126,13 +133,15 @@ class BodyPartByCell : public BodyPart
     ConcurrentCellLists &LoopRange() { return body_part_cells_; };
     size_t SizeOfLoopRange();
 
-    BodyPartByCell(RealBody &real_body, const std::string &body_part_name);
+    BodyPartByCell(RealBody &real_body);
     virtual ~BodyPartByCell() {};
+    DiscreteVariable<UnsignedInt> *dvCellList() { return dv_cell_list_; };
     DiscreteVariable<UnsignedInt> *getParticleIndex() { return dv_particle_index_; };
     DiscreteVariable<UnsignedInt> *getCellOffset() { return dv_cell_offset_; };
 
   protected:
     BaseCellLinkedList &cell_linked_list_;
+    DiscreteVariable<UnsignedInt> *dv_cell_list_;
     DiscreteVariable<UnsignedInt> *dv_particle_index_;
     DiscreteVariable<UnsignedInt> *dv_cell_offset_;
     typedef std::function<bool(Vecd, Real)> TaggingCellMethod;
@@ -239,7 +248,7 @@ class AlignedBoxPart
     UniquePtrKeeper<SingularVariable<AlignedBox>> sv_aligned_box_keeper_;
 
   public:
-    AlignedBoxPart(const std::string &name, const AlignedBox &aligned_box);
+    AlignedBoxPart(const std::string &part_name, const AlignedBox &aligned_box);
     virtual ~AlignedBoxPart() {};
     SingularVariable<AlignedBox> *svAlignedBox() { return sv_aligned_box_keeper_.getPtr(); };
     AlignedBox &getAlignedBox() { return aligned_box_; };
@@ -248,21 +257,21 @@ class AlignedBoxPart
     AlignedBox &aligned_box_;
 };
 
-class AlignedBoxPartByParticle : public BodyPartByParticle, public AlignedBoxPart
+class AlignedBoxByParticle : public BodyPartByParticle, public AlignedBoxPart
 {
   public:
-    AlignedBoxPartByParticle(RealBody &real_body, const AlignedBox &aligned_box);
-    virtual ~AlignedBoxPartByParticle() {};
+    AlignedBoxByParticle(RealBody &real_body, const AlignedBox &aligned_box);
+    virtual ~AlignedBoxByParticle() {};
 
   protected:
     bool tagByContain(size_t particle_index);
 };
 
-class AlignedBoxPartByCell : public BodyPartByCell, public AlignedBoxPart
+class AlignedBoxByCell : public BodyPartByCell, public AlignedBoxPart
 {
   public:
-    AlignedBoxPartByCell(RealBody &real_body, const AlignedBox &aligned_box);
-    virtual ~AlignedBoxPartByCell() {};
+    AlignedBoxByCell(RealBody &real_body, const AlignedBox &aligned_box);
+    virtual ~AlignedBoxByCell() {};
 
   protected:
     bool checkNotFar(Vecd cell_position, Real threshold);

--- a/src/shared/bodies/complex_bodies/tree_body.cpp
+++ b/src/shared/bodies/complex_bodies/tree_body.cpp
@@ -232,7 +232,7 @@ TreeBody::Branch::Branch(size_t parent_id, TreeBody *tree)
 }
 //=================================================================================================//
 TreeTerminates::TreeTerminates(SPHBody &sph_body)
-    : BodyPartByParticle(sph_body, "Leaves"),
+    : BodyPartByParticle(sph_body),
       tree_(DynamicCast<TreeBody>(this, sph_body))
 {
     for (const auto *branch : tree_.branches_)

--- a/src/shared/geometries/geometric_element.cpp
+++ b/src/shared/geometries/geometric_element.cpp
@@ -18,8 +18,8 @@ GeometricBox::GeometricBox(const Vecd &halfsize) : halfsize_(halfsize)
 //=================================================================================================//
 Vecd GeometricBox::findClosestPoint(const Vecd &probe_point)
 {
-    //This is from Simbody, Geo_Box.h
-    // first step to find the closest point for the point outside the box
+    // This is from Simbody, Geo_Box.h
+    //  first step to find the closest point for the point outside the box
     Vecd c(probe_point); // tentatively inside
     bool ptWasInside = true;
     for (int i = 0; i < Dimensions; ++i)
@@ -38,7 +38,7 @@ Vecd GeometricBox::findClosestPoint(const Vecd &probe_point)
 
     // second step to find the closest point for the point inside the box
     if (ptWasInside)
-    {                                              
+    {
         Real dToSide = halfsize_[0] - std::abs(c[0]);
 
         int which = 0; // tentatively the nearest side
@@ -56,6 +56,11 @@ Vecd GeometricBox::findClosestPoint(const Vecd &probe_point)
         c[which] = c[which] < 0 ? -halfsize_[which] : halfsize_[which];
     }
     return c;
+}
+//=================================================================================================//
+BoundingBox GeometricBox::findBounds()
+{
+    return BoundingBox(-halfsize_, halfsize_);
 }
 //=================================================================================================//
 GeometricBall::GeometricBall(Real radius) : radius_(radius)
@@ -76,6 +81,12 @@ bool GeometricBall::checkContain(const Vecd &probe_point)
 Vecd GeometricBall::findClosestPoint(const Vecd &probe_point)
 {
     return radius_ * probe_point.normalized();
+}
+//=================================================================================================//
+BoundingBox GeometricBall::findBounds()
+{
+    Vecd shift = radius_ * Vecd::Ones();
+    return BoundingBox(-shift, shift);
 }
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/geometries/geometric_element.h
+++ b/src/shared/geometries/geometric_element.h
@@ -53,8 +53,9 @@ class GeometricBox
         }
         return is_contained;
     };
-    
+
     Vecd findClosestPoint(const Vecd &probe_point);
+    BoundingBox findBounds();
 
   protected:
     Vecd halfsize_;
@@ -68,6 +69,7 @@ class GeometricBall
 
     bool checkContain(const Vecd &probe_point);
     Vecd findClosestPoint(const Vecd &probe_point);
+    BoundingBox findBounds();
 
   protected:
     Real radius_;

--- a/src/shared/geometries/geometric_shape.cpp
+++ b/src/shared/geometries/geometric_shape.cpp
@@ -3,27 +3,26 @@
 namespace SPH
 {
 //=================================================================================================//
-GeometricShapeBox::GeometricShapeBox(const Vecd &halfsize, const std::string &shape_name)
-    : GeometricBox(halfsize), Shape(shape_name) {}
+GeometricShapeBox::GeometricShapeBox(
+    const Transform &transform, const Vecd &halfsize, const std::string &name)
+    : TransformShape<GeometricBox>(name, transform, halfsize) {}
 //=================================================================================================//
-bool GeometricShapeBox::checkContain(const Vecd &probe_point, bool BOUNDARY_INCLUDED)
-{
-    return GeometricBox::checkContain(probe_point);
-}
+GeometricShapeBox::GeometricShapeBox(const BoundingBox &bounding_box, const std::string &name)
+    : TransformShape<GeometricBox>(
+          name,
+          Transform(0.5 * (bounding_box.first_ + bounding_box.second_)),
+          0.5 * (bounding_box.second_ - bounding_box.first_)) {}
 //=================================================================================================//
-Vecd GeometricShapeBox::findClosestPoint(const Vecd &probe_point)
-{
-    return GeometricBox::findClosestPoint(probe_point);
-}
-//=================================================================================================//
-BoundingBox GeometricShapeBox::findBounds()
-{
-    return BoundingBox(-halfsize_, halfsize_);
-}
+GeometricShapeBox::GeometricShapeBox(
+    const Vecd &lower_bound, const Vecd &upper_bound, const std::string &name)
+    : TransformShape<GeometricBox>(
+          name,
+          Transform(0.5 * (lower_bound + upper_bound)),
+          0.5 * (upper_bound - lower_bound)) {}
 //=================================================================================================//
 GeometricShapeBall::GeometricShapeBall(const Vecd &center, Real radius,
-                                       const std::string &shape_name)
-    : GeometricBall(radius), Shape(shape_name), center_(center) {}
+                                       const std::string &name)
+    : GeometricBall(radius), Shape(name), center_(center) {}
 //=================================================================================================//
 bool GeometricShapeBall::checkContain(const Vecd &probe_point, bool BOUNDARY_INCLUDED)
 {

--- a/src/shared/geometries/geometric_shape.h
+++ b/src/shared/geometries/geometric_shape.h
@@ -31,21 +31,20 @@
 
 #include "base_geometry.h"
 #include "geometric_element.h"
+#include "transform_geometry.h"
 
 namespace SPH
 {
-class GeometricShapeBox : public GeometricBox, public Shape
+class GeometricShapeBox : public TransformShape<GeometricBox>
 {
   public:
-    explicit GeometricShapeBox(const Vecd &halfsize,
-                               const std::string &shape_name = "GeometricShapeBox");
-    virtual ~GeometricShapeBox(){};
-
-    virtual bool checkContain(const Vecd &probe_point, bool BOUNDARY_INCLUDED = true) override;
-    virtual Vecd findClosestPoint(const Vecd &probe_point) override;
-
-  protected:
-    virtual BoundingBox findBounds() override;
+    GeometricShapeBox(const Transform &transform, const Vecd &halfsize,
+                      const std::string &name = "GeometricShapeBox");
+    explicit GeometricShapeBox(const BoundingBox &bounding_box,
+                               const std::string &name = "GeometricShapeBox");
+    GeometricShapeBox(const Vecd &lower_bound, const Vecd &upper_bound,
+                      const std::string &name = "GeometricShapeBox");
+    virtual ~GeometricShapeBox() {};
 };
 
 class GeometricShapeBall : public GeometricBall, public Shape
@@ -54,8 +53,8 @@ class GeometricShapeBall : public GeometricBall, public Shape
 
   public:
     explicit GeometricShapeBall(const Vecd &center, Real radius,
-                                const std::string &shape_name = "GeometricShapeBall");
-    virtual ~GeometricShapeBall(){};
+                                const std::string &name = "GeometricShapeBall");
+    virtual ~GeometricShapeBall() {};
 
     virtual bool checkContain(const Vecd &probe_point, bool BOUNDARY_INCLUDED = true) override;
     virtual Vecd findClosestPoint(const Vecd &probe_point) override;

--- a/src/shared/geometries/transform_geometry.h
+++ b/src/shared/geometries/transform_geometry.h
@@ -71,25 +71,26 @@ class TransformGeometry : public GeometryType
  * before or/and after access the interface functions.
  * Note that this is more suitable to apply for simple geometric shapes.
  */
-template <class ShapeType>
-class TransformShape : public TransformGeometry<ShapeType>
+template <class GeometryType>
+class TransformShape : public TransformGeometry<GeometryType>, public Shape
 {
 
   public:
     /** template constructor for general shapes. */
     template <typename... Args>
-    explicit TransformShape(const Transform &transform, Args &&...args)
-        : TransformGeometry<ShapeType>(transform, std::forward<Args>(args)...){};
+    explicit TransformShape(const std::string &name, const Transform &transform, Args &&...args)
+        : TransformGeometry<GeometryType>(transform, std::forward<Args>(args)...),
+          Shape(name){};
     virtual ~TransformShape() {};
 
     virtual bool checkContain(const Vecd &probe_point, bool BOUNDARY_INCLUDED = true) override
     {
-        return TransformGeometry<ShapeType>::checkContain(probe_point);
+        return TransformGeometry<GeometryType>::checkContain(probe_point);
     };
 
     virtual Vecd findClosestPoint(const Vecd &probe_point) override
     {
-        return TransformGeometry<ShapeType>::findClosestPoint(probe_point);
+        return TransformGeometry<GeometryType>::findClosestPoint(probe_point);
     };
 
   protected:
@@ -98,7 +99,7 @@ class TransformShape : public TransformGeometry<ShapeType>
     // But at least it encloses the underlying shape fully
     virtual BoundingBox findBounds() override
     {
-        BoundingBox original_bound = TransformGeometry<ShapeType>::findBounds();
+        BoundingBox original_bound = TransformGeometry<GeometryType>::findBounds();
         Vecd bb_min = Vecd::Constant(MaxReal);
         Vecd bb_max = Vecd::Constant(-MaxReal);
         for (auto x : {original_bound.first_.x(), original_bound.second_.x()})

--- a/src/shared/meshes/cell_linked_list.h
+++ b/src/shared/meshes/cell_linked_list.h
@@ -82,8 +82,8 @@ class BaseCellLinkedList : public BaseMeshField
     void searchNeighborsByMesh(Mesh &mesh, UnsignedInt mesh_offset,
                                DynamicsRange &dynamics_range, ParticleConfiguration &particle_configuration,
                                GetSearchDepth &get_search_depth, GetNeighborRelation &get_neighbor_relation);
-    DiscreteVariable<UnsignedInt> *getParticleIndex() { return dv_particle_index_; };
-    DiscreteVariable<UnsignedInt> *getCellOffset() { return dv_cell_offset_; };
+    DiscreteVariable<UnsignedInt> *dvParticleIndex() { return dv_particle_index_; };
+    DiscreteVariable<UnsignedInt> *dvCellOffset() { return dv_cell_offset_; };
 
     UnsignedInt TotalNumberOfCells() { return total_number_of_cells_; };
     template <typename DataType>

--- a/src/shared/meshes/cell_linked_list.hpp
+++ b/src/shared/meshes/cell_linked_list.hpp
@@ -186,8 +186,8 @@ DiscreteVariable<DataType> *BaseCellLinkedList::registerDiscreteVariableOnly(
 template <class ExecutionPolicy>
 NeighborSearch::NeighborSearch(const ExecutionPolicy &ex_policy, CellLinkedList &cell_linked_list)
     : Mesh(cell_linked_list.getMesh()),
-      particle_index_(cell_linked_list.getParticleIndex()->DelegatedData(ex_policy)),
-      cell_offset_(cell_linked_list.getCellOffset()->DelegatedData(ex_policy)) {}
+      particle_index_(cell_linked_list.dvParticleIndex()->DelegatedData(ex_policy)),
+      cell_offset_(cell_linked_list.dvCellOffset()->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <typename FunctionOnEach>
 void NeighborSearch::forEachSearch(UnsignedInt source_index, const Vecd *source_pos,

--- a/src/shared/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary.cpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary.cpp
@@ -10,10 +10,10 @@ BaseFlowBoundaryCondition::BaseFlowBoundaryCondition(BodyPartByCell &body_part)
       rho_(particles_->getVariableDataByName<Real>("Density")),
       p_(particles_->getVariableDataByName<Real>("Pressure")),
       pos_(particles_->getVariableDataByName<Vecd>("Position")),
-      vel_(particles_->getVariableDataByName<Vecd>("Velocity")){};
+      vel_(particles_->getVariableDataByName<Vecd>("Velocity")) {};
 //=================================================================================================//
 FlowVelocityBuffer::FlowVelocityBuffer(BodyPartByCell &body_part, Real relaxation_rate)
-    : BaseFlowBoundaryCondition(body_part), relaxation_rate_(relaxation_rate){};
+    : BaseFlowBoundaryCondition(body_part), relaxation_rate_(relaxation_rate) {};
 //=================================================================================================//
 void FlowVelocityBuffer::update(size_t index_i, Real dt)
 {
@@ -22,7 +22,7 @@ void FlowVelocityBuffer::update(size_t index_i, Real dt)
 //=================================================================================================//
 DampingBoundaryCondition::DampingBoundaryCondition(BodyRegionByCell &body_part)
     : BaseFlowBoundaryCondition(body_part), strength_(5.0),
-      damping_zone_bounds_(body_part.getBodyPartShape().getBounds()){};
+      damping_zone_bounds_(body_part.getBodyPartShape().getBounds()) {};
 //=================================================================================================//
 void DampingBoundaryCondition::update(size_t index_i, Real dt)
 {
@@ -32,7 +32,7 @@ void DampingBoundaryCondition::update(size_t index_i, Real dt)
 }
 //=================================================================================================//
 EmitterInflowCondition::
-    EmitterInflowCondition(AlignedBoxPartByParticle &aligned_box_part)
+    EmitterInflowCondition(AlignedBoxByParticle &aligned_box_part)
     : BaseLocalDynamics<BodyPartByParticle>(aligned_box_part),
       fluid_(DynamicCast<Fluid>(this, particles_->getBaseMaterial())),
       sorted_id_(particles_->ParticleSortedIds()),
@@ -59,7 +59,7 @@ void EmitterInflowCondition ::update(size_t original_index_i, Real dt)
 }
 //=================================================================================================//
 EmitterInflowInjection::
-    EmitterInflowInjection(AlignedBoxPartByParticle &aligned_box_part, ParticleBuffer<Base> &buffer)
+    EmitterInflowInjection(AlignedBoxByParticle &aligned_box_part, ParticleBuffer<Base> &buffer)
     : BaseLocalDynamics<BodyPartByParticle>(aligned_box_part),
       fluid_(DynamicCast<Fluid>(this, particles_->getBaseMaterial())),
       original_id_(particles_->ParticleOriginalIds()),
@@ -90,7 +90,7 @@ void EmitterInflowInjection::update(size_t original_index_i, Real dt)
 }
 //=================================================================================================//
 DisposerOutflowDeletion::
-    DisposerOutflowDeletion(AlignedBoxPartByCell &aligned_box_part)
+    DisposerOutflowDeletion(AlignedBoxByCell &aligned_box_part)
     : BaseLocalDynamics<BodyPartByCell>(aligned_box_part),
       pos_(particles_->getVariableDataByName<Vecd>("Position")),
       aligned_box_(aligned_box_part.getAlignedBox()) {}

--- a/src/shared/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary.h
@@ -47,7 +47,7 @@ class BaseFlowBoundaryCondition : public BaseLocalDynamics<BodyPartByCell>
 {
   public:
     BaseFlowBoundaryCondition(BodyPartByCell &body_part);
-    virtual ~BaseFlowBoundaryCondition(){};
+    virtual ~BaseFlowBoundaryCondition() {};
 
   protected:
     Real *rho_, *p_;
@@ -64,7 +64,7 @@ class FlowVelocityBuffer : public BaseFlowBoundaryCondition
 {
   public:
     FlowVelocityBuffer(BodyPartByCell &body_part, Real relaxation_rate = 0.3);
-    virtual ~FlowVelocityBuffer(){};
+    virtual ~FlowVelocityBuffer() {};
     void update(size_t index_i, Real dt = 0.0);
 
   protected:
@@ -87,13 +87,13 @@ class InflowVelocityCondition : public BaseFlowBoundaryCondition
 {
   public:
     /** default parameter indicates prescribe velocity */
-    explicit InflowVelocityCondition(AlignedBoxPartByCell &aligned_box_part, Real relaxation_rate = 1.0)
+    explicit InflowVelocityCondition(AlignedBoxByCell &aligned_box_part, Real relaxation_rate = 1.0)
         : BaseFlowBoundaryCondition(aligned_box_part),
           relaxation_rate_(relaxation_rate), aligned_box_(aligned_box_part.getAlignedBox()),
           transform_(aligned_box_.getTransform()), halfsize_(aligned_box_.HalfSize()),
           target_velocity(*this),
-          physical_time_(sph_system_.getSystemVariableDataByName<Real>("PhysicalTime")){};
-    virtual ~InflowVelocityCondition(){};
+          physical_time_(sph_system_.getSystemVariableDataByName<Real>("PhysicalTime")) {};
+    virtual ~InflowVelocityCondition() {};
     AlignedBox &getAlignedBox() { return aligned_box_; };
 
     void update(size_t index_i, Real dt = 0.0)
@@ -144,8 +144,8 @@ class FreeStreamVelocityCorrection : public LocalDynamics
           vel_(particles_->getVariableDataByName<Vecd>("Velocity")),
           indicator_(particles_->getVariableDataByName<int>("Indicator")),
           target_velocity(*this),
-          physical_time_(sph_system_.getSystemVariableDataByName<Real>("PhysicalTime")){};
-    virtual ~FreeStreamVelocityCorrection(){};
+          physical_time_(sph_system_.getSystemVariableDataByName<Real>("PhysicalTime")) {};
+    virtual ~FreeStreamVelocityCorrection() {};
 
     void update(size_t index_i, Real dt = 0.0)
     {
@@ -173,7 +173,7 @@ class DampingBoundaryCondition : public BaseFlowBoundaryCondition
 {
   public:
     explicit DampingBoundaryCondition(BodyRegionByCell &body_part);
-    virtual ~DampingBoundaryCondition(){};
+    virtual ~DampingBoundaryCondition() {};
     void update(size_t index_particle_i, Real dt = 0.0);
 
   protected:
@@ -190,8 +190,8 @@ class DampingBoundaryCondition : public BaseFlowBoundaryCondition
 class EmitterInflowCondition : public BaseLocalDynamics<BodyPartByParticle>
 {
   public:
-    explicit EmitterInflowCondition(AlignedBoxPartByParticle &aligned_box_part);
-    virtual ~EmitterInflowCondition(){};
+    explicit EmitterInflowCondition(AlignedBoxByParticle &aligned_box_part);
+    virtual ~EmitterInflowCondition() {};
 
     virtual void setupDynamics(Real dt = 0.0) override { updateTransform(); };
     void update(size_t original_index_i, Real dt = 0.0);
@@ -208,7 +208,7 @@ class EmitterInflowCondition : public BaseLocalDynamics<BodyPartByParticle>
     Transform &updated_transform_, old_transform_;
 
     /** no transform by default */
-    virtual void updateTransform(){};
+    virtual void updateTransform() {};
     virtual Vecd getTargetVelocity(Vecd &position, Vecd &velocity) = 0;
 };
 
@@ -221,8 +221,8 @@ class EmitterInflowCondition : public BaseLocalDynamics<BodyPartByParticle>
 class EmitterInflowInjection : public BaseLocalDynamics<BodyPartByParticle>
 {
   public:
-    EmitterInflowInjection(AlignedBoxPartByParticle &aligned_box_part, ParticleBuffer<Base> &buffer);
-    virtual ~EmitterInflowInjection(){};
+    EmitterInflowInjection(AlignedBoxByParticle &aligned_box_part, ParticleBuffer<Base> &buffer);
+    virtual ~EmitterInflowInjection() {};
 
     void update(size_t original_index_i, Real dt = 0.0);
 
@@ -244,8 +244,8 @@ class EmitterInflowInjection : public BaseLocalDynamics<BodyPartByParticle>
 class DisposerOutflowDeletion : public BaseLocalDynamics<BodyPartByCell>
 {
   public:
-    DisposerOutflowDeletion(AlignedBoxPartByCell &aligned_box_part);
-    virtual ~DisposerOutflowDeletion(){};
+    DisposerOutflowDeletion(AlignedBoxByCell &aligned_box_part);
+    virtual ~DisposerOutflowDeletion() {};
 
     void update(size_t index_i, Real dt = 0.0);
 

--- a/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.h
@@ -129,7 +129,7 @@ class ParticleSortCK : public LocalDynamics, public BaseDynamics<void>
         void update(UnsignedInt index_i);
 
       protected:
-        UnsignedInt *index_list_, *original_id_list_;
+        UnsignedInt *particle_list_, *original_id_list_;
         UnsignedInt *sorted_id_;
     };
 
@@ -149,7 +149,7 @@ class ParticleSortCK : public LocalDynamics, public BaseDynamics<void>
     Implementation<ExecutionPolicy, LocalDynamicsType, ComputingKernel> kernel_implementation_;
 
     StdVec<BodyPartByParticle *> body_parts_by_particle_;
-    StdVec<DiscreteVariable<UnsignedInt> *> dv_index_lists_, dv_original_id_lists_;
+    StdVec<DiscreteVariable<UnsignedInt> *> dv_particle_lists_, dv_original_id_lists_;
     using UpdateBodyPartParticleImplementation =
         Implementation<ExecutionPolicy, LocalDynamicsType, UpdateBodyPartByParticle>;
     UniquePtrsKeeper<UpdateBodyPartParticleImplementation> update_body_part_by_particle_implementation_ptrs_;

--- a/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.hpp
@@ -67,11 +67,12 @@ ParticleSortCK<ExecutionPolicy>::ParticleSortCK(RealBody &real_body)
     body_parts_by_particle_ = real_body.getBodyPartsByParticle();
     for (size_t i = 0; i != body_parts_by_particle_.size(); ++i)
     {
-        DiscreteVariable<UnsignedInt> *dv_index_list = body_parts_by_particle_[i]->dvIndexList();
-        dv_index_lists_.push_back(dv_index_list);
+        DiscreteVariable<UnsignedInt> *dv_particle_list =
+            body_parts_by_particle_[i]->dvParticleList();
+        dv_particle_lists_.push_back(dv_particle_list);
         DiscreteVariable<UnsignedInt> *original_id_list =
             particles_->addUniqueDiscreteVariableFrom<UnsignedInt>(
-                dv_index_list->Name() + "Initial", dv_index_list);
+                dv_particle_list->Name() + "Initial", dv_particle_list);
         dv_original_id_lists_.push_back(original_id_list);
     }
 
@@ -80,7 +81,8 @@ ParticleSortCK<ExecutionPolicy>::ParticleSortCK(RealBody &real_body)
         UpdateBodyPartParticleImplementation *update_body_part_by_particle_implementation =
             update_body_part_by_particle_implementation_ptrs_
                 .template createPtr<UpdateBodyPartParticleImplementation>(*this);
-        update_body_part_by_particle_implementations_.push_back(update_body_part_by_particle_implementation);
+        update_body_part_by_particle_implementations_.push_back(
+            update_body_part_by_particle_implementation);
     }
 }
 //=================================================================================================//
@@ -143,7 +145,7 @@ template <class EncloserType>
 ParticleSortCK<ExecutionPolicy>::UpdateBodyPartByParticle::
     UpdateBodyPartByParticle(const ExecutionPolicy &ex_policy,
                              EncloserType &encloser, UnsignedInt body_part_i)
-    : index_list_(encloser.dv_index_lists_[body_part_i]->DelegatedData(ex_policy)),
+    : particle_list_(encloser.dv_particle_lists_[body_part_i]->DelegatedData(ex_policy)),
       original_id_list_(encloser.dv_original_id_lists_[body_part_i]->DelegatedData(ex_policy)),
       sorted_id_(encloser.dv_sorted_id_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
@@ -151,7 +153,7 @@ template <class ExecutionPolicy>
 void ParticleSortCK<ExecutionPolicy>::UpdateBodyPartByParticle::
     update(UnsignedInt index_i)
 {
-    index_list_[index_i] = sorted_id_[original_id_list_[index_i]];
+    particle_list_[index_i] = sorted_id_[original_id_list_[index_i]];
 }
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/shared_ck/particle_dynamics/configuration_dynamics/update_cell_linked_list.hpp
+++ b/src/shared/shared_ck/particle_dynamics/configuration_dynamics/update_cell_linked_list.hpp
@@ -18,8 +18,8 @@ UpdateCellLinkedList<ExecutionPolicy, CellLinkedListType>::UpdateCellLinkedList(
       mesh_(cell_linked_list_.getMesh()),
       cell_offset_list_size_(cell_linked_list_.getCellOffsetListSize()),
       dv_pos_(particles_->getVariableByName<Vecd>("Position")),
-      dv_particle_index_(cell_linked_list_.getParticleIndex()),
-      dv_cell_offset_(cell_linked_list_.getCellOffset()),
+      dv_particle_index_(cell_linked_list_.dvParticleIndex()),
+      dv_cell_offset_(cell_linked_list_.dvCellOffset()),
       dv_current_cell_size_(DiscreteVariable<UnsignedInt>("CurrentCellSize", cell_offset_list_size_)),
       ex_policy_(ExecutionPolicy{}), kernel_implementation_(*this) {}
 //=================================================================================================//

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.cpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.cpp
@@ -5,8 +5,8 @@ namespace SPH
 namespace fluid_dynamics
 {
 //=================================================================================================//
-BufferIndicationCK::BufferIndicationCK(AlignedBoxPartByCell &aligned_box_part)
-    : BaseLocalDynamics<AlignedBoxPartByCell>(aligned_box_part),
+BufferIndicationCK::BufferIndicationCK(AlignedBoxByCell &aligned_box_part)
+    : BaseLocalDynamics<AlignedBoxByCell>(aligned_box_part),
       part_id_(aligned_box_part.getPartID()),
       sv_aligned_box_(aligned_box_part.svAlignedBox()),
       dv_pos_(particles_->getVariableByName<Vecd>("Position")),
@@ -15,8 +15,8 @@ BufferIndicationCK::BufferIndicationCK(AlignedBoxPartByCell &aligned_box_part)
     particles_->addEvolvingVariable<int>("BufferIndicator");
 }
 //=================================================================================================//
-BufferOutflowDeletionCK::BufferOutflowDeletionCK(AlignedBoxPartByCell &aligned_box_part)
-    : BaseLocalDynamics<AlignedBoxPartByCell>(aligned_box_part),
+BufferOutflowDeletionCK::BufferOutflowDeletionCK(AlignedBoxByCell &aligned_box_part)
+    : BaseLocalDynamics<AlignedBoxByCell>(aligned_box_part),
       part_id_(aligned_box_part.getPartID()),
       sv_aligned_box_(aligned_box_part.svAlignedBox()),
       sv_total_real_particles_(particles_->svTotalRealParticles()),

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.h
@@ -40,11 +40,11 @@ namespace SPH
 {
 namespace fluid_dynamics
 {
-class BufferIndicationCK : public BaseLocalDynamics<AlignedBoxPartByCell>
+class BufferIndicationCK : public BaseLocalDynamics<AlignedBoxByCell>
 {
 
   public:
-    BufferIndicationCK(AlignedBoxPartByCell &aligned_box_part);
+    BufferIndicationCK(AlignedBoxByCell &aligned_box_part);
     virtual ~BufferIndicationCK() {};
 
     class UpdateKernel
@@ -69,7 +69,7 @@ class BufferIndicationCK : public BaseLocalDynamics<AlignedBoxPartByCell>
 };
 
 template <class ConditionType>
-class BufferInflowInjectionCK : public BaseLocalDynamics<AlignedBoxPartByCell>
+class BufferInflowInjectionCK : public BaseLocalDynamics<AlignedBoxByCell>
 {
     using SpawnRealParticleKernel = typename SpawnRealParticle::ComputingKernel;
     using FluidType = typename ConditionType::Fluid;
@@ -77,7 +77,7 @@ class BufferInflowInjectionCK : public BaseLocalDynamics<AlignedBoxPartByCell>
 
   public:
     template <typename... Args>
-    BufferInflowInjectionCK(AlignedBoxPartByCell &aligned_box_part,
+    BufferInflowInjectionCK(AlignedBoxByCell &aligned_box_part,
                             ParticleBuffer<Base> &buffer, Args &&...args);
     virtual ~BufferInflowInjectionCK() {};
 
@@ -129,12 +129,12 @@ class BufferInflowInjectionCK : public BaseLocalDynamics<AlignedBoxPartByCell>
     Real upper_bound_fringe_;
 };
 
-class BufferOutflowDeletionCK : public BaseLocalDynamics<AlignedBoxPartByCell>
+class BufferOutflowDeletionCK : public BaseLocalDynamics<AlignedBoxByCell>
 {
     using RemoveRealParticleKernel = typename RemoveRealParticle::ComputingKernel;
 
   public:
-    BufferOutflowDeletionCK(AlignedBoxPartByCell &aligned_box_part);
+    BufferOutflowDeletionCK(AlignedBoxByCell &aligned_box_part);
     virtual ~BufferOutflowDeletionCK() {};
 
     class UpdateKernel
@@ -177,14 +177,14 @@ class BufferOutflowDeletionCK : public BaseLocalDynamics<AlignedBoxPartByCell>
 };
 
 template <class KernelCorrectionType, typename ConditionType>
-class PressureVelocityCondition : public BaseLocalDynamics<AlignedBoxPartByCell>,
+class PressureVelocityCondition : public BaseLocalDynamics<AlignedBoxByCell>,
                                   public BaseStateCondition
 {
     using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
 
   public:
     template <typename... Args>
-    PressureVelocityCondition(AlignedBoxPartByCell &aligned_box_part, Args &&...args);
+    PressureVelocityCondition(AlignedBoxByCell &aligned_box_part, Args &&...args);
 
     class UpdateKernel : public BaseStateCondition::ComputingKernel
     {
@@ -221,7 +221,7 @@ class BidirectionalBoundaryCK
 
   public:
     template <typename... Args>
-    BidirectionalBoundaryCK(AlignedBoxPartByCell &aligned_box_part,
+    BidirectionalBoundaryCK(AlignedBoxByCell &aligned_box_part,
                             ParticleBuffer<Base> &particle_buffer, Args &&...args);
     void tagBufferParticles() { tag_buffer_particles_.exec(); }
     void applyBoundaryCondition(Real dt) { boundary_condition_.exec(dt); }

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.hpp
@@ -27,9 +27,9 @@ void BufferIndicationCK::UpdateKernel::update(size_t index_i, Real dt)
 template <class ConditionType>
 template <typename... Args>
 BufferInflowInjectionCK<ConditionType>::
-    BufferInflowInjectionCK(AlignedBoxPartByCell &aligned_box_part,
+    BufferInflowInjectionCK(AlignedBoxByCell &aligned_box_part,
                             ParticleBuffer<Base> &buffer, Args &&...args)
-    : BaseLocalDynamics<AlignedBoxPartByCell>(aligned_box_part),
+    : BaseLocalDynamics<AlignedBoxByCell>(aligned_box_part),
       part_id_(aligned_box_part.getPartID()), buffer_(buffer),
       fluid_(DynamicCast<FluidType>(this, sph_body_.getBaseMaterial())),
       condition_(std::forward<Args>(args)...),
@@ -103,8 +103,8 @@ void BufferOutflowDeletionCK::UpdateKernel::update(size_t index_i, Real dt)
 template <class KernelCorrectionType, typename ConditionType>
 template <typename... Args>
 PressureVelocityCondition<KernelCorrectionType, ConditionType>::
-    PressureVelocityCondition(AlignedBoxPartByCell &aligned_box_part, Args &&...args)
-    : BaseLocalDynamics<AlignedBoxPartByCell>(aligned_box_part),
+    PressureVelocityCondition(AlignedBoxByCell &aligned_box_part, Args &&...args)
+    : BaseLocalDynamics<AlignedBoxByCell>(aligned_box_part),
       BaseStateCondition(this->particles_),
       sv_aligned_box_(aligned_box_part.svAlignedBox()),
       kernel_correction_method_(this->particles_),
@@ -145,7 +145,7 @@ void PressureVelocityCondition<KernelCorrectionType, ConditionType>::
 template <typename ExecutionPolicy, class KernelCorrectionType, class ConditionType>
 template <typename... Args>
 BidirectionalBoundaryCK<ExecutionPolicy, KernelCorrectionType, ConditionType>::
-    BidirectionalBoundaryCK(AlignedBoxPartByCell &aligned_box_part,
+    BidirectionalBoundaryCK(AlignedBoxByCell &aligned_box_part,
                             ParticleBuffer<Base> &particle_buffer, Args &&...args)
     : tag_buffer_particles_(aligned_box_part),
       boundary_condition_(aligned_box_part, std::forward<Args>(args)...),

--- a/src/shared/shared_ck/particle_dynamics/loop_range.h
+++ b/src/shared/shared_ck/particle_dynamics/loop_range.h
@@ -61,16 +61,19 @@ class LoopRangeCK<ExecutionPolicy, BodyPartByParticle>
 {
   public:
     LoopRangeCK(BodyPartByParticle &body_part)
-        : index_list_(body_part.dvIndexList()->DelegatedData(ExecutionPolicy{})),
+        : particle_list_(body_part.dvParticleList()->DelegatedData(ExecutionPolicy{})),
           loop_bound_(body_part.svRangeSize()->DelegatedData(ExecutionPolicy{})) {};
     template <class UnaryFunc>
-    void computeUnit(const UnaryFunc &f, UnsignedInt i) const { f(index_list_[i]); };
+    void computeUnit(const UnaryFunc &f, UnsignedInt i) const { f(particle_list_[i]); };
     template <class ReturnType, class BinaryFunc, class UnaryFunc>
-    ReturnType computeUnit(ReturnType temp, const BinaryFunc &bf, const UnaryFunc &uf, UnsignedInt i) const { return uf(index_list_[i]); };
+    ReturnType computeUnit(ReturnType temp, const BinaryFunc &bf, const UnaryFunc &uf, UnsignedInt i) const
+    {
+        return uf(particle_list_[i]);
+    };
     UnsignedInt LoopBound() const { return *loop_bound_; };
 
   protected:
-    UnsignedInt *index_list_;
+    UnsignedInt *particle_list_;
     UnsignedInt *loop_bound_;
 };
 
@@ -79,14 +82,14 @@ class LoopRangeCK<ExecutionPolicy, BodyPartByCell>
 {
   public:
     LoopRangeCK(BodyPartByCell &body_part)
-        : index_list_(body_part.dvIndexList()->DelegatedData(ExecutionPolicy{})),
+        : cell_list_(body_part.dvCellList()->DelegatedData(ExecutionPolicy{})),
           loop_bound_(body_part.svRangeSize()->DelegatedData(ExecutionPolicy{})),
           particle_index_(body_part.getParticleIndex()->DelegatedData(ExecutionPolicy{})),
           cell_offset_(body_part.getCellOffset()->DelegatedData(ExecutionPolicy{})) {};
     template <class UnaryFunc>
     void computeUnit(const UnaryFunc &uf, UnsignedInt i) const
     {
-        UnsignedInt cell_index = index_list_[i];
+        UnsignedInt cell_index = cell_list_[i];
         for (size_t k = cell_offset_[cell_index]; k != cell_offset_[cell_index + 1]; ++k)
         {
             uf(particle_index_[k]);
@@ -96,7 +99,7 @@ class LoopRangeCK<ExecutionPolicy, BodyPartByCell>
     template <class ReturnType, class BinaryFunc, class UnaryFunc>
     ReturnType computeUnit(ReturnType temp, const BinaryFunc &bf, const UnaryFunc &uf, UnsignedInt i) const
     {
-        UnsignedInt cell_index = index_list_[i];
+        UnsignedInt cell_index = cell_list_[i];
         for (size_t k = cell_offset_[cell_index]; k != cell_offset_[cell_index + 1]; ++k)
         {
             temp = bf(temp, uf(particle_index_[k]));
@@ -106,7 +109,7 @@ class LoopRangeCK<ExecutionPolicy, BodyPartByCell>
     UnsignedInt LoopBound() const { return *loop_bound_; };
 
   protected:
-    UnsignedInt *index_list_;
+    UnsignedInt *cell_list_;
     UnsignedInt *loop_bound_;
     UnsignedInt *particle_index_;
     UnsignedInt *cell_offset_;

--- a/src/shared/shared_ck/particle_dynamics/loop_range.h
+++ b/src/shared/shared_ck/particle_dynamics/loop_range.h
@@ -84,8 +84,8 @@ class LoopRangeCK<ExecutionPolicy, BodyPartByCell>
     LoopRangeCK(BodyPartByCell &body_part)
         : cell_list_(body_part.dvCellList()->DelegatedData(ExecutionPolicy{})),
           loop_bound_(body_part.svRangeSize()->DelegatedData(ExecutionPolicy{})),
-          particle_index_(body_part.getParticleIndex()->DelegatedData(ExecutionPolicy{})),
-          cell_offset_(body_part.getCellOffset()->DelegatedData(ExecutionPolicy{})) {};
+          particle_index_(body_part.dvParticleIndex()->DelegatedData(ExecutionPolicy{})),
+          cell_offset_(body_part.dvCellOffset()->DelegatedData(ExecutionPolicy{})) {};
     template <class UnaryFunc>
     void computeUnit(const UnaryFunc &uf, UnsignedInt i) const
     {

--- a/tests/2d_examples/2d_examples_ck/test_2d_column_collapse_ck/collumn_colapse_ck.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_column_collapse_ck/collumn_colapse_ck.cpp
@@ -44,8 +44,8 @@ class WallBoundary : public ComplexShape
   public:
     explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 std::vector<Vecd> soil_shape{
@@ -72,7 +72,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating bodies with corresponding materials and particles.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox> initial_soil_block(Transform(soil_block_translation), soil_block_halfsize, "GranularBody");
+    GeometricShapeBox initial_soil_block(Transform(soil_block_translation), soil_block_halfsize, "GranularBody");
     RealBody soil_block(sph_system, initial_soil_block);
     soil_block.defineMaterial<PlasticContinuum>(rho0_s, c_s, Youngs_modulus, poisson, friction_angle);
     soil_block.generateParticles<BaseParticles, Lattice>();

--- a/tests/2d_examples/2d_examples_ck/test_2d_dambreak_ck/dambreak_ck.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_dambreak_ck/dambreak_ck.cpp
@@ -39,8 +39,8 @@ class WallBoundary : public ComplexShape
   public:
     explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 //----------------------------------------------------------------------
@@ -57,7 +57,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating bodies with corresponding materials and particles.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox> initial_water_block(Transform(water_block_translation), water_block_halfsize, "WaterBody");
+    GeometricShapeBox initial_water_block(Transform(water_block_translation), water_block_halfsize, "WaterBody");
     FluidBody water_block(sph_system, initial_water_block);
     water_block.defineMaterial<WeaklyCompressibleFluid>(rho0_f, c_f);
     water_block.generateParticles<BaseParticles, Lattice>();

--- a/tests/2d_examples/2d_examples_ck/test_2d_filling_tank_ck/filling_tank_ck.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_filling_tank_ck/filling_tank_ck.cpp
@@ -100,7 +100,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating body, materials and particles.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox> water_inlet_shape(Transform(inlet_translation), inlet_halfsize);
+    GeometricShapeBox water_inlet_shape(Transform(inlet_translation), inlet_halfsize);
     FluidBody water_body(sph_system, water_inlet_shape, "WaterBody");
     water_body.defineMaterial<WeaklyCompressibleFluid>(rho0_f, c_f);
     ParticleBuffer<ReserveSizeFactor> inlet_buffer(350.0);

--- a/tests/2d_examples/2d_examples_ck/test_2d_filling_tank_ck/filling_tank_ck.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_filling_tank_ck/filling_tank_ck.cpp
@@ -115,7 +115,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating body parts.
     //----------------------------------------------------------------------
-    AlignedBoxPartByParticle emitter(water_body, AlignedBox(xAxis, Transform(inlet_translation), inlet_halfsize));
+    AlignedBoxByParticle emitter(water_body, AlignedBox(xAxis, Transform(inlet_translation), inlet_halfsize));
     //----------------------------------------------------------------------
     //	Define body relation map.
     //	The contact map gives the topological connections between the bodies.
@@ -165,8 +165,8 @@ int main(int ac, char *av[])
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::FreeSurfaceIndicationComplexSpatialTemporalCK>
         fluid_boundary_indicator(water_body_inner, water_wall_contact);
 
-    StateDynamics<MainExecutionPolicy, fluid_dynamics::EmitterInflowConditionCK<AlignedBoxPartByParticle, InletInflowCondition>> inflow_condition(emitter);
-    StateDynamics<MainExecutionPolicy, fluid_dynamics::EmitterInflowInjectionCK<AlignedBoxPartByParticle>> emitter_injection(emitter, inlet_buffer);
+    StateDynamics<MainExecutionPolicy, fluid_dynamics::EmitterInflowConditionCK<AlignedBoxByParticle, InletInflowCondition>> inflow_condition(emitter);
+    StateDynamics<MainExecutionPolicy, fluid_dynamics::EmitterInflowInjectionCK<AlignedBoxByParticle>> emitter_injection(emitter, inlet_buffer);
     //----------------------------------------------------------------------
     //	Define the methods for I/O operations, observations
     //	and regression tests of the simulation.

--- a/tests/2d_examples/2d_examples_ck/test_2d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
@@ -265,8 +265,8 @@ int main(int ac, char *av[])
     // //----------------------------------------------------------------------
     // //	Creating body parts.
     // //----------------------------------------------------------------------
-    AlignedBoxPartByCell left_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(left_bidirectional_translation), bidirectional_buffer_halfsize));
-    AlignedBoxPartByCell right_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(Rotation2d(Pi), Vec2d(right_disposer_translation)), bidirectional_buffer_halfsize));
+    AlignedBoxByCell left_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(left_bidirectional_translation), bidirectional_buffer_halfsize));
+    AlignedBoxByCell right_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(Rotation2d(Pi), Vec2d(right_disposer_translation)), bidirectional_buffer_halfsize));
 
     //----------------------------------------------------------------------
     //	Define body relation map.

--- a/tests/2d_examples/2d_examples_ck/test_2d_stfb_ck/stfb.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_stfb_ck/stfb.cpp
@@ -81,8 +81,8 @@ class WallBoundary : public ComplexShape
   public:
     explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 class WaterBlock : public ComplexShape
@@ -90,8 +90,8 @@ class WaterBlock : public ComplexShape
   public:
     explicit WaterBlock(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(water_block_translation), water_block_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(structure_translation), structure_halfsize);
+        add<GeometricShapeBox>(Transform(water_block_translation), water_block_halfsize);
+        subtract<GeometricShapeBox>(Transform(structure_translation), structure_halfsize);
     }
 };
 //----------------------------------------------------------------------
@@ -122,7 +122,7 @@ int main(int ac, char *av[])
     wall_boundary.defineMaterial<Solid>();
     wall_boundary.generateParticles<BaseParticles, Lattice>();
 
-    TransformShape<GeometricShapeBox> structure_shape(Transform(structure_translation), structure_halfsize, "Structure");
+    GeometricShapeBox structure_shape(Transform(structure_translation), structure_halfsize, "Structure");
     SolidBody structure(sph_system, structure_shape);
     structure.defineMaterial<Solid>(rho_s);
     structure.generateParticles<BaseParticles, Lattice>();
@@ -133,7 +133,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating body parts.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox> wave_probe_buffer_shape(Transform(gauge_translation), gauge_halfsize, "FreeSurfaceGauge");
+    GeometricShapeBox wave_probe_buffer_shape(Transform(gauge_translation), gauge_halfsize, "FreeSurfaceGauge");
     BodyRegionByCell wave_probe_buffer(water_block, wave_probe_buffer_shape);
     //----------------------------------------------------------------------
     //	Define body relation map.

--- a/tests/2d_examples/2d_examples_ck/test_2d_still_water_ck/stlw.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_still_water_ck/stlw.cpp
@@ -46,8 +46,8 @@ class WallBoundary : public ComplexShape
   public:
     explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 
@@ -61,7 +61,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating body, materials and particles.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox> water_body_shape(Transform(water_body_translation), water_body_halfsize, "WaterBody");
+    GeometricShapeBox water_body_shape(Transform(water_body_translation), water_body_halfsize, "WaterBody");
     FluidBody water_body(sph_system, water_body_shape);
     water_body.defineClosure<WeaklyCompressibleFluid, Viscosity>(ConstructArgs(rho0_f, c_f), mu_f);
     water_body.generateParticles<BaseParticles, Lattice>();
@@ -72,7 +72,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating body parts.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox> wave_probe_buffer_shape(Transform(gauge_translation), gauge_halfsize, "FreeSurfaceGauge");
+    GeometricShapeBox wave_probe_buffer_shape(Transform(gauge_translation), gauge_halfsize, "FreeSurfaceGauge");
     BodyRegionByCell wave_probe_buffer(water_body, wave_probe_buffer_shape);
     //----------------------------------------------------------------------
     //	Define body relation map.

--- a/tests/2d_examples/test_2d_T_shaped_pipe/T_shaped_pipe.cpp
+++ b/tests/2d_examples/test_2d_T_shaped_pipe/T_shaped_pipe.cpp
@@ -138,22 +138,22 @@ int main(int ac, char *av[])
 
     Vec2d emitter_halfsize = Vec2d(0.5 * BW, 0.5 * DH);
     Vec2d emitter_translation = Vec2d(-DL_sponge, 0.0) + emitter_halfsize;
-    AlignedBoxPartByParticle emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_translation)), emitter_halfsize));
+    AlignedBoxByParticle emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_translation)), emitter_halfsize));
     SimpleDynamics<fluid_dynamics::EmitterInflowInjection> emitter_inflow_injection(emitter, inlet_particle_buffer);
 
     Vec2d inlet_flow_buffer_halfsize = Vec2d(0.5 * DL_sponge, 0.5 * DH);
     Vec2d inlet_flow_buffer_translation = Vec2d(-DL_sponge, 0.0) + inlet_flow_buffer_halfsize;
-    AlignedBoxPartByCell inlet_flow_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(inlet_flow_buffer_translation)), inlet_flow_buffer_halfsize));
+    AlignedBoxByCell inlet_flow_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(inlet_flow_buffer_translation)), inlet_flow_buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<InflowVelocity>> inflow_condition(inlet_flow_buffer);
     Vec2d disposer_up_halfsize = Vec2d(0.3 * DH, 0.5 * BW);
     Vec2d disposer_up_translation = Vec2d(DL + 0.05 * DH, 2.0 * DH) - disposer_up_halfsize;
-    AlignedBoxPartByCell disposer_up(
+    AlignedBoxByCell disposer_up(
         water_block, AlignedBox(yAxis, Transform(Vec2d(disposer_up_translation)), disposer_up_halfsize));
     SimpleDynamics<fluid_dynamics::DisposerOutflowDeletion> disposer_up_outflow_deletion(disposer_up);
 
     Vec2d disposer_down_halfsize = disposer_up_halfsize;
     Vec2d disposer_down_translation = Vec2d(DL1 - 0.05 * DH, -DH) + disposer_down_halfsize;
-    AlignedBoxPartByCell disposer_down(
+    AlignedBoxByCell disposer_down(
         water_block, AlignedBox(yAxis, Transform(Rotation2d(Pi), Vec2d(disposer_down_translation)), disposer_down_halfsize));
     SimpleDynamics<fluid_dynamics::DisposerOutflowDeletion> disposer_down_outflow_deletion(disposer_down);
     //----------------------------------------------------------------------

--- a/tests/2d_examples/test_2d_channel_flow_fluid_shell/channel_flow_shell.cpp
+++ b/tests/2d_examples/test_2d_channel_flow_fluid_shell/channel_flow_shell.cpp
@@ -50,7 +50,7 @@ class ParticleGenerator<SurfaceParticles, WallBoundary> : public ParticleGenerat
                                Real resolution_ref, Real wall_thickness)
         : ParticleGenerator<SurfaceParticles>(sph_body, surface_particles),
           DL_sponge_(20 * resolution_ref), BW_(4 * resolution_ref),
-          resolution_ref_(resolution_ref), wall_thickness_(wall_thickness){};
+          resolution_ref_(resolution_ref), wall_thickness_(wall_thickness) {};
     void prepareGeometricData() override
     {
         auto particle_number_mid_surface = int((DL + DL_sponge_ + 2 * BW_) / resolution_ref_);
@@ -215,7 +215,7 @@ void channel_flow_shell(const Real resolution_ref, const Real wall_thickness)
     InteractionWithUpdate<fluid_dynamics::TransportVelocityCorrectionComplex<AllParticles>> transport_correction(water_block_inner, water_block_contact);
     InteractionWithUpdate<fluid_dynamics::ViscousForceWithWall> viscous_acceleration(water_block_inner, water_block_contact);
     /** Inflow boundary condition. */
-    AlignedBoxPartByCell inflow_buffer(
+    AlignedBoxByCell inflow_buffer(
         water_block, AlignedBox(xAxis, Transform(Vec2d(buffer_translation)), buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<InflowVelocity>> parabolic_inflow(inflow_buffer);
     /** Periodic BCs in x direction. */

--- a/tests/2d_examples/test_2d_cohesive_soil_failure/cohesive_soil_failure.h
+++ b/tests/2d_examples/test_2d_cohesive_soil_failure/cohesive_soil_failure.h
@@ -44,8 +44,8 @@ class WallBoundary : public ComplexShape
   public:
     explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 std::vector<Vecd> soil_shape{

--- a/tests/2d_examples/test_2d_column_collapse/column_collapse.cpp
+++ b/tests/2d_examples/test_2d_column_collapse/column_collapse.cpp
@@ -43,8 +43,8 @@ class WallBoundary : public ComplexShape
   public:
     explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 std::vector<Vecd> soil_shape{

--- a/tests/2d_examples/test_2d_dambreak/Dambreak.cpp
+++ b/tests/2d_examples/test_2d_dambreak/Dambreak.cpp
@@ -41,8 +41,8 @@ class WallBoundary : public ComplexShape
   public:
     explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 //----------------------------------------------------------------------
@@ -59,7 +59,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating bodies with corresponding materials and particles.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox> initial_water_block(Transform(water_block_translation), water_block_halfsize, "WaterBody");
+    GeometricShapeBox initial_water_block(Transform(water_block_translation), water_block_halfsize, "WaterBody");
     FluidBody water_block(sph_system, initial_water_block);
     water_block.defineMaterial<WeaklyCompressibleFluid>(rho0_f, c_f);
     water_block.generateParticles<BaseParticles, Lattice>();

--- a/tests/2d_examples/test_2d_droplet_impact/2d_droplet_impact.h
+++ b/tests/2d_examples/test_2d_droplet_impact/2d_droplet_impact.h
@@ -57,7 +57,7 @@ class AirBlock : public ComplexShape
 public:
     explicit AirBlock(const std::string& shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(air_translation), air_halfsize);
+        add<GeometricShapeBox>(Transform(air_translation), air_halfsize);
         subtract<GeometricShapeBall>(droplet_center, droplet_radius);
     }
 };
@@ -70,8 +70,8 @@ class WallBoundary : public ComplexShape
 public:
     explicit WallBoundary(const std::string& shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/2d_examples/test_2d_filling_tank/filling_tank.cpp
+++ b/tests/2d_examples/test_2d_filling_tank/filling_tank.cpp
@@ -73,7 +73,7 @@ class WallBoundary : public MultiPolygonShape
 class InletInflowCondition : public fluid_dynamics::EmitterInflowCondition
 {
   public:
-    InletInflowCondition(AlignedBoxPartByParticle &aligned_box_part)
+    InletInflowCondition(AlignedBoxByParticle &aligned_box_part)
         : EmitterInflowCondition(aligned_box_part) {}
 
   protected:
@@ -136,7 +136,7 @@ int main(int ac, char *av[])
     ReduceDynamics<fluid_dynamics::AdvectionTimeStep> get_fluid_advection_time_step_size(water_body, U_f);
     ReduceDynamics<fluid_dynamics::AcousticTimeStep> get_fluid_time_step_size(water_body);
 
-    AlignedBoxPartByParticle emitter(water_body, AlignedBox(xAxis, Transform(inlet_translation), inlet_halfsize));
+    AlignedBoxByParticle emitter(water_body, AlignedBox(xAxis, Transform(inlet_translation), inlet_halfsize));
     SimpleDynamics<InletInflowCondition> inflow_condition(emitter);
     SimpleDynamics<fluid_dynamics::EmitterInflowInjection> emitter_injection(emitter, inlet_buffer);
     //----------------------------------------------------------------------

--- a/tests/2d_examples/test_2d_filling_tank/filling_tank.cpp
+++ b/tests/2d_examples/test_2d_filling_tank/filling_tank.cpp
@@ -93,7 +93,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating body, materials and particles.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox> water_inlet_shape(Transform(inlet_translation), inlet_halfsize);
+    GeometricShapeBox water_inlet_shape(Transform(inlet_translation), inlet_halfsize);
     FluidBody water_body(sph_system, water_inlet_shape, "WaterBody");
     water_body.getSPHAdaptation().resetKernel<KernelTabulated<KernelWendlandC2>>(20);
     water_body.defineMaterial<WeaklyCompressibleFluid>(rho0_f, c_f);

--- a/tests/2d_examples/test_2d_flow_stream_around_fish/2d_flow_stream_around_fish.cpp
+++ b/tests/2d_examples/test_2d_flow_stream_around_fish/2d_flow_stream_around_fish.cpp
@@ -122,13 +122,13 @@ int main(int ac, char *av[])
     ReduceDynamics<fluid_dynamics::AdvectionViscousTimeStep> get_fluid_advection_time_step_size(water_block, U_f);
     ReduceDynamics<fluid_dynamics::AcousticTimeStep> get_fluid_time_step_size(water_block);
 
-    AlignedBoxPartByParticle emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_translation)), emitter_halfsize));
+    AlignedBoxByParticle emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_translation)), emitter_halfsize));
     SimpleDynamics<fluid_dynamics::EmitterInflowInjection> emitter_inflow_injection(emitter, inlet_particle_buffer);
 
-    AlignedBoxPartByCell emitter_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_buffer_translation)), emitter_buffer_halfsize));
+    AlignedBoxByCell emitter_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_buffer_translation)), emitter_buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<FreeStreamVelocity>> emitter_buffer_inflow_condition(emitter_buffer);
 
-    AlignedBoxPartByCell disposer(water_block, AlignedBox(xAxis, Transform(Vec2d(disposer_translation)), disposer_halfsize));
+    AlignedBoxByCell disposer(water_block, AlignedBox(xAxis, Transform(Vec2d(disposer_translation)), disposer_halfsize));
     SimpleDynamics<fluid_dynamics::DisposerOutflowDeletion> disposer_outflow_deletion(disposer);
 
     SimpleDynamics<fluid_dynamics::FreeStreamVelocityCorrection<FreeStreamVelocity>> velocity_boundary_condition_constraint(water_block);

--- a/tests/2d_examples/test_2d_free_stream_around_cylinder/2d_free_stream_around_cylinder.cpp
+++ b/tests/2d_examples/test_2d_free_stream_around_cylinder/2d_free_stream_around_cylinder.cpp
@@ -113,13 +113,13 @@ int main(int ac, char *av[])
     Dynamics1Level<fluid_dynamics::Integration2ndHalfWithWallNoRiemann> density_relaxation(water_block_inner, water_block_contact);
     InteractionWithUpdate<fluid_dynamics::DensitySummationFreeStreamComplex> update_fluid_density(water_block_inner, water_block_contact);
 
-    AlignedBoxPartByParticle emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_translation)), emitter_halfsize));
+    AlignedBoxByParticle emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_translation)), emitter_halfsize));
     SimpleDynamics<fluid_dynamics::EmitterInflowInjection> emitter_inflow_injection(emitter, inlet_particle_buffer);
 
-    AlignedBoxPartByCell emitter_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_buffer_translation)), emitter_buffer_halfsize));
+    AlignedBoxByCell emitter_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_buffer_translation)), emitter_buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<FreeStreamVelocity>> emitter_buffer_inflow_condition(emitter_buffer);
 
-    AlignedBoxPartByCell disposer(water_block, AlignedBox(xAxis, Transform(Vec2d(disposer_translation)), disposer_halfsize));
+    AlignedBoxByCell disposer(water_block, AlignedBox(xAxis, Transform(Vec2d(disposer_translation)), disposer_halfsize));
     SimpleDynamics<fluid_dynamics::DisposerOutflowDeletion> disposer_outflow_deletion(disposer);
 
     ReduceDynamics<fluid_dynamics::AdvectionViscousTimeStep> get_fluid_advection_time_step_size(water_block, U_f);

--- a/tests/2d_examples/test_2d_free_stream_around_cylinder_mr/mr_free_stream_around_cylinder.cpp
+++ b/tests/2d_examples/test_2d_free_stream_around_cylinder_mr/mr_free_stream_around_cylinder.cpp
@@ -123,11 +123,11 @@ int main(int ac, char *av[])
     Dynamics1Level<fluid_dynamics::Integration2ndHalfWithWallNoRiemann> density_relaxation(water_block_inner, water_contact);
     InteractionWithUpdate<fluid_dynamics::DensitySummationFreeStreamComplexAdaptive> update_fluid_density(water_block_inner, water_contact);
 
-    AlignedBoxPartByParticle emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_translation)), emitter_halfsize));
+    AlignedBoxByParticle emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_translation)), emitter_halfsize));
     SimpleDynamics<fluid_dynamics::EmitterInflowInjection> emitter_inflow_injection(emitter, inlet_particle_buffer);
-    AlignedBoxPartByCell emitter_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_buffer_translation)), emitter_buffer_halfsize));
+    AlignedBoxByCell emitter_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(emitter_buffer_translation)), emitter_buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<FreeStreamVelocity>> emitter_buffer_inflow_condition(emitter_buffer, 0.1);
-    AlignedBoxPartByCell disposer(water_block, AlignedBox(xAxis, Transform(Vec2d(disposer_translation)), disposer_halfsize));
+    AlignedBoxByCell disposer(water_block, AlignedBox(xAxis, Transform(Vec2d(disposer_translation)), disposer_halfsize));
     SimpleDynamics<fluid_dynamics::DisposerOutflowDeletion> disposer_outflow_deletion(disposer);
 
     /** Time step size without considering sound wave speed. */

--- a/tests/2d_examples/test_2d_fsi2/fsi2.cpp
+++ b/tests/2d_examples/test_2d_fsi2/fsi2.cpp
@@ -142,7 +142,7 @@ int main(int ac, char *av[])
     ReduceDynamics<fluid_dynamics::AdvectionViscousTimeStep> get_fluid_advection_time_step_size(water_block, U_f);
     ReduceDynamics<fluid_dynamics::AcousticTimeStep> get_fluid_time_step_size(water_block);
 
-    AlignedBoxPartByCell inflow_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(buffer_translation)), buffer_halfsize));
+    AlignedBoxByCell inflow_buffer(water_block, AlignedBox(xAxis, Transform(Vec2d(buffer_translation)), buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<InflowVelocity>> parabolic_inflow(inflow_buffer);
     PeriodicAlongAxis periodic_along_x(water_block.getSPHBodyBounds(), xAxis);
     PeriodicConditionUsingCellLinkedList periodic_condition(water_block, periodic_along_x);

--- a/tests/2d_examples/test_2d_heat_transfer/heat_transfer.cpp
+++ b/tests/2d_examples/test_2d_heat_transfer/heat_transfer.cpp
@@ -241,7 +241,7 @@ int main(int ac, char *av[])
     ReduceDynamics<fluid_dynamics::AcousticTimeStep> get_fluid_time_step(thermofluid_body);
     PeriodicAlongAxis periodic_along_x(thermofluid_body.getSPHBodyBounds(), xAxis);
     PeriodicConditionUsingCellLinkedList periodic_condition(thermofluid_body, periodic_along_x);
-    AlignedBoxPartByCell inflow_buffer(thermofluid_body, AlignedBox(xAxis, Transform(Vec2d(buffer_translation)), buffer_halfsize));
+    AlignedBoxByCell inflow_buffer(thermofluid_body, AlignedBox(xAxis, Transform(Vec2d(buffer_translation)), buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<InflowVelocity>> parabolic_inflow(inflow_buffer);
 
     GetDiffusionTimeStepSize get_thermal_time_step(thermofluid_body);

--- a/tests/2d_examples/test_2d_lid_driven_cavity_non_newtonian/lid_driven_cavity.cpp
+++ b/tests/2d_examples/test_2d_lid_driven_cavity_non_newtonian/lid_driven_cavity.cpp
@@ -42,7 +42,7 @@ class Lid_Boundary : public ComplexShape
         Transform translate_to_origin(scaled_container);
         Vecd transform(-boundary_width, height);
         Transform translate_to_position(transform + scaled_container);
-        add<TransformShape<GeometricShapeBox>>(Transform(translate_to_position), scaled_container);
+        add<GeometricShapeBox>(Transform(translate_to_position), scaled_container);
     }
 };
 class No_Slip_Boundary : public ComplexShape
@@ -55,8 +55,8 @@ class No_Slip_Boundary : public ComplexShape
         Transform translate_to_origin_outer(Vec2d(-boundary_width, -boundary_width) + scaled_container_outer);
         Transform translate_to_origin_inner(scaled_container);
 
-        add<TransformShape<GeometricShapeBox>>(Transform(translate_to_origin_outer), scaled_container_outer);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translate_to_origin_inner), scaled_container);
+        add<GeometricShapeBox>(Transform(translate_to_origin_outer), scaled_container_outer);
+        subtract<GeometricShapeBox>(Transform(translate_to_origin_inner), scaled_container);
     }
 };
 class FluidFilling : public ComplexShape
@@ -66,7 +66,7 @@ class FluidFilling : public ComplexShape
     {
         Vecd scaled_container(0.5 * width, 0.5 * height);
         Transform translate_to_origin(scaled_container);
-        add<TransformShape<GeometricShapeBox>>(Transform(translate_to_origin), scaled_container);
+        add<GeometricShapeBox>(Transform(translate_to_origin), scaled_container);
     }
 };
 

--- a/tests/2d_examples/test_2d_mr_cantilever_beam/test_2d_mr_cantilever_beam.cpp
+++ b/tests/2d_examples/test_2d_mr_cantilever_beam/test_2d_mr_cantilever_beam.cpp
@@ -116,8 +116,7 @@ class Beam : public MultiPolygonShape
 class FixPart : public BodyPartByParticle
 {
   public:
-    FixPart(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    FixPart(SPHBody &body) : BodyPartByParticle(body)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&FixPart::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -238,7 +237,7 @@ return_data beam_multi_resolution(Real dp_factor, bool damping_on, int refinemen
     };
 
     // Boundary conditions
-    FixPart fix_bc_part(beam_body, "ClampingPart");
+    FixPart fix_bc_part(beam_body);
     SimpleDynamics<FixBodyPartConstraint> fix_bc(fix_bc_part);
 
     // gravity

--- a/tests/2d_examples/test_2d_plate/2d_plate.cpp
+++ b/tests/2d_examples/test_2d_plate/2d_plate.cpp
@@ -62,8 +62,7 @@ class ParticleGenerator<SurfaceParticles, Plate> : public ParticleGenerator<Surf
 class BoundaryGeometry : public BodyPartByParticle
 {
   public:
-    BoundaryGeometry(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    BoundaryGeometry(SPHBody &body) : BodyPartByParticle(body)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&BoundaryGeometry::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -118,7 +117,7 @@ int main(int ac, char *av[])
     SimpleDynamics<solid_dynamics::DistributingPointForces>
         apply_point_force(plate_body, point_force, reference_position, time_to_full_external_force, resolution_ref);
     /** Constrain the Boundary. */
-    BoundaryGeometry boundary_geometry(plate_body, "BoundaryGeometry");
+    BoundaryGeometry boundary_geometry(plate_body);
     SimpleDynamics<thin_structure_dynamics::ConstrainShellBodyRegion> constrain_holder(boundary_geometry);
     DampingWithRandomChoice<InteractionSplit<DampingPairwiseInner<Vec2d, FixedDampingRate>>>
         plate_position_damping(0.2, plate_body_inner, "Velocity", physical_viscosity);

--- a/tests/2d_examples/test_2d_shell/2d_shell.cpp
+++ b/tests/2d_examples/test_2d_shell/2d_shell.cpp
@@ -63,8 +63,7 @@ class ParticleGenerator<SurfaceParticles, Cylinder> : public ParticleGenerator<S
 class BoundaryGeometry : public BodyPartByParticle
 {
   public:
-    BoundaryGeometry(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    BoundaryGeometry(SPHBody &body) : BodyPartByParticle(body)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&BoundaryGeometry::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -114,7 +113,7 @@ int main(int ac, char *av[])
     Dynamics1Level<thin_structure_dynamics::ShellStressRelaxationSecondHalf> stress_relaxation_second_half(cylinder_body_inner);
 
     ReduceDynamics<thin_structure_dynamics::ShellAcousticTimeStepSize> computing_time_step_size(cylinder_body);
-    BoundaryGeometry boundary_geometry(cylinder_body, "BoundaryGeometry");
+    BoundaryGeometry boundary_geometry(cylinder_body);
     SimpleDynamics<thin_structure_dynamics::ConstrainShellBodyRegion> fixed_free_rotate_shell_boundary(boundary_geometry);
     DampingWithRandomChoice<InteractionSplit<DampingPairwiseInner<Vec2d, FixedDampingRate>>>
         cylinder_position_damping(0.2, cylinder_body_inner, "Velocity", physical_viscosity);

--- a/tests/2d_examples/test_2d_square_droplet/2d_square_droplet.cpp
+++ b/tests/2d_examples/test_2d_square_droplet/2d_square_droplet.cpp
@@ -48,7 +48,7 @@ class WaterBlock : public ComplexShape
   public:
     explicit WaterBlock(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(droplet_translation), droplet_halfsize);
+        add<GeometricShapeBox>(Transform(droplet_translation), droplet_halfsize);
     }
 };
 //----------------------------------------------------------------------
@@ -59,8 +59,8 @@ class AirBlock : public ComplexShape
   public:
     explicit AirBlock(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(air_translation), air_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(droplet_translation), droplet_halfsize);
+        add<GeometricShapeBox>(Transform(air_translation), air_halfsize);
+        subtract<GeometricShapeBox>(Transform(droplet_translation), droplet_halfsize);
     }
 };
 //----------------------------------------------------------------------
@@ -72,8 +72,8 @@ class WallBoundary : public ComplexShape
   public:
     explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(wall_translation), inner_wall_halfsize);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/2d_examples/test_2d_standing_wave/standing_wave.cpp
+++ b/tests/2d_examples/test_2d_standing_wave/standing_wave.cpp
@@ -40,8 +40,8 @@ class WallBoundary : public ComplexShape
   public:
     explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/2d_examples/test_2d_stfb/stfb.cpp
+++ b/tests/2d_examples/test_2d_stfb/stfb.cpp
@@ -26,7 +26,7 @@ int main(int ac, char *av[])
     wall_boundary.defineMaterial<Solid>();
     wall_boundary.generateParticles<BaseParticles, Lattice>();
 
-    TransformShape<GeometricShapeBox> structure_shape(Transform(structure_translation), structure_halfsize, "Structure");
+    GeometricShapeBox structure_shape(Transform(structure_translation), structure_halfsize, "Structure");
     SolidBody structure(sph_system, structure_shape);
     structure.defineMaterial<Solid>(rho_s);
     structure.generateParticles<BaseParticles, Lattice>();
@@ -152,7 +152,7 @@ int main(int ac, char *av[])
     //	Define the methods for I/O operations and observations of the simulation.
     //----------------------------------------------------------------------
     BodyStatesRecordingToVtp write_real_body_states(sph_system);
-    TransformShape<GeometricShapeBox> wave_probe_buffer_shape(Transform(gauge_translation), gauge_halfsize, "FreeSurfaceGauge");
+    GeometricShapeBox wave_probe_buffer_shape(Transform(gauge_translation), gauge_halfsize, "FreeSurfaceGauge");
     BodyRegionByCell wave_probe_buffer(water_block, wave_probe_buffer_shape);
     RegressionTestDynamicTimeWarping<ReducedQuantityRecording<UpperFrontInAxisDirection<BodyPartByCell>>>
         wave_gauge(wave_probe_buffer, "FreeSurfaceHeight");

--- a/tests/2d_examples/test_2d_stfb/stfb.h
+++ b/tests/2d_examples/test_2d_stfb/stfb.h
@@ -84,8 +84,8 @@ class WallBoundary : public ComplexShape
   public:
     explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 class WaterBlock : public ComplexShape
@@ -93,8 +93,8 @@ class WaterBlock : public ComplexShape
   public:
     explicit WaterBlock(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(water_block_translation), water_block_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(structure_translation), structure_halfsize);
+        add<GeometricShapeBox>(Transform(water_block_translation), water_block_halfsize);
+        subtract<GeometricShapeBox>(Transform(structure_translation), structure_halfsize);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/2d_examples/test_2d_stlw/stlw.cpp
+++ b/tests/2d_examples/test_2d_stlw/stlw.cpp
@@ -17,7 +17,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating body, materials and particles.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox> water_block_shape(Transform(water_block_translation), water_block_halfsize, "WaterBody");
+    GeometricShapeBox water_block_shape(Transform(water_block_translation), water_block_halfsize, "WaterBody");
     FluidBody water_block(sph_system, water_block_shape);
     water_block.defineClosure<WeaklyCompressibleFluid, Viscosity>(ConstructArgs(rho0_f, c_f), mu_f);
     water_block.generateParticles<BaseParticles, Lattice>();
@@ -62,7 +62,7 @@ int main(int ac, char *av[])
     //	Define the methods for I/O operations and observations of the simulation.
     //----------------------------------------------------------------------
     BodyStatesRecordingToVtp write_real_body_states(sph_system);
-    TransformShape<GeometricShapeBox> wave_probe_buffer_shape(Transform(gauge_translation), gauge_halfsize, "FreeSurfaceGauge");
+    GeometricShapeBox wave_probe_buffer_shape(Transform(gauge_translation), gauge_halfsize, "FreeSurfaceGauge");
     BodyRegionByCell wave_probe_buffer(water_block, wave_probe_buffer_shape);
     RegressionTestDynamicTimeWarping<ReducedQuantityRecording<UpperFrontInAxisDirection<BodyPartByCell>>>
         wave_gauge(wave_probe_buffer, "FreeSurfaceHeight");

--- a/tests/2d_examples/test_2d_stlw/stlw.h
+++ b/tests/2d_examples/test_2d_stlw/stlw.h
@@ -41,8 +41,8 @@ class WallBoundary : public ComplexShape
   public:
     explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/2d_examples/test_2d_tethered_dead_fish_in_flow/src/tethered_dead_fish_in_flow.cpp
+++ b/tests/2d_examples/test_2d_tethered_dead_fish_in_flow/src/tethered_dead_fish_in_flow.cpp
@@ -319,7 +319,7 @@ int main(int ac, char *av[])
     /** Computing vorticity in the flow. */
     InteractionDynamics<fluid_dynamics::VorticityInner> compute_vorticity(water_block_inner);
     /** Inflow boundary condition. */
-    AlignedBoxPartByCell inflow_buffer(
+    AlignedBoxByCell inflow_buffer(
         water_block, AlignedBox(xAxis, Transform(Vec2d(buffer_translation)), buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<InflowVelocity>> parabolic_inflow(inflow_buffer);
 

--- a/tests/2d_examples/test_2d_three_ring_impact/test_2d_three_ring_impact.cpp
+++ b/tests/2d_examples/test_2d_three_ring_impact/test_2d_three_ring_impact.cpp
@@ -103,9 +103,8 @@ class BoundaryGeometry : public BodyPartByParticle
     Vec2d center_;
 
   public:
-    BoundaryGeometry(SPHBody &body, const std::string &body_part_name, Real diameter, Real dp, const Vec2d &center)
-        : BodyPartByParticle(body, body_part_name),
-          diameter_(diameter), dp_(dp), center_(center)
+    BoundaryGeometry(SPHBody &body, Real diameter, Real dp, const Vec2d &center)
+        : BodyPartByParticle(body), diameter_(diameter), dp_(dp), center_(center)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&BoundaryGeometry::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -281,7 +280,7 @@ void three_ring_impact(int resolution_factor_l, int resolution_factor_m, int res
     SimpleDynamics<InitialVelocityCondition> vel_ic_s(ring_s_body, Vec2d(-30, 30));
 
     // Boundary condition
-    BoundaryGeometry fixed_part_l(ring_l_body, "FixedPartL", diameter_outer_l, dp_l, center_l);
+    BoundaryGeometry fixed_part_l(ring_l_body, diameter_outer_l, dp_l, center_l);
     SimpleDynamics<FixBodyPartConstraint> fix_bc_l(fixed_part_l);
 
     // Observer

--- a/tests/3d_examples/3d_examples_ck/test_3d_dambreak_ck/dambreak.cpp
+++ b/tests/3d_examples/3d_examples_ck/test_3d_dambreak_ck/dambreak.cpp
@@ -33,7 +33,7 @@ class WaterBlock : public ComplexShape
     {
         Vecd halfsize_water(0.5 * LL, 0.5 * LH, 0.5 * LW);
         Transform translation_water(halfsize_water);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_water), halfsize_water);
+        add<GeometricShapeBox>(Transform(translation_water), halfsize_water);
     }
 };
 
@@ -45,8 +45,8 @@ class WallBoundary : public ComplexShape //	define the static solid wall boundar
         Vecd halfsize_outer(0.5 * DL + BW, 0.5 * DH + BW, 0.5 * DW + BW);
         Vecd halfsize_inner(0.5 * DL, 0.5 * DH, 0.5 * DW);
         Transform translation_wall(halfsize_inner);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_wall), halfsize_outer);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translation_wall), halfsize_inner);
+        add<GeometricShapeBox>(Transform(translation_wall), halfsize_outer);
+        subtract<GeometricShapeBox>(Transform(translation_wall), halfsize_inner);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/3d_examples/3d_examples_ck/test_3d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
+++ b/tests/3d_examples/3d_examples_ck/test_3d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
@@ -239,13 +239,13 @@ int main(int ac, char *av[])
     // //----------------------------------------------------------------------
     // //	Creating body parts.
     // //----------------------------------------------------------------------
-    AlignedBoxPartByCell left_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(left_bidirectional_translation), bidirectional_buffer_halfsize));
+    AlignedBoxByCell left_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(left_bidirectional_translation), bidirectional_buffer_halfsize));
     auto defulat_normal = Vec3d::UnitX();
     auto rotated_normal = -1 * Vec3d::UnitX();
     auto rotation_axis = Vec3d::UnitY();
     auto rot3d = Rotation3d(std::acos(defulat_normal.dot(rotated_normal)), rotation_axis);
-    AlignedBoxPartByCell right_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(rot3d, right_bidirectional_translation), bidirectional_buffer_halfsize));
-    // AlignedBoxPartByCell right_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(left_bidirectional_translation), bidirectional_buffer_halfsize));
+    AlignedBoxByCell right_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(rot3d, right_bidirectional_translation), bidirectional_buffer_halfsize));
+    // AlignedBoxByCell right_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(left_bidirectional_translation), bidirectional_buffer_halfsize));
     //----------------------------------------------------------------------
     //	Define body relation map.
     //	The contact map gives the topological connections between the bodies.

--- a/tests/3d_examples/3d_examples_ck/test_3d_repose_angle_ck/repose_angle_ck.cpp
+++ b/tests/3d_examples/3d_examples_ck/test_3d_repose_angle_ck/repose_angle_ck.cpp
@@ -45,8 +45,8 @@ class WallBoundary : public ComplexShape
         Vecd outer_wall_translation = Vecd(-BW, -BW, -BW) + outer_wall_halfsize;
         Vecd inner_wall_halfsize = Vecd(0.5 * DL, 0.5 * DH, 0.5 * DW);
         Vecd inner_wall_translation = inner_wall_halfsize;
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/3d_examples/3d_examples_ck/test_3d_stfb_ck/stfb.cpp
+++ b/tests/3d_examples/3d_examples_ck/test_3d_stfb_ck/stfb.cpp
@@ -60,7 +60,7 @@ class FloatingStructure : public ComplexShape
   public:
     explicit FloatingStructure(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_str), halfsize_structure);
+        add<GeometricShapeBox>(Transform(translation_str), halfsize_structure);
     }
 };
 
@@ -89,8 +89,8 @@ class WaterBlock : public ComplexShape
         Vecd halfsize_water(0.5 * DW, 0.5 * DL, 0.5 * WH);
         Vecd water_pos(0.5 * DW, 0.5 * DL, 0.5 * WH);
         Transform translation_water(water_pos);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_water), halfsize_water);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translation_str), halfsize_structure);
+        add<GeometricShapeBox>(Transform(translation_water), halfsize_water);
+        subtract<GeometricShapeBox>(Transform(translation_str), halfsize_structure);
     }
 };
 //----------------------------------------------------------------------
@@ -104,12 +104,12 @@ class WallBoundary : public ComplexShape
         Vecd halfsize_wall_outer(0.5 * DW + BW, 0.5 * DL + BW, 0.5 * DH + BW);
         Vecd wall_outer_pos(0.5 * DW, 0.5 * DL, 0.5 * DH);
         Transform translation_wall_outer(wall_outer_pos);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_wall_outer), halfsize_wall_outer);
+        add<GeometricShapeBox>(Transform(translation_wall_outer), halfsize_wall_outer);
 
         Vecd halfsize_wall_inner(0.5 * DW, 0.5 * DL, 0.5 * DH + BW);
         Vecd wall_inner_pos(0.5 * DW, 0.5 * DL, 0.5 * DH + BW);
         Transform translation_wall_inner(wall_inner_pos);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translation_wall_inner), halfsize_wall_inner);
+        subtract<GeometricShapeBox>(Transform(translation_wall_inner), halfsize_wall_inner);
     }
 };
 //----------------------------------------------------------------------
@@ -155,7 +155,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating body parts.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox>
+    GeometricShapeBox
         wave_probe_buffer_shape(Transform(translation_FS_gauge), FS_gauge);
     BodyRegionByCell wave_probe_buffer(water_block, wave_probe_buffer_shape);
 
@@ -245,7 +245,7 @@ int main(int ac, char *av[])
     /** the forces of the system. */
     SimTK::GeneralForceSubsystem forces(MBsystem);
     /** mass properties of the fixed spot. */
-    TransformShape<GeometricShapeBox> fix_spot_shape(Transform(translation_str), halfsize_structure);
+    GeometricShapeBox fix_spot_shape(Transform(translation_str), halfsize_structure);
     StructureSystemForSimbody structure_multibody(structure, fix_spot_shape);
     /** Mass properties of the constrained spot.
      * SimTK::MassProperties(mass, center of mass, inertia)

--- a/tests/3d_examples/test_3d_FVM_incompressible_channel_flow/test_3d_FVM_incompressible_channel_flow.h
+++ b/tests/3d_examples/test_3d_FVM_incompressible_channel_flow/test_3d_FVM_incompressible_channel_flow.h
@@ -42,7 +42,7 @@ class AirBody : public ComplexShape
     {
         Vecd halfsize_wave(0.5 * DH, 0.5 * DL, 0.5 * DW);
         Transform translation_wave(halfsize_wave);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_wave), halfsize_wave);
+        add<GeometricShapeBox>(Transform(translation_wave), halfsize_wave);
     }
 };
 ///----------------------------------------------------------------------

--- a/tests/3d_examples/test_3d_arch/3d_arch.cpp
+++ b/tests/3d_examples/test_3d_arch/3d_arch.cpp
@@ -77,8 +77,7 @@ class ParticleGenerator<SurfaceParticles, Cylinder> : public ParticleGenerator<S
 class DisControlGeometry : public BodyPartByParticle
 {
   public:
-    DisControlGeometry(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    DisControlGeometry(SPHBody &body) : BodyPartByParticle(body)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&DisControlGeometry::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -116,8 +115,7 @@ class ControlDisplacement : public thin_structure_dynamics::ConstrainShellBodyRe
 class BoundaryGeometry : public BodyPartByParticle
 {
   public:
-    BoundaryGeometry(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    BoundaryGeometry(SPHBody &body) : BodyPartByParticle(body)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&BoundaryGeometry::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -169,9 +167,9 @@ int main(int ac, char *av[])
     Dynamics1Level<thin_structure_dynamics::ShellStressRelaxationSecondHalf> stress_relaxation_second_half(cylinder_body_inner);
 
     ReduceDynamics<thin_structure_dynamics::ShellAcousticTimeStepSize> computing_time_step_size(cylinder_body);
-    DisControlGeometry dis_control_geometry(cylinder_body, "DisControlGeometry");
+    DisControlGeometry dis_control_geometry(cylinder_body);
     SimpleDynamics<ControlDisplacement> dis_control(dis_control_geometry);
-    BoundaryGeometry boundary_geometry(cylinder_body, "BoundaryGeometry");
+    BoundaryGeometry boundary_geometry(cylinder_body);
     SimpleDynamics<thin_structure_dynamics::ConstrainShellBodyRegion> constrain_holder(boundary_geometry);
     DampingWithRandomChoice<InteractionSplit<DampingPairwiseInner<Vecd, FixedDampingRate>>>
         cylinder_position_damping(0.2, cylinder_body_inner, "Velocity", physical_viscosity);

--- a/tests/3d_examples/test_3d_bending_circular_plate_parametric_cvt/test_3d_bending_circular_plate_parametric_cvt.cpp
+++ b/tests/3d_examples/test_3d_bending_circular_plate_parametric_cvt/test_3d_bending_circular_plate_parametric_cvt.cpp
@@ -253,7 +253,7 @@ return_data bending_circular_plate(Real dp_ratio)
     Dynamics1Level<thin_structure_dynamics::ShellStressRelaxationSecondHalf> stress_relaxation_second_half(shell_body_inner);
 
     ReduceDynamics<thin_structure_dynamics::ShellAcousticTimeStepSize> computing_time_step_size(shell_body);
-    BodyPartByParticle constrained_edges(shell_body, "constrained_edges");
+    BodyPartByParticle constrained_edges(shell_body);
     auto constrained_edge_ids = [&]() { // brute force finding the edges
         IndexVector ids;
         for (size_t i = 0; i < shell_body.getBaseParticles().TotalRealParticles(); ++i)

--- a/tests/3d_examples/test_3d_cubic_droplet/3d_cubic_droplet.cpp
+++ b/tests/3d_examples/test_3d_cubic_droplet/3d_cubic_droplet.cpp
@@ -39,7 +39,7 @@ class WaterBlock : public ComplexShape
     {
         Vecd water_halfsize(0.5 * LL, 0.5 * LH, 0.5 * LW);
         Transform water_translation(Vecd(0, 0, 0));
-        add<TransformShape<GeometricShapeBox>>(Transform(water_translation), water_halfsize);
+        add<GeometricShapeBox>(Transform(water_translation), water_halfsize);
     }
 };
 //----------------------------------------------------------------------
@@ -54,8 +54,8 @@ class AirBlock : public ComplexShape
         Transform water_translation(Vecd(0, 0, 0));
         Vecd air_halfsize(0.5 * DL, 0.5 * DH, 0.5 * DW);
         Transform air_translation(Vecd(0, 0, 0));
-        add<TransformShape<GeometricShapeBox>>(Transform(air_translation), air_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(water_translation), water_halfsize);
+        add<GeometricShapeBox>(Transform(air_translation), air_halfsize);
+        subtract<GeometricShapeBox>(Transform(water_translation), water_halfsize);
     }
 };
 //----------------------------------------------------------------------
@@ -70,8 +70,8 @@ class WallBoundary : public ComplexShape
         Vecd halfsize_outer(0.5 * DL + BW, 0.5 * DH + BW, 0.5 * DW + BW);
         Vecd halfsize_inner(0.5 * DL, 0.5 * DH, 0.5 * DW);
         Transform translation_wall(Vecd(0, 0, 0));
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_wall), halfsize_outer);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translation_wall), halfsize_inner);
+        add<GeometricShapeBox>(Transform(translation_wall), halfsize_outer);
+        subtract<GeometricShapeBox>(Transform(translation_wall), halfsize_inner);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/3d_examples/test_3d_dambreak/dambreak.cpp
+++ b/tests/3d_examples/test_3d_dambreak/dambreak.cpp
@@ -31,7 +31,7 @@ class WaterBlock : public ComplexShape
     {
         Vecd halfsize_water(0.5 * LL, 0.5 * LH, 0.5 * LW);
         Transform translation_water(halfsize_water);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_water), halfsize_water);
+        add<GeometricShapeBox>(Transform(translation_water), halfsize_water);
     }
 };
 //	define the static solid wall boundary shape
@@ -43,8 +43,8 @@ class WallBoundary : public ComplexShape
         Vecd halfsize_outer(0.5 * DL + BW, 0.5 * DH + BW, 0.5 * DW + BW);
         Vecd halfsize_inner(0.5 * DL, 0.5 * DH, 0.5 * DW);
         Transform translation_wall(halfsize_inner);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_wall), halfsize_outer);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translation_wall), halfsize_inner);
+        add<GeometricShapeBox>(Transform(translation_wall), halfsize_outer);
+        subtract<GeometricShapeBox>(Transform(translation_wall), halfsize_inner);
     }
 };
 

--- a/tests/3d_examples/test_3d_dambreak_elastic_plate_shell/test_3d_dambreak_elastic_plate_shell.cpp
+++ b/tests/3d_examples/test_3d_dambreak_elastic_plate_shell/test_3d_dambreak_elastic_plate_shell.cpp
@@ -116,8 +116,7 @@ class ParticleGenerator<SurfaceParticles, Plate> : public ParticleGenerator<Surf
 class BoundaryGeometry : public BodyPartByParticle
 {
   public:
-    BoundaryGeometry(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    BoundaryGeometry(SPHBody &body) : BodyPartByParticle(body)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&BoundaryGeometry::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -222,7 +221,7 @@ int main(int ac, char *av[])
     SimpleDynamics<thin_structure_dynamics::AverageShellCurvature> plate_average_curvature(plate_curvature_inner);
     SimpleDynamics<thin_structure_dynamics::UpdateShellNormalDirection> plate_update_normal(plate);
     /** constraint and damping */
-    BoundaryGeometry plate_boundary_geometry(plate, "BoundaryGeometry");
+    BoundaryGeometry plate_boundary_geometry(plate);
     SimpleDynamics<thin_structure_dynamics::ConstrainShellBodyRegion> plate_constraint(plate_boundary_geometry);
     // fluid
     Gravity gravity(Vec3d(0.0, -gravity_g, 0.0));

--- a/tests/3d_examples/test_3d_dambreak_elastic_plate_shell/test_3d_dambreak_elastic_plate_shell.cpp
+++ b/tests/3d_examples/test_3d_dambreak_elastic_plate_shell/test_3d_dambreak_elastic_plate_shell.cpp
@@ -52,7 +52,7 @@ class WaterBlock : public ComplexShape
     {
         Vec3d halfsize_water(0.5 * LL, 0.5 * LH, 0.5 * LW);
         Transform translation_water(halfsize_water);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_water), halfsize_water);
+        add<GeometricShapeBox>(Transform(translation_water), halfsize_water);
     }
 };
 //	define the static solid wall boundary shape
@@ -64,12 +64,12 @@ class WallBoundary : public ComplexShape
         Vec3d halfsize_outer(0.5 * DL + BW, 0.5 * DH + BW, 0.5 * DW + BW);
         Vec3d halfsize_inner(0.5 * DL, 0.5 * DH, 0.5 * DW);
         Transform translation_wall(halfsize_inner);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_wall), halfsize_outer);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translation_wall), halfsize_inner);
+        add<GeometricShapeBox>(Transform(translation_wall), halfsize_outer);
+        subtract<GeometricShapeBox>(Transform(translation_wall), halfsize_inner);
 
         Vec3d halfsize_plate(0.5 * resolution_ref, 0.5 * plate_width, 0.5 * (plate_height + BW));
         Transform translation_plate(halfsize_plate + Vec3d(plate_x_pos, -BW, (DW - plate_width) * 0.5));
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translation_plate), halfsize_plate);
+        subtract<GeometricShapeBox>(Transform(translation_plate), halfsize_plate);
     }
 };
 //	define the rigid solid gate shape
@@ -80,7 +80,7 @@ class MovingGate : public ComplexShape
     {
         Vec3d halfsize_gate(0.5 * BW, 0.5 * DH, 0.5 * DW);
         Transform translation_gate(Vec3d(LL, 0, 0) + halfsize_gate);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_gate), halfsize_gate);
+        add<GeometricShapeBox>(Transform(translation_gate), halfsize_gate);
     }
 };
 //	define the elastic plate shape

--- a/tests/3d_examples/test_3d_dynamic_plate/test_3d_dynamic_plate.cpp
+++ b/tests/3d_examples/test_3d_dynamic_plate/test_3d_dynamic_plate.cpp
@@ -66,8 +66,7 @@ class ParticleGenerator<SurfaceParticles, Plate> : public ParticleGenerator<Surf
 class BoundaryGeometry : public BodyPartByParticle
 {
   public:
-    BoundaryGeometry(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    BoundaryGeometry(SPHBody &body) : BodyPartByParticle(body)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&BoundaryGeometry::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -124,7 +123,7 @@ int main(int ac, char *av[])
     /** Time step size calculation. */
     ReduceDynamics<thin_structure_dynamics::ShellAcousticTimeStepSize> computing_time_step_size(plate_body);
     /** Constrain the Boundary. */
-    BoundaryGeometry boundary_geometry(plate_body, "BoundaryGeometry");
+    BoundaryGeometry boundary_geometry(plate_body);
     SimpleDynamics<FixBodyPartConstraint> constrain_holder(boundary_geometry);
     /** Output */
     IOEnvironment io_environment(sph_system);

--- a/tests/3d_examples/test_3d_mr_cantilever_beam/test_3d_mr_cantilever_beam.cpp
+++ b/tests/3d_examples/test_3d_mr_cantilever_beam/test_3d_mr_cantilever_beam.cpp
@@ -110,8 +110,7 @@ struct solid_algs
 class FixPart : public BodyPartByParticle
 {
   public:
-    FixPart(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    FixPart(SPHBody &body) : BodyPartByParticle(body)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&FixPart::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -230,7 +229,7 @@ return_data beam_multi_resolution(Real dp_factor, bool damping_on, int refinemen
     };
 
     // Boundary conditions
-    FixPart fix_bc_part(beam_body, "ClampingPart");
+    FixPart fix_bc_part(beam_body);
     SimpleDynamics<FixBodyPartConstraint> fix_bc(fix_bc_part);
 
     // gravity

--- a/tests/3d_examples/test_3d_mr_cantilever_beam/test_3d_mr_cantilever_beam.cpp
+++ b/tests/3d_examples/test_3d_mr_cantilever_beam/test_3d_mr_cantilever_beam.cpp
@@ -167,13 +167,13 @@ return_data beam_multi_resolution(Real dp_factor, bool damping_on, int refinemen
     // Import meshes
     const Vec3d halfsize = 0.5 * (Vec3d(params.length, params.height, params.width) + extension_length * Vec3d::UnitX());
     const Vec3d translation = 0.5 * (params.length - extension_length) * Vec3d::UnitX();
-    auto mesh = makeShared<TransformShape<GeometricShapeBox>>(Transform(translation), halfsize, "beam");
+    auto mesh = makeShared<GeometricShapeBox>(Transform(translation), halfsize, "beam");
 
     // refinement region
     const Real refinement_region_length = 0.5 * params.length;
     const Vec3d refinement_halfsize = 0.5 * Vec3d(refinement_region_length, params.height, params.width);
     const Vec3d refinement_translation = (params.length - 0.5 * refinement_region_length) * Vec3d::UnitX();
-    auto refinement_region = makeShared<TransformShape<GeometricShapeBox>>(Transform(refinement_translation), refinement_halfsize);
+    auto refinement_region = makeShared<GeometricShapeBox>(Transform(refinement_translation), refinement_halfsize);
 
     // System bounding box
     BoundingBox bb_system = mesh->getBounds();

--- a/tests/3d_examples/test_3d_muscle_activation/src/muscle_activation.cpp
+++ b/tests/3d_examples/test_3d_muscle_activation/src/muscle_activation.cpp
@@ -65,7 +65,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating bodies with corresponding materials and particles.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox> muscle_body_shape(Transform(translation_myocardium), halfsize_myocardium, "MyocardiumMuscleBody");
+    GeometricShapeBox muscle_body_shape(Transform(translation_myocardium), halfsize_myocardium, "MyocardiumMuscleBody");
     SolidBody muscle_body(sph_system, muscle_body_shape);
     muscle_body.defineMaterial<ActiveMuscle<Muscle>>(rho0_s, bulk_modulus, fiber_direction, sheet_direction, a0, b0);
     muscle_body.generateParticles<BaseParticles, Lattice>();
@@ -89,7 +89,7 @@ int main(int ac, char *av[])
 
     ReduceDynamics<solid_dynamics::AcousticTimeStep> computing_time_step_size(muscle_body);
     SimpleDynamics<MyocardiumActivation> myocardium_activation(muscle_body);
-    BodyRegionByParticle holder(muscle_body, makeShared<TransformShape<GeometricShapeBox>>(Transform(translation_holder), halfsize_holder));
+    BodyRegionByParticle holder(muscle_body, makeShared<GeometricShapeBox>(Transform(translation_holder), halfsize_holder));
     SimpleDynamics<FixedInAxisDirection> constrain_holder(holder, Vecd(0.0, 1.0, 1.0));
     //----------------------------------------------------------------------
     //	Define the methods for I/O operations, observations

--- a/tests/3d_examples/test_3d_muscle_soft_body_contact/muscle_soft_body_contact.cpp
+++ b/tests/3d_examples/test_3d_muscle_soft_body_contact/muscle_soft_body_contact.cpp
@@ -36,8 +36,8 @@ class Myocardium : public ComplexShape
   public:
     explicit Myocardium(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_myocardium), halfsize_myocardium);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_stationary_plate), halfsize_stationary_plate);
+        add<GeometricShapeBox>(Transform(translation_myocardium), halfsize_myocardium);
+        add<GeometricShapeBox>(Transform(translation_stationary_plate), halfsize_stationary_plate);
     }
 };
 
@@ -46,7 +46,7 @@ class MovingPlate : public ComplexShape
   public:
     explicit MovingPlate(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_moving_plate), halfsize_moving_plate);
+        add<GeometricShapeBox>(Transform(translation_moving_plate), halfsize_moving_plate);
     }
 };
 //----------------------------------------------------------------------
@@ -99,7 +99,7 @@ int main(int ac, char *av[])
     InteractionWithUpdate<solid_dynamics::ContactForce> myocardium_compute_solid_contact_forces(myocardium_plate_contact);
     InteractionWithUpdate<solid_dynamics::ContactForce> plate_compute_solid_contact_forces(plate_myocardium_contact);
     /** Constrain the holder. */
-    TransformShape<GeometricShapeBox> holder_shape(Transform(translation_stationary_plate), halfsize_stationary_plate, "Holder");
+    GeometricShapeBox holder_shape(Transform(translation_stationary_plate), halfsize_stationary_plate, "Holder");
     BodyRegionByParticle holder(myocardium_body, holder_shape);
     SimpleDynamics<FixBodyPartConstraint> constraint_holder(holder);
     /** Add spring constraint on the plate. */

--- a/tests/3d_examples/test_3d_muscle_solid_contact/muscle_solid_contact.cpp
+++ b/tests/3d_examples/test_3d_muscle_solid_contact/muscle_solid_contact.cpp
@@ -36,8 +36,8 @@ class Myocardium : public ComplexShape
   public:
     explicit Myocardium(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_myocardium), halfsize_myocardium);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_stationary_plate), halfsize_stationary_plate);
+        add<GeometricShapeBox>(Transform(translation_myocardium), halfsize_myocardium);
+        add<GeometricShapeBox>(Transform(translation_stationary_plate), halfsize_stationary_plate);
     }
 };
 
@@ -46,7 +46,7 @@ class MovingPlate : public ComplexShape
   public:
     explicit MovingPlate(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_moving_plate), halfsize_moving_plate);
+        add<GeometricShapeBox>(Transform(translation_moving_plate), halfsize_moving_plate);
     }
 };
 //----------------------------------------------------------------------
@@ -95,7 +95,7 @@ int main(int ac, char *av[])
     /** Time step size calculation. */
     ReduceDynamics<solid_dynamics::AcousticTimeStep> computing_time_step_size(myocardium_body);
     /** Constrain the holder. */
-    TransformShape<GeometricShapeBox> holder_shape(Transform(translation_stationary_plate), halfsize_stationary_plate, "Holder");
+    GeometricShapeBox holder_shape(Transform(translation_stationary_plate), halfsize_stationary_plate, "Holder");
     BodyRegionByParticle holder(myocardium_body, holder_shape);
     SimpleDynamics<FixBodyPartConstraint> constraint_holder(holder);
     /** Damping with the solid body*/
@@ -117,7 +117,7 @@ int main(int ac, char *av[])
     SimTK::GeneralForceSubsystem forces(MBsystem);
     SimTK::CableTrackerSubsystem cables(MBsystem);
     /** mass properties of the fixed spot. */
-    TransformShape<GeometricShapeBox> moving_plate_shape(Transform(translation_moving_plate), halfsize_moving_plate, "Plate");
+    GeometricShapeBox moving_plate_shape(Transform(translation_moving_plate), halfsize_moving_plate, "Plate");
     SimpleDynamics<NormalDirectionFromBodyShape> moving_plate_normal_direction(moving_plate);
     SolidBodyPartForSimbody plate_multibody(moving_plate, moving_plate_shape);
     /** Mass properties of the constrained spot.

--- a/tests/3d_examples/test_3d_nonlinear_wave_fsi/nonlinear_wave_fsi.cpp
+++ b/tests/3d_examples/test_3d_nonlinear_wave_fsi/nonlinear_wave_fsi.cpp
@@ -159,7 +159,7 @@ int main(int ac, char *av[])
     /** Damp waves */
     Vecd translation_damping(0.5 * DW, 9.5, 0.5 * HWM);
     Vecd damping(0.5 * DW, 0.5, 0.5 * HWM);
-    TransformShape<GeometricShapeBox> damping_buffer_shape(Transform(translation_damping), damping);
+    GeometricShapeBox damping_buffer_shape(Transform(translation_damping), damping);
     BodyRegionByCell damping_buffer(water_block, damping_buffer_shape);
     SimpleDynamics<fluid_dynamics::DampingBoundaryCondition> damping_wave(damping_buffer);
 
@@ -167,7 +167,7 @@ int main(int ac, char *av[])
     InteractionWithUpdate<solid_dynamics::ViscousForceFromFluid> viscous_force_on_solid(structure_contact);
     InteractionWithUpdate<solid_dynamics::PressureForceFromFluid<decltype(density_relaxation)>> pressure_force_on_structure(structure_contact);
     /** constrain region of the part of wall boundary. */
-    TransformShape<GeometricShapeBox> transform_wave_maker_shape(Transform(translation_wave_maker), wave_maker_shape);
+    GeometricShapeBox transform_wave_maker_shape(Transform(translation_wave_maker), wave_maker_shape);
     BodyRegionByParticle wave_maker(wall_boundary, transform_wave_maker_shape);
     SimpleDynamics<WaveMaking> wave_making(wave_maker);
     //----------------------------------------------------------------------
@@ -264,7 +264,7 @@ int main(int ac, char *av[])
     BodyStatesRecordingToVtp write_real_body_states(sph_system);
     write_real_body_states.addToWrite<Real>(water_block, "Pressure");
     /** WaveProbes. */
-    BodyRegionByCell wave_probe_buffer(water_block, makeShared<TransformShape<GeometricShapeBox>>(Transform(translation_WGauge), WGaugeDim));
+    BodyRegionByCell wave_probe_buffer(water_block, makeShared<GeometricShapeBox>(Transform(translation_WGauge), WGaugeDim));
     ReducedQuantityRecording<UpperFrontInAxisDirection<BodyPartByCell>>
         wave_gauge(wave_probe_buffer, "FreeSurfaceHeight");
 

--- a/tests/3d_examples/test_3d_nonlinear_wave_fsi/nonlinear_wave_fsi.h
+++ b/tests/3d_examples/test_3d_nonlinear_wave_fsi/nonlinear_wave_fsi.h
@@ -298,7 +298,7 @@ class WaterBlock : public ComplexShape
         Vecd halfsize_water(0.5 * DW, 0.5 * (DL - EXS), 0.5 * WH);
         Vecd water_pos(0.5 * DW, 0.5 * (DL - EXS), 0.5 * WH);
         Transform translation_water(water_pos);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_water), halfsize_water);
+        add<GeometricShapeBox>(Transform(translation_water), halfsize_water);
         subtract<TriangleMeshShapeSTL>(stl_structure_path, translation_str, StructureScale);
     }
 };
@@ -321,14 +321,14 @@ class WallBoundary : public ComplexShape
         Vecd halfsize_wall_outer(0.5 * DW + BW, 0.5 * DL + BW, 0.5 * DH + BW);
         Vecd wall_outer_pos(0.5 * DW, 0.5 * DL - EXS, 0.5 * DH);
         Transform translation_wall_outer(wall_outer_pos);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_wall_outer), halfsize_wall_outer);
+        add<GeometricShapeBox>(Transform(translation_wall_outer), halfsize_wall_outer);
 
         Vecd halfsize_wall_inner(0.5 * DW, 0.5 * DL, 0.5 * DH + BW);
         Vecd wall_inner_pos(0.5 * DW, 0.5 * DL - EXS, BW + 0.5 * DH);
         Transform translation_wall_inner(wall_inner_pos);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translation_wall_inner), halfsize_wall_inner);
+        subtract<GeometricShapeBox>(Transform(translation_wall_inner), halfsize_wall_inner);
 
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_wave_maker), wave_maker_shape);
+        add<GeometricShapeBox>(Transform(translation_wave_maker), wave_maker_shape);
     }
 };
 

--- a/tests/3d_examples/test_3d_passive_cantilever/passive_cantilever.cpp
+++ b/tests/3d_examples/test_3d_passive_cantilever/passive_cantilever.cpp
@@ -41,8 +41,8 @@ class Cantilever : public ComplexShape
   public:
     explicit Cantilever(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_cantilever), halfsize_cantilever);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_holder), halfsize_holder);
+        add<GeometricShapeBox>(Transform(translation_cantilever), halfsize_cantilever);
+        add<GeometricShapeBox>(Transform(translation_holder), halfsize_holder);
     }
 };
 /**
@@ -96,7 +96,7 @@ int main(int ac, char *av[])
     /** Time step size calculation. */
     ReduceDynamics<solid_dynamics::AcousticTimeStep> computing_time_step_size(cantilever_body);
     /** Constrain the holder. */
-    TransformShape<GeometricShapeBox> holder_shape(Transform(translation_holder), halfsize_holder, "Holder");
+    GeometricShapeBox holder_shape(Transform(translation_holder), halfsize_holder, "Holder");
     BodyRegionByParticle holder(cantilever_body, holder_shape);
     SimpleDynamics<FixBodyPartConstraint> constraint_holder(holder);
     /** Output */

--- a/tests/3d_examples/test_3d_passive_cantilever_neohookean/passive_cantilever_neohookean.cpp
+++ b/tests/3d_examples/test_3d_passive_cantilever_neohookean/passive_cantilever_neohookean.cpp
@@ -36,8 +36,8 @@ class Cantilever : public ComplexShape
   public:
     explicit Cantilever(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_cantilever), halfsize_cantilever);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_holder), halfsize_holder);
+        add<GeometricShapeBox>(Transform(translation_cantilever), halfsize_cantilever);
+        add<GeometricShapeBox>(Transform(translation_holder), halfsize_holder);
     }
 };
 
@@ -80,7 +80,7 @@ int main(int ac, char *av[])
     /** Time step size calculation. */
     ReduceDynamics<solid_dynamics::AcousticTimeStep> computing_time_step_size(cantilever_body);
     /** Constrain the holder. */
-    TransformShape<GeometricShapeBox> holder_shape(Transform(translation_holder), halfsize_holder, "Holder");
+    GeometricShapeBox holder_shape(Transform(translation_holder), halfsize_holder, "Holder");
     BodyRegionByParticle holder(cantilever_body, holder_shape);
     SimpleDynamics<FixBodyPartConstraint> constraint_holder(holder);
     DampingWithRandomChoice<InteractionSplit<DampingProjectionInner<Vec3d, FixedDampingRate>>>

--- a/tests/3d_examples/test_3d_poiseuille_flow_shell/poiseuille_flow_shell.cpp
+++ b/tests/3d_examples/test_3d_poiseuille_flow_shell/poiseuille_flow_shell.cpp
@@ -233,11 +233,11 @@ void poiseuille_flow(const Real resolution_ref, const Real resolution_shell, con
     //----------------------------------------------------------------------
     //	Boundary conditions. Inflow & Outflow in Y-direction
     //----------------------------------------------------------------------
-    AlignedBoxPartByParticle emitter(water_block, AlignedBox(yAxis, Transform(Vec3d(emitter_translation)), emitter_halfsize));
+    AlignedBoxByParticle emitter(water_block, AlignedBox(yAxis, Transform(Vec3d(emitter_translation)), emitter_halfsize));
     SimpleDynamics<fluid_dynamics::EmitterInflowInjection> emitter_inflow_injection(emitter, inlet_particle_buffer);
-    AlignedBoxPartByCell emitter_buffer(water_block, AlignedBox(yAxis, Transform(Vec3d(emitter_buffer_translation)), emitter_buffer_halfsize));
+    AlignedBoxByCell emitter_buffer(water_block, AlignedBox(yAxis, Transform(Vec3d(emitter_buffer_translation)), emitter_buffer_halfsize));
     SimpleDynamics<fluid_dynamics::InflowVelocityCondition<InflowVelocity>> emitter_buffer_inflow_condition(emitter_buffer);
-    AlignedBoxPartByCell disposer(water_block, AlignedBox(yAxis, Transform(Vec3d(disposer_translation)), disposer_halfsize));
+    AlignedBoxByCell disposer(water_block, AlignedBox(yAxis, Transform(Vec3d(disposer_translation)), disposer_halfsize));
     SimpleDynamics<fluid_dynamics::DisposerOutflowDeletion> disposer_outflow_deletion(disposer);
     //----------------------------------------------------------------------
     //	Define the configuration related particles dynamics.

--- a/tests/3d_examples/test_3d_repose_angle/repose_angle.cpp
+++ b/tests/3d_examples/test_3d_repose_angle/repose_angle.cpp
@@ -45,8 +45,8 @@ class WallBoundary : public ComplexShape
         Vecd outer_wall_translation = Vecd(-BW, -BW, -BW) + outer_wall_halfsize;
         Vecd inner_wall_halfsize = Vecd(0.5 * DL, 0.5 * DH, 0.5 * DW);
         Vecd inner_wall_translation = inner_wall_halfsize;
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/3d_examples/test_3d_roof/3d_roof.cpp
+++ b/tests/3d_examples/test_3d_roof/3d_roof.cpp
@@ -79,8 +79,7 @@ class ParticleGenerator<SurfaceParticles, Cylinder> : public ParticleGenerator<S
 class BoundaryGeometry : public BodyPartByParticle
 {
   public:
-    BoundaryGeometry(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    BoundaryGeometry(SPHBody &body) : BodyPartByParticle(body)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&BoundaryGeometry::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -132,7 +131,7 @@ int main(int ac, char *av[])
 
     /** Time step size calculation. */
     ReduceDynamics<thin_structure_dynamics::ShellAcousticTimeStepSize> computing_time_step_size(cylinder_body);
-    BoundaryGeometry boundary_geometry(cylinder_body, "BoundaryGeometry");
+    BoundaryGeometry boundary_geometry(cylinder_body);
     SimpleDynamics<FixedInAxisDirection> constrain_holder(boundary_geometry, Vecd(0.0, 1.0, 0.0));
     DampingWithRandomChoice<InteractionSplit<DampingProjectionInner<Vec3d, FixedDampingRate>>>
         cylinder_position_damping(0.3, cylinder_body_inner, "Velocity", physical_viscosity);

--- a/tests/3d_examples/test_3d_roof_parametric_cvt/test_3d_roof_parametric_cvt.cpp
+++ b/tests/3d_examples/test_3d_roof_parametric_cvt/test_3d_roof_parametric_cvt.cpp
@@ -372,7 +372,7 @@ return_data roof_under_self_weight(Real dp, bool cvt = true, int particle_number
 
     ReduceDynamics<thin_structure_dynamics::ShellAcousticTimeStepSize> computing_time_step_size(shell_body);
 
-    BodyPartByParticle constrained_edges(shell_body, "constrained_edges");
+    BodyPartByParticle constrained_edges(shell_body);
     BaseParticles &base_particles = shell_body.getBaseParticles();
     auto constrained_edge_ids = [&]() { // brute force finding the edges
         IndexVector ids;

--- a/tests/3d_examples/test_3d_self_contact/3d_self_contact.cpp
+++ b/tests/3d_examples/test_3d_self_contact/3d_self_contact.cpp
@@ -45,7 +45,7 @@ class StationaryPlate : public ComplexShape
     {
         Vecd halfsize_plate(half_width + BW, 0.5 * BW, half_width + BW);
         Vecd translation_plate(0.0, -half_width - 0.75 * BW, half_width);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_plate), halfsize_plate);
+        add<GeometricShapeBox>(Transform(translation_plate), halfsize_plate);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/3d_examples/test_3d_shell_stability_half_sphere/test_3d_shell_stability_half_sphere.cpp
+++ b/tests/3d_examples/test_3d_shell_stability_half_sphere/test_3d_shell_stability_half_sphere.cpp
@@ -161,7 +161,7 @@ void sphere_compression(int dp_ratio, Real pressure, Real gravity_z)
     SimpleDynamics<thin_structure_dynamics::UpdateShellNormalDirection> normal_update(shell_body);
     SimpleDynamics<solid_dynamics::PressureForceOnShell> apply_pressure(shell_body, pressure * pow(unit_mm, 2));
 
-    BodyPartByParticle constrained_edges(shell_body, "constrained_edges");
+    BodyPartByParticle constrained_edges(shell_body);
     Vec3d *position = shell_particles->getVariableDataByName<Vec3d>("Position");
     auto constrained_edge_ids = [&]() { // brute force finding the edges
         IndexVector ids;

--- a/tests/3d_examples/test_3d_slender_beam/test_3d_slender_beam.cpp
+++ b/tests/3d_examples/test_3d_slender_beam/test_3d_slender_beam.cpp
@@ -79,10 +79,10 @@ class ParticleGenerator<LinearParticles, Bar> : public ParticleGenerator<LinearP
 class BoundaryGeometryParallelToXAxis : public BodyPartByParticle
 {
   public:
-    BoundaryGeometryParallelToXAxis(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    BoundaryGeometryParallelToXAxis(SPHBody &body) : BodyPartByParticle(body)
     {
-        TaggingParticleMethod tagging_particle_method = std::bind(&BoundaryGeometryParallelToXAxis::tagManually, this, _1);
+        TaggingParticleMethod tagging_particle_method =
+            std::bind(&BoundaryGeometryParallelToXAxis::tagManually, this, _1);
         tagParticles(tagging_particle_method);
     };
     virtual ~BoundaryGeometryParallelToXAxis() {};
@@ -97,8 +97,8 @@ class BoundaryGeometryParallelToXAxis : public BodyPartByParticle
 class BoundaryGeometryParallelToYAxis : public BodyPartByParticle
 {
   public:
-    BoundaryGeometryParallelToYAxis(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    BoundaryGeometryParallelToYAxis(SPHBody &body)
+        : BodyPartByParticle(body)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&BoundaryGeometryParallelToYAxis::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -152,10 +152,10 @@ int main(int ac, char *av[])
     /** Time step size calculation. */
     ReduceDynamics<slender_structure_dynamics::BarAcousticTimeStepSize> computing_time_step_size(bar_body);
     /** Constrain the Boundary. */
-    BoundaryGeometryParallelToXAxis boundary_geometry_x(bar_body, "BoundaryGeometryParallelToXAxis");
+    BoundaryGeometryParallelToXAxis boundary_geometry_x(bar_body);
     SimpleDynamics<slender_structure_dynamics::ConstrainBarBodyRegionAlongAxis>
         constrain_holder_x(boundary_geometry_x, 0);
-    BoundaryGeometryParallelToYAxis boundary_geometry_y(bar_body, "BoundaryGeometryParallelToYAxis");
+    BoundaryGeometryParallelToYAxis boundary_geometry_y(bar_body);
     SimpleDynamics<slender_structure_dynamics::ConstrainBarBodyRegionAlongAxis>
         constrain_holder_y(boundary_geometry_y, 1);
     DampingWithRandomChoice<InteractionSplit<DampingPairwiseInner<Vec3d, FixedDampingRate>>>

--- a/tests/3d_examples/test_3d_stfb/stfb.cpp
+++ b/tests/3d_examples/test_3d_stfb/stfb.cpp
@@ -105,7 +105,7 @@ int main(int ac, char *av[])
     /** the forces of the system. */
     SimTK::GeneralForceSubsystem forces(MBsystem);
     /** mass properties of the fixed spot. */
-    TransformShape<GeometricShapeBox> fix_spot_shape(Transform(translation_str), halfsize_structure);
+    GeometricShapeBox fix_spot_shape(Transform(translation_str), halfsize_structure);
     StructureSystemForSimbody structure_multibody(structure, fix_spot_shape);
     /** Mass properties of the constrained spot.
      * SimTK::MassProperties(mass, center of mass, inertia)
@@ -167,7 +167,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     BodyStatesRecordingToVtp write_real_body_states(sph_system);
     /** WaveProbes. */
-    BodyRegionByCell wave_probe_buffer(water_block, makeShared<TransformShape<GeometricShapeBox>>(Transform(translation_FS_gauge), FS_gauge));
+    BodyRegionByCell wave_probe_buffer(water_block, makeShared<GeometricShapeBox>(Transform(translation_FS_gauge), FS_gauge));
     RegressionTestDynamicTimeWarping<ReducedQuantityRecording<UpperFrontInAxisDirection<BodyPartByCell>>>
         wave_gauge(wave_probe_buffer, "FreeSurfaceHeight");
     InteractionDynamics<InterpolatingAQuantity<Vecd>>

--- a/tests/3d_examples/test_3d_stfb/stfb.h
+++ b/tests/3d_examples/test_3d_stfb/stfb.h
@@ -64,7 +64,7 @@ class FloatingStructure : public ComplexShape
   public:
     explicit FloatingStructure(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_str), halfsize_structure);
+        add<GeometricShapeBox>(Transform(translation_str), halfsize_structure);
     }
 };
 
@@ -93,8 +93,8 @@ class WaterBlock : public ComplexShape
         Vecd halfsize_water(0.5 * DW, 0.5 * DL, 0.5 * WH);
         Vecd water_pos(0.5 * DW, 0.5 * DL, 0.5 * WH);
         Transform translation_water(water_pos);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_water), halfsize_water);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translation_str), halfsize_structure);
+        add<GeometricShapeBox>(Transform(translation_water), halfsize_water);
+        subtract<GeometricShapeBox>(Transform(translation_str), halfsize_structure);
     }
 };
 //----------------------------------------------------------------------
@@ -108,12 +108,12 @@ class WallBoundary : public ComplexShape
         Vecd halfsize_wall_outer(0.5 * DW + BW, 0.5 * DL + BW, 0.5 * DH + BW);
         Vecd wall_outer_pos(0.5 * DW, 0.5 * DL, 0.5 * DH);
         Transform translation_wall_outer(wall_outer_pos);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_wall_outer), halfsize_wall_outer);
+        add<GeometricShapeBox>(Transform(translation_wall_outer), halfsize_wall_outer);
 
         Vecd halfsize_wall_inner(0.5 * DW, 0.5 * DL, 0.5 * DH + BW);
         Vecd wall_inner_pos(0.5 * DW, 0.5 * DL, 0.5 * DH + BW);
         Transform translation_wall_inner(wall_inner_pos);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translation_wall_inner), halfsize_wall_inner);
+        subtract<GeometricShapeBox>(Transform(translation_wall_inner), halfsize_wall_inner);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/3d_examples/test_3d_stlw/stlw.cpp
+++ b/tests/3d_examples/test_3d_stlw/stlw.cpp
@@ -73,7 +73,7 @@ int main(int ac, char *av[])
     //	Define the methods for I/O operations and observations of the simulation.
     //----------------------------------------------------------------------
     BodyStatesRecordingToVtp write_real_body_states(sph_system);
-    TransformShape<GeometricShapeBox> wave_probe_buffer_shape(Transform(translation_FS_gauge), FS_gauge);
+    GeometricShapeBox wave_probe_buffer_shape(Transform(translation_FS_gauge), FS_gauge);
     BodyRegionByCell wave_probe_buffer(water_block, wave_probe_buffer_shape);
     RegressionTestDynamicTimeWarping<ReducedQuantityRecording<UpperFrontInAxisDirection<BodyPartByCell>>>
         wave_gauge(wave_probe_buffer, "FreeSurfaceHeight");

--- a/tests/3d_examples/test_3d_stlw/stlw.h
+++ b/tests/3d_examples/test_3d_stlw/stlw.h
@@ -40,7 +40,7 @@ class WaterBlock : public ComplexShape
         Vecd halfsize_water(0.5 * DW, 0.5 * DL, 0.5 * WH);
         Vecd water_pos(0.5 * DW, 0.5 * DL, 0.5 * WH);
         Transform translation_water(water_pos);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_water), halfsize_water);
+        add<GeometricShapeBox>(Transform(translation_water), halfsize_water);
     }
 };
 //----------------------------------------------------------------------
@@ -54,12 +54,12 @@ class WallBoundary : public ComplexShape
         Vecd halfsize_wall_outer(0.5 * DW + BW, 0.5 * DL + BW, 0.5 * DH + BW);
         Vecd wall_outer_pos(0.5 * DW, 0.5 * DL, 0.5 * DH);
         Transform translation_wall_outer(wall_outer_pos);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_wall_outer), halfsize_wall_outer);
+        add<GeometricShapeBox>(Transform(translation_wall_outer), halfsize_wall_outer);
 
         Vecd halfsize_wall_inner(0.5 * DW, 0.5 * DL, 0.5 * DH + BW);
         Vecd wall_inner_pos(0.5 * DW, 0.5 * DL, 0.5 * DH + BW);
         Transform translation_wall_inner(wall_inner_pos);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translation_wall_inner), halfsize_wall_inner);
+        subtract<GeometricShapeBox>(Transform(translation_wall_inner), halfsize_wall_inner);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/3d_examples/test_3d_thin_plate/test_3d_thin_plate.cpp
+++ b/tests/3d_examples/test_3d_thin_plate/test_3d_thin_plate.cpp
@@ -76,8 +76,8 @@ class ParticleGenerator<SurfaceParticles, Plate> : public ParticleGenerator<Surf
 class BoundaryGeometryParallelToXAxis : public BodyPartByParticle
 {
   public:
-    BoundaryGeometryParallelToXAxis(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    BoundaryGeometryParallelToXAxis(SPHBody &body)
+        : BodyPartByParticle(body)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&BoundaryGeometryParallelToXAxis::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -94,8 +94,8 @@ class BoundaryGeometryParallelToXAxis : public BodyPartByParticle
 class BoundaryGeometryParallelToYAxis : public BodyPartByParticle
 {
   public:
-    BoundaryGeometryParallelToYAxis(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    BoundaryGeometryParallelToYAxis(SPHBody &body)
+        : BodyPartByParticle(body)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&BoundaryGeometryParallelToYAxis::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -148,10 +148,10 @@ int main(int ac, char *av[])
     /** Time step size calculation. */
     ReduceDynamics<thin_structure_dynamics::ShellAcousticTimeStepSize> computing_time_step_size(plate_body);
     /** Constrain the Boundary. */
-    BoundaryGeometryParallelToXAxis boundary_geometry_x(plate_body, "BoundaryGeometryParallelToXAxis");
+    BoundaryGeometryParallelToXAxis boundary_geometry_x(plate_body);
     SimpleDynamics<thin_structure_dynamics::ConstrainShellBodyRegionAlongAxis>
         constrain_holder_x(boundary_geometry_x, 0);
-    BoundaryGeometryParallelToYAxis boundary_geometry_y(plate_body, "BoundaryGeometryParallelToYAxis");
+    BoundaryGeometryParallelToYAxis boundary_geometry_y(plate_body);
     SimpleDynamics<thin_structure_dynamics::ConstrainShellBodyRegionAlongAxis>
         constrain_holder_y(boundary_geometry_y, 1);
     DampingWithRandomChoice<InteractionSplit<DampingPairwiseInner<Vec3d, FixedDampingRate>>>

--- a/tests/3d_examples/test_3d_twisting_column/twisting_column.cpp
+++ b/tests/3d_examples/test_3d_twisting_column/twisting_column.cpp
@@ -36,8 +36,8 @@ class Column : public ComplexShape
   public:
     explicit Column(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_column), halfsize_column);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_holder), halfsize_holder);
+        add<GeometricShapeBox>(Transform(translation_column), halfsize_column);
+        add<GeometricShapeBox>(Transform(translation_holder), halfsize_holder);
     }
 };
 //----------------------------------------------------------------------
@@ -110,7 +110,7 @@ int main(int ac, char *av[])
     ReduceDynamics<solid_dynamics::AcousticTimeStep> computing_time_step_size(column, 0.5);
     SimpleDynamics<InitialCondition> initial_condition(column);
 
-    TransformShape<GeometricShapeBox> holder_shape(Transform(translation_holder), halfsize_holder, "Holder");
+    GeometricShapeBox holder_shape(Transform(translation_holder), halfsize_holder, "Holder");
     BodyRegionByParticle holder(column, holder_shape);
     SimpleDynamics<FixBodyPartConstraint> constraint_holder(holder);
     //----------------------------------------------------------------------

--- a/tests/3d_examples/test_3d_twisting_rigid_elastic_bar/test_3d_twisting_rigid_elastic_bar.cpp
+++ b/tests/3d_examples/test_3d_twisting_rigid_elastic_bar/test_3d_twisting_rigid_elastic_bar.cpp
@@ -242,12 +242,12 @@ void run_rigid_elastic_coupling(int res_factor)
     // mesh of the total bar
     const Vec3d halfsize = 0.5 * Vec3d(total_length + constraint_length, height, width);
     const Vec3d translation = (min_x_pos + halfsize.x()) * Vec3d::UnitX() + 0.5 * width * Vec3d::UnitZ();
-    auto mesh = makeShared<TransformShape<GeometricShapeBox>>(Transform(translation), halfsize, "bar");
+    auto mesh = makeShared<GeometricShapeBox>(Transform(translation), halfsize, "bar");
 
     // mesh of the rigid body part
     const Vec3d rigid_halfsize = 0.5 * Vec3d(rigid_length, height, width);
     const Vec3d rigid_translation = (x0 + elastic_length + 0.5 * rigid_length) * Vec3d::UnitX() + 0.5 * width * Vec3d::UnitZ();
-    auto mesh_rigid = makeShared<TransformShape<GeometricShapeBox>>(Transform(rigid_translation), rigid_halfsize, "rigid_bar");
+    auto mesh_rigid = makeShared<GeometricShapeBox>(Transform(rigid_translation), rigid_halfsize, "rigid_bar");
 
     // System bounding box
     auto bbox = mesh->getBounds();

--- a/tests/3d_examples/test_3d_twisting_rigid_elastic_bar/test_3d_twisting_rigid_elastic_bar.cpp
+++ b/tests/3d_examples/test_3d_twisting_rigid_elastic_bar/test_3d_twisting_rigid_elastic_bar.cpp
@@ -31,7 +31,7 @@ class FixPart : public BodyPartByParticle
 
   public:
     FixPart(SPHBody &body, const std::string &body_part_name, std::function<bool(Vec3d &)> contains)
-        : BodyPartByParticle(body, body_part_name),
+        : BodyPartByParticle(body),
           contains_(std::move(contains))
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&FixPart::tagManually, this, _1);

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/bidirectional_buffer.h
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/bidirectional_buffer.h
@@ -57,7 +57,7 @@ class BidirectionalBuffer
     class TagBufferParticles : public BaseLocalDynamics<BodyPartByCell>
     {
       public:
-        TagBufferParticles(AlignedBoxPartByCell &aligned_box_part)
+        TagBufferParticles(AlignedBoxByCell &aligned_box_part)
             : BaseLocalDynamics<BodyPartByCell>(aligned_box_part),
               part_id_(aligned_box_part.getPartID()),
               pos_(particles_->getVariableDataByName<Vecd>("Position")),
@@ -86,7 +86,7 @@ class BidirectionalBuffer
     class Injection : public BaseLocalDynamics<BodyPartByCell>
     {
       public:
-        Injection(AlignedBoxPartByCell &aligned_box_part, ParticleBuffer<Base> &particle_buffer,
+        Injection(AlignedBoxByCell &aligned_box_part, ParticleBuffer<Base> &particle_buffer,
                   TargetPressure &target_pressure)
             : BaseLocalDynamics<BodyPartByCell>(aligned_box_part),
               part_id_(aligned_box_part.getPartID()),
@@ -149,7 +149,7 @@ class BidirectionalBuffer
     class Deletion : public BaseLocalDynamics<BodyPartByCell>
     {
       public:
-        Deletion(AlignedBoxPartByCell &aligned_box_part)
+        Deletion(AlignedBoxByCell &aligned_box_part)
             : BaseLocalDynamics<BodyPartByCell>(aligned_box_part),
               part_id_(aligned_box_part.getPartID()),
               aligned_box_(aligned_box_part.getAlignedBox()),
@@ -181,7 +181,7 @@ class BidirectionalBuffer
     };
 
   public:
-    BidirectionalBuffer(AlignedBoxPartByCell &aligned_box_part, ParticleBuffer<Base> &particle_buffer)
+    BidirectionalBuffer(AlignedBoxByCell &aligned_box_part, ParticleBuffer<Base> &particle_buffer)
         : target_pressure_(*this),
           tag_buffer_particles(aligned_box_part),
           injection(aligned_box_part, particle_buffer, target_pressure_),

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/pressure_boundary.h
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/pressure_boundary.h
@@ -41,7 +41,7 @@ class PressureBoundaryCondition : public BaseFlowBoundaryCondition
 {
   public:
     /** default parameter indicates prescribe pressure */
-    explicit PressureBoundaryCondition(AlignedBoxPartByCell &aligned_box_part)
+    explicit PressureBoundaryCondition(AlignedBoxByCell &aligned_box_part)
         : BaseFlowBoundaryCondition(aligned_box_part),
           aligned_box_(aligned_box_part.getAlignedBox()),
           alignment_axis_(aligned_box_.AlignmentAxis()),
@@ -49,15 +49,15 @@ class PressureBoundaryCondition : public BaseFlowBoundaryCondition
           target_pressure_(*this),
           kernel_sum_(particles_->getVariableDataByName<Vecd>("KernelSummation")),
           kernel_correction_(this->particles_),
-          physical_time_(sph_system_.getSystemVariableDataByName<Real>("PhysicalTime")){};
-    virtual ~PressureBoundaryCondition(){};
+          physical_time_(sph_system_.getSystemVariableDataByName<Real>("PhysicalTime")) {};
+    virtual ~PressureBoundaryCondition() {};
     AlignedBox &getAlignedBox() { return aligned_box_; };
 
     void update(size_t index_i, Real dt = 0.0)
     {
         if (aligned_box_.checkContain(pos_[index_i]))
         {
-            //vel_[index_i] += 2.0 * kernel_sum_[index_i] * target_pressure_(p_[index_i], *physical_time_) / rho_[index_i] * dt;
+            // vel_[index_i] += 2.0 * kernel_sum_[index_i] * target_pressure_(p_[index_i], *physical_time_) / rho_[index_i] * dt;
             vel_[index_i] += 2.0 * kernel_correction_(index_i) * kernel_sum_[index_i] * target_pressure_(p_[index_i], *physical_time_) / rho_[index_i] * dt;
 
             Vecd frame_velocity = Vecd::Zero();

--- a/tests/extra_source_and_tests/test_2d_T_pipe_VIPO_shell/T_pipe_VIPO_shell.cpp
+++ b/tests/extra_source_and_tests/test_2d_T_pipe_VIPO_shell/T_pipe_VIPO_shell.cpp
@@ -220,8 +220,7 @@ struct DownOutflowPressure
 class BoundaryGeometry : public BodyPartByParticle
 {
   public:
-    BoundaryGeometry(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    BoundaryGeometry(SPHBody &body) : BodyPartByParticle(body)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&BoundaryGeometry::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -299,7 +298,7 @@ int main(int ac, char *av[])
     SimpleDynamics<thin_structure_dynamics::AverageShellCurvature> shell_average_curvature(shell_curvature_inner);
     SimpleDynamics<thin_structure_dynamics::UpdateShellNormalDirection> shell_update_normal(shell_body);
     /** Exert constrain on shell. */
-    BoundaryGeometry boundary_geometry(shell_body, "BoundaryGeometry");
+    BoundaryGeometry boundary_geometry(shell_body);
     SimpleDynamics<thin_structure_dynamics::ConstrainShellBodyRegion> constrain_holder(boundary_geometry);
     //----------------------------------------------------------------------
     // Fluid dynamics.
@@ -316,17 +315,17 @@ int main(int ac, char *av[])
     // left buffer
     Vec2d left_buffer_halfsize = Vec2d(0.5 * buffer_width, 0.5 * DH);
     Vec2d left_buffer_translation = Vec2d(-DL_sponge, 0.0) + left_buffer_halfsize;
-    AlignedBoxPartByCell left_emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(left_buffer_translation)), left_buffer_halfsize));
+    AlignedBoxByCell left_emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(left_buffer_translation)), left_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<LeftInflowPressure> left_bidirection_buffer(left_emitter, in_outlet_particle_buffer);
     // up buffer
     Vec2d up_buffer_halfsize = Vec2d(0.5 * buffer_width, 0.75);
     Vec2d up_buffer_translation = Vec2d(0.5 * (DL + DL1), 2.0 * DH - 0.5 * buffer_width);
-    AlignedBoxPartByCell up_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(-0.5 * Pi), Vec2d(up_buffer_translation)), up_buffer_halfsize));
+    AlignedBoxByCell up_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(-0.5 * Pi), Vec2d(up_buffer_translation)), up_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<UpOutflowPressure> right_up_bidirection_buffer(up_emitter, in_outlet_particle_buffer);
     // down buffer
     Vec2d down_buffer_halfsize = Vec2d(0.5 * buffer_width, 0.75);
     Vec2d down_buffer_translation = Vec2d(0.5 * (DL + DL1), -DH + 0.5 * buffer_width);
-    AlignedBoxPartByCell down_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(0.5 * Pi), Vec2d(down_buffer_translation)), down_buffer_halfsize));
+    AlignedBoxByCell down_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(0.5 * Pi), Vec2d(down_buffer_translation)), down_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<DownOutflowPressure> right_down_bidirection_buffer(down_emitter, in_outlet_particle_buffer);
 
     InteractionWithUpdate<fluid_dynamics::DensitySummationPressureComplex> update_fluid_density(water_block_inner, water_shell_contact);

--- a/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -195,9 +195,9 @@ int main(int ac, char *av[])
     ReduceDynamics<fluid_dynamics::AdvectionViscousTimeStep> get_fluid_advection_time_step_size(water_block, U_f);
     ReduceDynamics<fluid_dynamics::AcousticTimeStep> get_fluid_time_step_size(water_block);
 
-    AlignedBoxPartByCell left_emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(left_bidirectional_translation)), bidirectional_buffer_halfsize));
+    AlignedBoxByCell left_emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(left_bidirectional_translation)), bidirectional_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<LeftInflowPressure> left_bidirection_buffer(left_emitter, in_outlet_particle_buffer);
-    AlignedBoxPartByCell right_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(Pi), Vec2d(right_bidirectional_translation)), bidirectional_buffer_halfsize));
+    AlignedBoxByCell right_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(Pi), Vec2d(right_bidirectional_translation)), bidirectional_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<RightInflowPressure> right_bidirection_buffer(right_emitter, in_outlet_particle_buffer);
 
     InteractionWithUpdate<fluid_dynamics::DensitySummationPressureComplex> update_fluid_density(water_block_inner, water_block_contact);

--- a/tests/extra_source_and_tests/test_2d_modified_T_flow/modified_T_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_modified_T_flow/modified_T_flow.cpp
@@ -200,21 +200,21 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     Vec2d left_buffer_halfsize = Vec2d(0.5 * BW, 0.5 * DH);
     Vec2d left_buffer_translation = Vec2d(-DL_sponge, 0.0) + left_buffer_halfsize;
-    AlignedBoxPartByCell left_emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(left_buffer_translation)), left_buffer_halfsize));
+    AlignedBoxByCell left_emitter(water_block, AlignedBox(xAxis, Transform(Vec2d(left_buffer_translation)), left_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<LeftInflowPressure> left_bidirection_buffer(left_emitter, in_outlet_particle_buffer);
     //----------------------------------------------------------------------
     // Up buffer
     //----------------------------------------------------------------------
     Vec2d up_buffer_halfsize = Vec2d(0.5 * BW, 0.75);
     Vec2d up_buffer_translation = Vec2d(0.5 * (DL + DL1), 2.0 * DH - 0.5 * BW);
-    AlignedBoxPartByCell up_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(-0.5 * Pi), Vec2d(up_buffer_translation)), up_buffer_halfsize));
+    AlignedBoxByCell up_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(-0.5 * Pi), Vec2d(up_buffer_translation)), up_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<UpOutflowPressure> up_bidirection_buffer(up_emitter, in_outlet_particle_buffer);
     //----------------------------------------------------------------------
     // Down buffer
     //----------------------------------------------------------------------
     Vec2d down_buffer_halfsize = Vec2d(0.5 * BW, 0.75);
     Vec2d down_buffer_translation = Vec2d(0.5 * (DL + DL1), -DH + 0.5 * BW);
-    AlignedBoxPartByCell down_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(0.5 * Pi), Vec2d(down_buffer_translation)), down_buffer_halfsize));
+    AlignedBoxByCell down_emitter(water_block, AlignedBox(xAxis, Transform(Rotation2d(0.5 * Pi), Vec2d(down_buffer_translation)), down_buffer_halfsize));
     fluid_dynamics::BidirectionalBuffer<DownOutflowPressure> down_bidirection_buffer(down_emitter, in_outlet_particle_buffer);
 
     InteractionWithUpdate<fluid_dynamics::DensitySummationPressureComplex> update_fluid_density(water_block_inner, water_block_contact);

--- a/tests/extra_source_and_tests/test_2d_pulsatile_poiseuille_flow/pulsatile_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/test_2d_pulsatile_poiseuille_flow/pulsatile_poiseuille_flow.cpp
@@ -180,11 +180,11 @@ int main(int ac, char *av[])
     ReduceDynamics<fluid_dynamics::AcousticTimeStep> get_fluid_time_step_size(water_block);
 
     AlignedBox left_emitter_shape(xAxis, Transform(Vec2d(left_bidirectional_translation)), bidirectional_buffer_halfsize);
-    AlignedBoxPartByCell left_emitter(water_block, left_emitter_shape);
+    AlignedBoxByCell left_emitter(water_block, left_emitter_shape);
     fluid_dynamics::BidirectionalBuffer<LeftInflowPressure> left_bidirection_buffer(left_emitter, in_outlet_particle_buffer);
 
     AlignedBox right_emitter_shape(xAxis, Transform(Rotation2d(Pi), Vec2d(right_bidirectional_translation)), bidirectional_buffer_halfsize);
-    AlignedBoxPartByCell right_emitter(water_block, right_emitter_shape);
+    AlignedBoxByCell right_emitter(water_block, right_emitter_shape);
     fluid_dynamics::BidirectionalBuffer<RightInflowPressure> right_bidirection_buffer(right_emitter, in_outlet_particle_buffer);
 
     SimpleDynamics<fluid_dynamics::PressureCondition<LeftInflowPressure>> left_inflow_pressure_condition(left_emitter);

--- a/tests/extra_source_and_tests/test_2d_turbulent_channel/test_2d_turbulent_channel.cpp
+++ b/tests/extra_source_and_tests/test_2d_turbulent_channel/test_2d_turbulent_channel.cpp
@@ -131,7 +131,7 @@ int main(int ac, char *av[])
     // Left/Inlet buffer
     //----------------------------------------------------------------------
     AlignedBox left_emitter_shape(xAxis, Transform(Vec2d(left_buffer_translation)), left_buffer_halfsize);
-    AlignedBoxPartByCell left_emitter(water_block, left_emitter_shape);
+    AlignedBoxByCell left_emitter(water_block, left_emitter_shape);
     fluid_dynamics::BidirectionalBuffer<LeftInflowPressure> left_bidirection_buffer(left_emitter, inlet_particle_buffer);
 
     SimpleDynamics<fluid_dynamics::PressureConditionCorrection<LeftInflowPressure>> left_inflow_pressure_condition(left_emitter);
@@ -142,7 +142,7 @@ int main(int ac, char *av[])
     // Right/Outlet buffer
     //----------------------------------------------------------------------
     AlignedBox right_emitter_shape(xAxis, Transform(Rotation2d(Pi), Vec2d(right_buffer_translation)), right_buffer_halfsize);
-    AlignedBoxPartByCell right_emitter(water_block, right_emitter_shape);
+    AlignedBoxByCell right_emitter(water_block, right_emitter_shape);
     fluid_dynamics::BidirectionalBuffer<RightOutflowPressure> right_bidirection_buffer(right_emitter, inlet_particle_buffer);
     SimpleDynamics<fluid_dynamics::PressureConditionCorrection<RightOutflowPressure>> right_outflow_pressure_condition(right_emitter);
     //----------------------------------------------------------------------

--- a/tests/extra_source_and_tests/test_3d_passive_cantilever_LG/passive_cantilever_LG.cpp
+++ b/tests/extra_source_and_tests/test_3d_passive_cantilever_LG/passive_cantilever_LG.cpp
@@ -41,8 +41,8 @@ class Cantilever : public ComplexShape
   public:
     explicit Cantilever(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_cantilever), halfsize_cantilever);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_holder), halfsize_holder);
+        add<GeometricShapeBox>(Transform(translation_cantilever), halfsize_cantilever);
+        add<GeometricShapeBox>(Transform(translation_holder), halfsize_holder);
     }
 };
 /**
@@ -97,7 +97,7 @@ int main(int ac, char *av[])
     ReduceDynamics<solid_dynamics::AcousticTimeStep> computing_time_step_size(cantilever_body, 0.3);
     SimpleDynamics<CantileverInitialCondition> initialization(cantilever_body);
 
-    TransformShape<GeometricShapeBox> holder_shape(Transform(translation_holder), halfsize_holder, "Holder");
+    GeometricShapeBox holder_shape(Transform(translation_holder), halfsize_holder, "Holder");
     BodyRegionByParticle holder(cantilever_body, holder_shape);
     SimpleDynamics<FixBodyPartConstraint> constraint_holder(holder);
     /** Output */

--- a/tests/test_python_interface/test_2d_dambreak_python/dambreak_python.cpp
+++ b/tests/test_python_interface/test_2d_dambreak_python/dambreak_python.cpp
@@ -47,8 +47,8 @@ class WallBoundary : public ComplexShape, public Parameter
   public:
     explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 //----------------------------------------------------------------------
@@ -70,7 +70,7 @@ class PreSettingCase : public Parameter
         : system_domain_bounds(Vec2d(-BW, -BW), Vec2d(DL + BW, DH + BW)),
           sph_system(system_domain_bounds, particle_spacing_ref),
           io_environment(sph_system),
-          water_block(sph_system, makeShared<TransformShape<GeometricShapeBox>>(
+          water_block(sph_system, makeShared<GeometricShapeBox>(
                                       Transform(water_block_translation), water_block_halfsize, "WaterBody")),
           wall_boundary(sph_system, makeShared<WallBoundary>("WallBoundary")),
           observation_location({Vecd(DL, 0.2)}),

--- a/tests/test_python_interface/test_3d_thin_plate_python/thin_plate_python.cpp
+++ b/tests/test_python_interface/test_3d_thin_plate_python/thin_plate_python.cpp
@@ -68,8 +68,7 @@ class ParticleGenerator<SurfaceParticles, Plate> : public ParticleGenerator<Surf
 class BoundaryGeometryParallelToXAxis : public BodyPartByParticle, public Parameter
 {
   public:
-    BoundaryGeometryParallelToXAxis(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    BoundaryGeometryParallelToXAxis(SPHBody &body) : BodyPartByParticle(body)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&BoundaryGeometryParallelToXAxis::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -86,8 +85,7 @@ class BoundaryGeometryParallelToXAxis : public BodyPartByParticle, public Parame
 class BoundaryGeometryParallelToYAxis : public BodyPartByParticle, public Parameter
 {
   public:
-    BoundaryGeometryParallelToYAxis(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    BoundaryGeometryParallelToYAxis(SPHBody &body) : BodyPartByParticle(body)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&BoundaryGeometryParallelToYAxis::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -206,9 +204,9 @@ class Environment : public PreSettingCase
           stress_relaxation_second_half(plate_body_inner),
           corrected_configuration(plate_body_inner),
           computing_time_step_size(plate_body),
-          boundary_geometry_x(plate_body, "BoundaryGeometryParallelToXAxis"),
+          boundary_geometry_x(plate_body),
           constrain_holder_x(boundary_geometry_x, 0),
-          boundary_geometry_y(plate_body, "BoundaryGeometryParallelToYAxis"),
+          boundary_geometry_y(plate_body),
           constrain_holder_y(boundary_geometry_y, 1),
           plate_position_damping(0.5, plate_body_inner, "Velocity", physical_viscosity),
           plate_rotation_damping(0.5, plate_body_inner, "AngularVelocity", physical_viscosity),

--- a/tests/tests_sycl/2d_examples/test_2d_column_collapse_sycl/column_collapse_sycl.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_column_collapse_sycl/column_collapse_sycl.cpp
@@ -44,8 +44,8 @@ class WallBoundary : public ComplexShape
   public:
     explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 std::vector<Vecd> soil_shape{
@@ -72,7 +72,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating bodies with corresponding materials and particles.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox> initial_soil_block(Transform(soil_block_translation), soil_block_halfsize, "GranularBody");
+    GeometricShapeBox initial_soil_block(Transform(soil_block_translation), soil_block_halfsize, "GranularBody");
     RealBody soil_block(sph_system, initial_soil_block);
     soil_block.defineMaterial<PlasticContinuum>(rho0_s, c_s, Youngs_modulus, poisson, friction_angle);
     soil_block.generateParticles<BaseParticles, Lattice>();

--- a/tests/tests_sycl/2d_examples/test_2d_dambreak_sycl/dambreak_sycl.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_dambreak_sycl/dambreak_sycl.cpp
@@ -39,8 +39,8 @@ class WallBoundary : public ComplexShape
   public:
     explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 //----------------------------------------------------------------------
@@ -57,7 +57,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating bodies with corresponding materials and particles.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox> initial_water_block(Transform(water_block_translation), water_block_halfsize, "WaterBody");
+    GeometricShapeBox initial_water_block(Transform(water_block_translation), water_block_halfsize, "WaterBody");
     FluidBody water_block(sph_system, initial_water_block);
     water_block.defineMaterial<WeaklyCompressibleFluid>(rho0_f, c_f);
     water_block.generateParticles<BaseParticles, Lattice>();

--- a/tests/tests_sycl/2d_examples/test_2d_filling_tank_sycl/filling_tank_sycl.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_filling_tank_sycl/filling_tank_sycl.cpp
@@ -115,7 +115,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating body parts.
     //----------------------------------------------------------------------
-    AlignedBoxPartByParticle emitter(water_body, AlignedBox(xAxis, Transform(inlet_translation), inlet_halfsize));
+    AlignedBoxByParticle emitter(water_body, AlignedBox(xAxis, Transform(inlet_translation), inlet_halfsize));
     //----------------------------------------------------------------------
     //	Define body relation map.
     //	The contact map gives the topological connections between the bodies.
@@ -162,8 +162,8 @@ int main(int ac, char *av[])
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AdvectionTimeStepCK> fluid_advection_time_step(water_body, U_f);
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK<>> fluid_acoustic_time_step(water_body);
 
-    StateDynamics<MainExecutionPolicy, fluid_dynamics::EmitterInflowConditionCK<AlignedBoxPartByParticle, InletInflowCondition>> inflow_condition(emitter);
-    StateDynamics<MainExecutionPolicy, fluid_dynamics::EmitterInflowInjectionCK<AlignedBoxPartByParticle>> emitter_injection(emitter, inlet_buffer);
+    StateDynamics<MainExecutionPolicy, fluid_dynamics::EmitterInflowConditionCK<AlignedBoxByParticle, InletInflowCondition>> inflow_condition(emitter);
+    StateDynamics<MainExecutionPolicy, fluid_dynamics::EmitterInflowInjectionCK<AlignedBoxByParticle>> emitter_injection(emitter, inlet_buffer);
     //----------------------------------------------------------------------
     //	Define the methods for I/O operations, observations
     //	and regression tests of the simulation.

--- a/tests/tests_sycl/2d_examples/test_2d_filling_tank_sycl/filling_tank_sycl.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_filling_tank_sycl/filling_tank_sycl.cpp
@@ -100,7 +100,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating body, materials and particles.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox> water_inlet_shape(Transform(inlet_translation), inlet_halfsize);
+    GeometricShapeBox water_inlet_shape(Transform(inlet_translation), inlet_halfsize);
     FluidBody water_body(sph_system, water_inlet_shape, "WaterBody");
     water_body.defineMaterial<WeaklyCompressibleFluid>(rho0_f, c_f);
     ParticleBuffer<ReserveSizeFactor> inlet_buffer(350.0);

--- a/tests/tests_sycl/2d_examples/test_2d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -263,8 +263,8 @@ int main(int ac, char *av[])
     // //----------------------------------------------------------------------
     // //	Creating body parts.
     // //----------------------------------------------------------------------
-    AlignedBoxPartByCell left_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(left_bidirectional_translation), bidirectional_buffer_halfsize));
-    AlignedBoxPartByCell right_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(Rotation2d(Pi), Vec2d(right_disposer_translation)), bidirectional_buffer_halfsize));
+    AlignedBoxByCell left_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(left_bidirectional_translation), bidirectional_buffer_halfsize));
+    AlignedBoxByCell right_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(Rotation2d(Pi), Vec2d(right_disposer_translation)), bidirectional_buffer_halfsize));
     //----------------------------------------------------------------------
     //	Define body relation map.
     //	The contact map gives the topological connections between the bodies.

--- a/tests/tests_sycl/2d_examples/test_2d_stfb_sycl/stfb.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_stfb_sycl/stfb.cpp
@@ -81,8 +81,8 @@ class WallBoundary : public ComplexShape
   public:
     explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 class WaterBlock : public ComplexShape
@@ -90,8 +90,8 @@ class WaterBlock : public ComplexShape
   public:
     explicit WaterBlock(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(water_block_translation), water_block_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(structure_translation), structure_halfsize);
+        add<GeometricShapeBox>(Transform(water_block_translation), water_block_halfsize);
+        subtract<GeometricShapeBox>(Transform(structure_translation), structure_halfsize);
     }
 };
 //----------------------------------------------------------------------
@@ -120,7 +120,7 @@ int main(int ac, char *av[])
     wall_boundary.defineMaterial<Solid>();
     wall_boundary.generateParticles<BaseParticles, Lattice>();
 
-    TransformShape<GeometricShapeBox> structure_shape(Transform(structure_translation), structure_halfsize, "Structure");
+    GeometricShapeBox structure_shape(Transform(structure_translation), structure_halfsize, "Structure");
     SolidBody structure(sph_system, structure_shape);
     structure.defineMaterial<Solid>(rho_s);
     structure.generateParticles<BaseParticles, Lattice>();
@@ -131,7 +131,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating body parts.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox> wave_probe_buffer_shape(Transform(gauge_translation), gauge_halfsize, "FreeSurfaceGauge");
+    GeometricShapeBox wave_probe_buffer_shape(Transform(gauge_translation), gauge_halfsize, "FreeSurfaceGauge");
     BodyRegionByCell wave_probe_buffer(water_block, wave_probe_buffer_shape);
     //----------------------------------------------------------------------
     //	Define body relation map.

--- a/tests/tests_sycl/2d_examples/test_2d_still_water_sycl/stlw_sycl.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_still_water_sycl/stlw_sycl.cpp
@@ -46,8 +46,8 @@ class WallBoundary : public ComplexShape
   public:
     explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 
@@ -61,7 +61,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating body, materials and particles.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox> water_body_shape(Transform(water_body_translation), water_body_halfsize, "WaterBody");
+    GeometricShapeBox water_body_shape(Transform(water_body_translation), water_body_halfsize, "WaterBody");
     FluidBody water_body(sph_system, water_body_shape);
     water_body.defineClosure<WeaklyCompressibleFluid, Viscosity>(ConstructArgs(rho0_f, c_f), mu_f);
     water_body.generateParticles<BaseParticles, Lattice>();
@@ -72,7 +72,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating body parts.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox> wave_probe_buffer_shape(Transform(gauge_translation), gauge_halfsize, "FreeSurfaceGauge");
+    GeometricShapeBox wave_probe_buffer_shape(Transform(gauge_translation), gauge_halfsize, "FreeSurfaceGauge");
     BodyRegionByCell wave_probe_buffer(water_body, wave_probe_buffer_shape);
     //----------------------------------------------------------------------
     //	Define body relation map.

--- a/tests/tests_sycl/3d_examples/test_3d_dambreak_sycl/dambreak.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_dambreak_sycl/dambreak.cpp
@@ -33,7 +33,7 @@ class WaterBlock : public ComplexShape
     {
         Vecd halfsize_water(0.5 * LL, 0.5 * LH, 0.5 * LW);
         Transform translation_water(halfsize_water);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_water), halfsize_water);
+        add<GeometricShapeBox>(Transform(translation_water), halfsize_water);
     }
 };
 
@@ -45,8 +45,8 @@ class WallBoundary : public ComplexShape //	define the static solid wall boundar
         Vecd halfsize_outer(0.5 * DL + BW, 0.5 * DH + BW, 0.5 * DW + BW);
         Vecd halfsize_inner(0.5 * DL, 0.5 * DH, 0.5 * DW);
         Transform translation_wall(halfsize_inner);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_wall), halfsize_outer);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translation_wall), halfsize_inner);
+        add<GeometricShapeBox>(Transform(translation_wall), halfsize_outer);
+        subtract<GeometricShapeBox>(Transform(translation_wall), halfsize_inner);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -238,13 +238,13 @@ int main(int ac, char *av[])
     // //----------------------------------------------------------------------
     // //	Creating body parts.
     // //----------------------------------------------------------------------
-    AlignedBoxPartByCell left_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(left_bidirectional_translation), bidirectional_buffer_halfsize));
+    AlignedBoxByCell left_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(left_bidirectional_translation), bidirectional_buffer_halfsize));
     auto defulat_normal = Vec3d::UnitX();
     auto rotated_normal = -1 * Vec3d::UnitX();
     auto rotation_axis = Vec3d::UnitY();
     auto rot3d = Rotation3d(std::acos(defulat_normal.dot(rotated_normal)), rotation_axis);
-    AlignedBoxPartByCell right_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(rot3d, right_bidirectional_translation), bidirectional_buffer_halfsize));
-    // AlignedBoxPartByCell right_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(left_bidirectional_translation), bidirectional_buffer_halfsize));
+    AlignedBoxByCell right_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(rot3d, right_bidirectional_translation), bidirectional_buffer_halfsize));
+    // AlignedBoxByCell right_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(left_bidirectional_translation), bidirectional_buffer_halfsize));
     //----------------------------------------------------------------------
     //	Define body relation map.
     //	The contact map gives the topological connections between the bodies.

--- a/tests/tests_sycl/3d_examples/test_3d_repose_angle_sycl/repose_angle_sycl.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_repose_angle_sycl/repose_angle_sycl.cpp
@@ -44,8 +44,8 @@ class WallBoundary : public ComplexShape
         Vecd outer_wall_translation = Vecd(-BW, -BW, -BW) + outer_wall_halfsize;
         Vecd inner_wall_halfsize = Vecd(0.5 * DL, 0.5 * DH, 0.5 * DW);
         Vecd inner_wall_translation = inner_wall_halfsize;
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/tests_sycl/3d_examples/test_3d_stfb_sycl/stfb.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_stfb_sycl/stfb.cpp
@@ -60,7 +60,7 @@ class FloatingStructure : public ComplexShape
   public:
     explicit FloatingStructure(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_str), halfsize_structure);
+        add<GeometricShapeBox>(Transform(translation_str), halfsize_structure);
     }
 };
 
@@ -89,8 +89,8 @@ class WaterBlock : public ComplexShape
         Vecd halfsize_water(0.5 * DW, 0.5 * DL, 0.5 * WH);
         Vecd water_pos(0.5 * DW, 0.5 * DL, 0.5 * WH);
         Transform translation_water(water_pos);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_water), halfsize_water);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translation_str), halfsize_structure);
+        add<GeometricShapeBox>(Transform(translation_water), halfsize_water);
+        subtract<GeometricShapeBox>(Transform(translation_str), halfsize_structure);
     }
 };
 //----------------------------------------------------------------------
@@ -104,12 +104,12 @@ class WallBoundary : public ComplexShape
         Vecd halfsize_wall_outer(0.5 * DW + BW, 0.5 * DL + BW, 0.5 * DH + BW);
         Vecd wall_outer_pos(0.5 * DW, 0.5 * DL, 0.5 * DH);
         Transform translation_wall_outer(wall_outer_pos);
-        add<TransformShape<GeometricShapeBox>>(Transform(translation_wall_outer), halfsize_wall_outer);
+        add<GeometricShapeBox>(Transform(translation_wall_outer), halfsize_wall_outer);
 
         Vecd halfsize_wall_inner(0.5 * DW, 0.5 * DL, 0.5 * DH + BW);
         Vecd wall_inner_pos(0.5 * DW, 0.5 * DL, 0.5 * DH + BW);
         Transform translation_wall_inner(wall_inner_pos);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translation_wall_inner), halfsize_wall_inner);
+        subtract<GeometricShapeBox>(Transform(translation_wall_inner), halfsize_wall_inner);
     }
 };
 //----------------------------------------------------------------------
@@ -155,7 +155,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     //	Creating body parts.
     //----------------------------------------------------------------------
-    TransformShape<GeometricShapeBox> wave_probe_buffer_shape(Transform(translation_FS_gauge), FS_gauge);
+    GeometricShapeBox wave_probe_buffer_shape(Transform(translation_FS_gauge), FS_gauge);
     BodyRegionByCell wave_probe_buffer(water_block, wave_probe_buffer_shape);
 
     BodySurfaceLayer structure_surface(structure, 1.0);
@@ -244,7 +244,7 @@ int main(int ac, char *av[])
     /** the forces of the system. */
     SimTK::GeneralForceSubsystem forces(MBsystem);
     /** mass properties of the fixed spot. */
-    TransformShape<GeometricShapeBox> fix_spot_shape(Transform(translation_str), halfsize_structure);
+    GeometricShapeBox fix_spot_shape(Transform(translation_str), halfsize_structure);
     StructureSystemForSimbody structure_multibody(structure, fix_spot_shape);
     /** Mass properties of the constrained spot.
      * SimTK::MassProperties(mass, center of mass, inertia)

--- a/tests/tests_sycl/unit_test_src/shared/particle_dynamics/general_dynamics/unit_test_gradient_sycl/2d_gradient.cpp
+++ b/tests/tests_sycl/unit_test_src/shared/particle_dynamics/general_dynamics/unit_test_gradient_sycl/2d_gradient.cpp
@@ -30,7 +30,7 @@ class WaterBlock : public ComplexShape
     {
         Vecd container(0.5 * width, 0.5 * height);
         Transform translate_to_origin(container);
-        add<TransformShape<GeometricShapeBox>>(Transform(translate_to_origin), container);
+        add<GeometricShapeBox>(Transform(translate_to_origin), container);
     }
 };
 class WallBoundary : public ComplexShape
@@ -43,8 +43,8 @@ class WallBoundary : public ComplexShape
         Transform translate_to_origin_outer(Vec2d(-boundary_width, -boundary_width) + container_outer);
         Transform translate_to_origin_inner(Vec2d(-boundary_width, 0.0) + container);
 
-        add<TransformShape<GeometricShapeBox>>(Transform(translate_to_origin_outer), container_outer);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translate_to_origin_inner), container);
+        add<GeometricShapeBox>(Transform(translate_to_origin_outer), container_outer);
+        subtract<GeometricShapeBox>(Transform(translate_to_origin_inner), container);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/tests_sycl/unit_test_src/shared/particle_dynamics/general_dynamics/unit_test_interpolation_sycl/2d_interpolation.cpp
+++ b/tests/tests_sycl/unit_test_src/shared/particle_dynamics/general_dynamics/unit_test_interpolation_sycl/2d_interpolation.cpp
@@ -39,7 +39,7 @@ class WaterBlock : public ComplexShape
     {
         Vecd scaled_container(0.5 * width, 0.5 * height);
         Transform translate_to_origin(scaled_container);
-        add<TransformShape<GeometricShapeBox>>(Transform(translate_to_origin), scaled_container);
+        add<GeometricShapeBox>(Transform(translate_to_origin), scaled_container);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/unit_tests_src/for_2D_build/geometries/test_2d_geometric_shape/test_geometric_shape.cpp
+++ b/tests/unit_tests_src/for_2D_build/geometries/test_2d_geometric_shape/test_geometric_shape.cpp
@@ -20,8 +20,8 @@ class WallBoundary : public ComplexShape
   public:
     explicit WallBoundary(const std::string &shape_name) : ComplexShape(shape_name)
     {
-        add<TransformShape<GeometricShapeBox>>(Transform(outer_wall_translation), outer_wall_halfsize);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(inner_wall_translation), inner_wall_halfsize);
+        add<GeometricShapeBox>(Transform(outer_wall_translation), outer_wall_halfsize);
+        subtract<GeometricShapeBox>(Transform(inner_wall_translation), inner_wall_halfsize);
     }
 };
 Vec2d test_point(0.1, -0.025);
@@ -30,7 +30,7 @@ auto tolerance = []()
 
 TEST(test_GeometricShapeBox, test_closest_point)
 {
-    TransformShape<GeometricShapeBox> inner_wall_box(Transform(inner_wall_translation), inner_wall_halfsize);
+    GeometricShapeBox inner_wall_box(Transform(inner_wall_translation), inner_wall_halfsize);
 
     EXPECT_LE((inner_wall_box.findClosestPoint(test_point) - Vec2d(0.1, 0.0)).cwiseAbs().maxCoeff(), tolerance());
 }

--- a/tests/unit_tests_src/for_3D_build/geometrices/test_3d_geometric_shape/test_geometric_shape.cpp
+++ b/tests/unit_tests_src/for_3D_build/geometrices/test_3d_geometric_shape/test_geometric_shape.cpp
@@ -9,7 +9,7 @@ TEST(test_GeometricShapeBox, test_findBounds)
     Vec3d halfsize(1.0, 0.5, 0.25);
     Transform transform(Vec3d(1.0, 0.5, 0.25));
 
-    TransformShape<GeometricShapeBox> brick(transform, halfsize);
+    GeometricShapeBox brick(transform, halfsize);
     BoundingBox box = brick.getBounds();
 
     EXPECT_EQ(BoundingBox(Vec3d(0.0, 0.0, 0.0), Vec3d(2.0, 1.0, 0.5)), box);

--- a/tests/unit_tests_src/for_3D_build/meshes/test_3d_particle_for_split/test_particle_for_split.cpp
+++ b/tests/unit_tests_src/for_3D_build/meshes/test_3d_particle_for_split/test_particle_for_split.cpp
@@ -8,7 +8,7 @@ TEST(test_meshes, split_for)
     Real length = 10;
     Real dp = 1;
 
-    auto shape = makeShared<GeometricShapeBox>(0.5 * length * Vec3d::Ones(), "Shape");
+    auto shape = makeShared<GeometricShapeBox>(Transform(), 0.5 * length * Vec3d::Ones(), "Shape");
 
     BoundingBox bb_system = shape->getBounds();
 

--- a/tests/unit_tests_src/shared/geometries/test_complex_shape/test_complex_shape.cpp
+++ b/tests/unit_tests_src/shared/geometries/test_complex_shape/test_complex_shape.cpp
@@ -12,8 +12,8 @@ TEST(test_ComplexShape, test_findNormalDirection)
     Transform transfrom(Vec3d(1.0, 0.5, 0.25));
 
     ComplexShape body_shape("TestShape");
-    body_shape.add<TransformShape<GeometricShapeBox>>(transfrom, halfsize_outer);
-    body_shape.subtract<TransformShape<GeometricShapeBox>>(transfrom, halfsize_inner);
+    body_shape.add<GeometricShapeBox>(transfrom, halfsize_outer);
+    body_shape.subtract<GeometricShapeBox>(transfrom, halfsize_inner);
     Vec3d point(1.0, 0.5, -0.095);
     Vec3d normal = body_shape.findNormalDirection(point);
 

--- a/tests/unit_tests_src/shared/particle_dynamics/fluid_dynamics/test_2d_velocity_gradient/2d_velocity_gradient.cpp
+++ b/tests/unit_tests_src/shared/particle_dynamics/fluid_dynamics/test_2d_velocity_gradient/2d_velocity_gradient.cpp
@@ -46,7 +46,7 @@ class UpperBoundary : public ComplexShape
         Transform translate_to_origin(scaled_container);
         Vecd transform(-boundary_width, height);
         Transform translate_to_position(transform + scaled_container);
-        add<TransformShape<GeometricShapeBox>>(Transform(translate_to_position), scaled_container);
+        add<GeometricShapeBox>(Transform(translate_to_position), scaled_container);
     }
 };
 class WallBoundary : public ComplexShape
@@ -59,8 +59,8 @@ class WallBoundary : public ComplexShape
         Transform translate_to_origin_outer(Vec2d(-boundary_width, -boundary_width) + scaled_container_outer);
         Transform translate_to_origin_inner(Vec2d(-boundary_width, 0.0) + scaled_container);
 
-        add<TransformShape<GeometricShapeBox>>(Transform(translate_to_origin_outer), scaled_container_outer);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translate_to_origin_inner), scaled_container);
+        add<GeometricShapeBox>(Transform(translate_to_origin_outer), scaled_container_outer);
+        subtract<GeometricShapeBox>(Transform(translate_to_origin_inner), scaled_container);
     }
 };
 class WaterBlock : public ComplexShape
@@ -70,7 +70,7 @@ class WaterBlock : public ComplexShape
     {
         Vecd scaled_container(0.5 * width, 0.5 * height);
         Transform translate_to_origin(scaled_container);
-        add<TransformShape<GeometricShapeBox>>(Transform(translate_to_origin), scaled_container);
+        add<GeometricShapeBox>(Transform(translate_to_origin), scaled_container);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/unit_tests_src/shared/particle_dynamics/general_dynamics/unit_test_gradient_ck/2d_gradient.cpp
+++ b/tests/unit_tests_src/shared/particle_dynamics/general_dynamics/unit_test_gradient_ck/2d_gradient.cpp
@@ -30,7 +30,7 @@ class WaterBlock : public ComplexShape
     {
         Vecd container(0.5 * width, 0.5 * height);
         Transform translate_to_origin(container);
-        add<TransformShape<GeometricShapeBox>>(Transform(translate_to_origin), container);
+        add<GeometricShapeBox>(Transform(translate_to_origin), container);
     }
 };
 class WallBoundary : public ComplexShape
@@ -43,8 +43,8 @@ class WallBoundary : public ComplexShape
         Transform translate_to_origin_outer(Vec2d(-boundary_width, -boundary_width) + container_outer);
         Transform translate_to_origin_inner(Vec2d(-boundary_width, 0.0) + container);
 
-        add<TransformShape<GeometricShapeBox>>(Transform(translate_to_origin_outer), container_outer);
-        subtract<TransformShape<GeometricShapeBox>>(Transform(translate_to_origin_inner), container);
+        add<GeometricShapeBox>(Transform(translate_to_origin_outer), container_outer);
+        subtract<GeometricShapeBox>(Transform(translate_to_origin_inner), container);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/unit_tests_src/shared/particle_dynamics/general_dynamics/unit_test_interpolation_ck/2d_interpolation.cpp
+++ b/tests/unit_tests_src/shared/particle_dynamics/general_dynamics/unit_test_interpolation_ck/2d_interpolation.cpp
@@ -39,7 +39,7 @@ class WaterBlock : public ComplexShape
     {
         Vecd scaled_container(0.5 * width, 0.5 * height);
         Transform translate_to_origin(scaled_container);
-        add<TransformShape<GeometricShapeBox>>(Transform(translate_to_origin), scaled_container);
+        add<GeometricShapeBox>(Transform(translate_to_origin), scaled_container);
     }
 };
 //----------------------------------------------------------------------

--- a/tests/unit_tests_src/shared/particle_dynamics/solid_dynamics/test_thin_structure_dynamics/test_thin_structure_dynamics.cpp
+++ b/tests/unit_tests_src/shared/particle_dynamics/solid_dynamics/test_thin_structure_dynamics/test_thin_structure_dynamics.cpp
@@ -78,8 +78,7 @@ class ParticleGenerator<SurfaceParticles, Plate> : public ParticleGenerator<Surf
 class ControlledGeometry : public BodyPartByParticle
 {
   public:
-    ControlledGeometry(SPHBody &body, const std::string &body_part_name)
-        : BodyPartByParticle(body, body_part_name)
+    ControlledGeometry(SPHBody &body) : BodyPartByParticle(body)
     {
         TaggingParticleMethod tagging_particle_method = std::bind(&ControlledGeometry::tagManually, this, _1);
         tagParticles(tagging_particle_method);
@@ -155,7 +154,7 @@ int main(int ac, char *av[])
     /** Time step size calculation. */
     ReduceDynamics<thin_structure_dynamics::ShellAcousticTimeStepSize> computing_time_step_size(plate_body);
     /** Constrain the Boundary. */
-    ControlledGeometry controlled_geometry(plate_body, "ControlledGeometry");
+    ControlledGeometry controlled_geometry(plate_body);
     SimpleDynamics<ControlledRotation> controlled_rotation(controlled_geometry);
     SimpleDynamics<thin_structure_dynamics::UpdateShellNormalDirection> update_normal(plate_body);
     /** File and screen outputs */


### PR DESCRIPTION
naming and refactoring
This pull request refactors the `BodyPart` class hierarchy and associated methods to simplify naming conventions, improve consistency, and enhance functionality. The most significant changes include removing redundant name-based parameters, introducing new identifiers, and updating related methods and classes to align with the new design.

### Refactoring of `BodyPart` and Derived Classes

* Removed the `body_part_name` parameter from the `BodyPart` constructor and replaced it with an auto-generated `part_name` based on the `SPHBody` name and part ID. This change simplifies the creation of body parts and ensures unique naming. (`[[1]](diffhunk://#diff-f1c10084a4ad0b18bcc8b6ec8a5b36cc53aae0e943a7580524e9729e5ce9ccecL8-R25)`, `[[2]](diffhunk://#diff-d6e7fed8f35c0f6a75461bc22dbb6dfeb49c4165d573ddab5e0f2187945fcf51L50-R97)`)
* Updated the `BodyPartByParticle` and `BodyPartByCell` classes to remove redundant name-based variables like `dv_body_part_indicator` and replace them with `dv_body_part_id`. This ensures a more consistent and streamlined approach to identifying body parts. (`[[1]](diffhunk://#diff-f1c10084a4ad0b18bcc8b6ec8a5b36cc53aae0e943a7580524e9729e5ce9ccecL45-R63)`, `[[2]](diffhunk://#diff-f1c10084a4ad0b18bcc8b6ec8a5b36cc53aae0e943a7580524e9729e5ce9ccecL81-R97)`)
* Simplified constructors for derived classes such as `BodyRegionByParticle`, `BodySurface`, and `AlignedBoxByParticle` by removing the need for explicit name parameters. (`[[1]](diffhunk://#diff-f1c10084a4ad0b18bcc8b6ec8a5b36cc53aae0e943a7580524e9729e5ce9ccecL143-R145)`, `[[2]](diffhunk://#diff-f1c10084a4ad0b18bcc8b6ec8a5b36cc53aae0e943a7580524e9729e5ce9ccecL199-R226)`, `[[3]](diffhunk://#diff-d6e7fed8f35c0f6a75461bc22dbb6dfeb49c4165d573ddab5e0f2187945fcf51L251-R274)`)

### New Features and Enhancements

* Introduced a `TargetParticleMask` template within the `BodyPart` class to enable flexible particle selection criteria based on part IDs. This feature enhances usability for defining custom operations on specific body parts. (`F76fcbaeL47R105`)
* Added a new method `findBounds` to the `GeometricBox` class, which computes the bounding box for the geometric element. (`[src/shared/geometries/geometric_element.cppR61-R65](diffhunk://#diff-00e4f08765d75f15b09282f4fc6f1406fcc0409f652c9b77161fa891f3081998R61-R65)`)

### Updates to Related Files and Tests

* Updated test cases in `aortic_valve.cpp` to reflect the removal of `body_part_name` from the `BoundaryGeometry` constructor. (`[[1]](diffhunk://#diff-5cca611ebbf4539e40dc27232e689e03b67ebe541cb4ffd232747c8d52063461L39-R39)`, `[[2]](diffhunk://#diff-5cca611ebbf4539e40dc27232e689e03b67ebe541cb4ffd232747c8d52063461L157-R156)`)
* Adjusted naming conventions for classes like `AlignedBoxPartByParticle` and `AlignedBoxPartByCell` to `AlignedBoxByParticle` and `AlignedBoxByCell`, respectively, for consistency. (`[[1]](diffhunk://#diff-d6e7fed8f35c0f6a75461bc22dbb6dfeb49c4165d573ddab5e0f2187945fcf51L251-R274)`, `[[2]](diffhunk://#diff-f1c10084a4ad0b18bcc8b6ec8a5b36cc53aae0e943a7580524e9729e5ce9ccecL199-R226)`)

These changes improve code maintainability, reduce redundancy, and align the design with modern C++ practices.