### PR TITLE
using new error measure to avoid compare value near zero

### DIFF
--- a/tests/2d_examples/2d_examples_ck/test_2d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
@@ -183,7 +183,7 @@ int velocity_validation(
 
         Real error = std::abs((vel_x_simulation - vel_x_analytical) / U_f);
         std::ostringstream msg;
-        msg << "Mismatch at observer index " << index
+        msg << "Measure at observer index " << index
             << " | Analytical: " << vel_x_analytical
             << " | Simulation: " << vel_x_simulation
             << " | Error: " << error;
@@ -312,8 +312,6 @@ int main(int ac, char *av[])
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK<>> fluid_acoustic_time_step(water_body);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::ViscousForceWithWallCK>
         fluid_viscous_force(water_body_inner, water_wall_contact);
-    InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityLimitedCorrectionCorrectedComplexBulkParticlesCKWithoutUpdate>
-        zero_gradient_ck(water_body_inner, water_wall_contact);
     fluid_dynamics::BidirectionalBoundaryCK<MainExecutionPolicy, LinearCorrectionCK, InflowVelocityPrescribed>
         bidirectional_velocity_condition_left(left_emitter_by_cell, particle_buffer, DH, U_f, mu_f);
     fluid_dynamics::BidirectionalBoundaryCK<MainExecutionPolicy, LinearCorrectionCK, PressurePrescribed<>>
@@ -386,7 +384,6 @@ int main(int ac, char *av[])
             {
                 acoustic_dt = SMIN(fluid_acoustic_time_step.exec(), advection_dt);
                 fluid_acoustic_step_1st_half.exec(acoustic_dt);
-                zero_gradient_ck.exec();
                 bidirectional_velocity_condition_left.applyBoundaryCondition(acoustic_dt);
                 bidirectional_pressure_condition_right.applyBoundaryCondition(acoustic_dt);
                 fluid_acoustic_step_2nd_half.exec(acoustic_dt);

--- a/tests/3d_examples/3d_examples_ck/test_3d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
+++ b/tests/3d_examples/3d_examples_ck/test_3d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
@@ -142,7 +142,7 @@ int velocity_validation(
 
         Real error = std::abs((vel_x_simulation - vel_x_analytical) / U_f);
         std::ostringstream msg;
-        msg << "Mismatch at observer index " << index
+        msg << "Measure at observer index " << index
             << " | Analytical: " << vel_x_analytical
             << " | Simulation: " << vel_x_simulation
             << " | Error: " << error;
@@ -293,8 +293,6 @@ int main(int ac, char *av[])
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK<>> fluid_acoustic_time_step(water_body);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::ViscousForceWithWallCK>
         fluid_viscous_force(water_body_inner, water_wall_contact);
-    InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityLimitedCorrectionCorrectedComplexBulkParticlesCKWithoutUpdate>
-        zero_gradient_ck(water_body_inner, water_wall_contact);
     fluid_dynamics::BidirectionalBoundaryCK<MainExecutionPolicy, LinearCorrectionCK, InflowVelocityPrescribed>
         bidirectional_velocity_condition_left(left_emitter_by_cell, particle_buffer, DH, U_f, mu_f);
     fluid_dynamics::BidirectionalBoundaryCK<MainExecutionPolicy, LinearCorrectionCK, PressurePrescribed<>>
@@ -369,7 +367,6 @@ int main(int ac, char *av[])
             {
                 acoustic_dt = SMIN(fluid_acoustic_time_step.exec(), advection_dt);
                 fluid_acoustic_step_1st_half.exec(acoustic_dt);
-                zero_gradient_ck.exec();
                 bidirectional_velocity_condition_left.applyBoundaryCondition(acoustic_dt);
                 bidirectional_pressure_condition_right.applyBoundaryCondition(acoustic_dt);
                 fluid_acoustic_step_2nd_half.exec(acoustic_dt);

--- a/tests/tests_sycl/2d_examples/test_2d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -172,7 +172,7 @@ int velocity_validation(
 {
     size_t total_passed = 0;
     size_t total_failed = 0;
-    std::vector<std::string> failure_messages;
+    std::vector<std::string> messages;
 
     // Loop over each observer point and compare the x-component of the velocity.
     for (size_t index = 0; index < observer_location.size(); ++index)
@@ -181,38 +181,34 @@ int velocity_validation(
         Real vel_x_analytical = analytical_solution(y);
         Real vel_x_simulation = observer_vel[index][0];
 
-        // Check if within tolerance
-        if (std::abs((vel_x_simulation - vel_x_analytical) / vel_x_analytical) <= tolerance_factor)
+        Real error = std::abs((vel_x_simulation - vel_x_analytical) / U_f);
+        std::ostringstream msg;
+        msg << "Measure at observer index " << index
+            << " | Analytical: " << vel_x_analytical
+            << " | Simulation: " << vel_x_simulation
+            << " | Error: " << error;
+        messages.push_back(msg.str());
+
+        if (error <= tolerance_factor)
         {
             total_passed++;
         }
         else
         {
             total_failed++;
-            std::ostringstream msg;
-            msg << "Mismatch at observer index " << index
-                << " | Analytical: " << vel_x_analytical
-                << " | Simulation: " << vel_x_simulation
-                << " | Error: " << std::abs((vel_x_simulation - vel_x_analytical) / vel_x_analytical);
-            failure_messages.push_back(msg.str());
         }
     }
 
     // Print summary
+    std::cout << "Detailed error measures:\n";
+    for (const auto &msg : messages)
+    {
+        std::cout << msg << "\n";
+    }
     std::cout << "[TEST SUMMARY] Velocity Validation:\n"
               << "Total Observations: " << observer_location.size() << "\n"
               << "Passed: " << total_passed << "\n"
               << "Failed: " << total_failed << "\n";
-
-    // Print detailed failure messages if any
-    if (!failure_messages.empty())
-    {
-        std::cout << "Detailed Failures:\n";
-        for (const auto &msg : failure_messages)
-        {
-            std::cout << msg << "\n";
-        }
-    }
 
     // Final assertion for unit testing
     if (total_failed != 0)
@@ -316,8 +312,6 @@ int main(int ac, char *av[])
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK<>> fluid_acoustic_time_step(water_body);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::ViscousForceWithWallCK>
         fluid_viscous_force(water_body_inner, water_wall_contact);
-    InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityLimitedCorrectionCorrectedComplexBulkParticlesCKWithoutUpdate>
-        zero_gradient_ck(water_body_inner, water_wall_contact);
     fluid_dynamics::BidirectionalBoundaryCK<MainExecutionPolicy, LinearCorrectionCK, InflowVelocityPrescribed>
         bidirectional_velocity_condition_left(left_emitter_by_cell, particle_buffer, DH, U_f, mu_f);
     fluid_dynamics::BidirectionalBoundaryCK<MainExecutionPolicy, LinearCorrectionCK, PressurePrescribed<>>
@@ -377,10 +371,10 @@ int main(int ac, char *av[])
             tick_instance = TickCount::now();
             fluid_density_regularization.exec();
             water_advection_step_setup.exec();
-            fluid_viscous_force.exec();
-            transport_correction_ck.exec();
-            Real advection_dt = fluid_advection_time_step.exec();
             fluid_linear_correction_matrix.exec();
+            transport_correction_ck.exec();
+            fluid_viscous_force.exec();
+            Real advection_dt = fluid_advection_time_step.exec();
             interval_outer_loop += TickCount::now() - tick_instance;
 
             tick_instance = TickCount::now();
@@ -390,7 +384,6 @@ int main(int ac, char *av[])
             {
                 acoustic_dt = SMIN(fluid_acoustic_time_step.exec(), advection_dt);
                 fluid_acoustic_step_1st_half.exec(acoustic_dt);
-                zero_gradient_ck.exec();
                 bidirectional_velocity_condition_left.applyBoundaryCondition(acoustic_dt);
                 bidirectional_pressure_condition_right.applyBoundaryCondition(acoustic_dt);
                 fluid_acoustic_step_2nd_half.exec(acoustic_dt);
@@ -438,14 +431,6 @@ int main(int ac, char *av[])
         body_states_recording.writeToFile(MainExecutionPolicy{});
         fluid_observer_contact_relation.exec();
         interval_io += TickCount::now() - tick_instance;
-        {
-            auto observer_vel = velocity_observer.getBaseParticles().getVariableDataByName<Vecd>("Velocity");
-            // Validate observer velocities against analytical Poiseuille profile
-            // Convert the pointer to a std::vector using the number of observer particles.
-            std::vector<Vecd> observer_vel_vec(observer_vel, observer_vel + observer_location.size());
-            Real error_tolerance = 3 * 0.01; // Less than 3 percent when resolution is DH/20
-            velocity_validation(observer_location, observer_vel_vec, poiseuille_2d_u_steady, error_tolerance, U_f);
-        }
     }
 
     TimeInterval tt = TickCount::now() - tick_start - interval_io;

--- a/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -27,7 +27,7 @@ BoundingBox system_domain_bounds(
 const Real Inlet_pressure = 0.1;
 const Real Outlet_pressure = 0.0;
 Real rho0_f = 1000.0;
-Real Re = 25;
+Real Re = 50;
 Real mu_f = std::sqrt(rho0_f * std::pow(DH, 3.0) * std::abs(Inlet_pressure - Outlet_pressure) / (32.0 * Re * DL));
 
 /**
@@ -130,7 +130,7 @@ int velocity_validation(
 {
     size_t total_passed = 0;
     size_t total_failed = 0;
-    std::vector<std::string> failure_messages;
+    std::vector<std::string> messages;
 
     // Loop over each observer point and compare the x-component of the velocity.
     for (size_t index = 0; index < observer_location.size(); ++index)
@@ -140,39 +140,36 @@ int velocity_validation(
         Real vel_x_analytical = analytical_solution(y, z);
         Real vel_x_simulation = observer_vel[index][0];
 
-        // Check if within tolerance
-        if (std::abs((vel_x_simulation - vel_x_analytical) / vel_x_analytical) <= tolerance_factor)
+        Real error = std::abs((vel_x_simulation - vel_x_analytical) / U_f);
+        std::ostringstream msg;
+        msg << "Measure at observer index " << index
+            << " | Analytical: " << vel_x_analytical
+            << " | Simulation: " << vel_x_simulation
+            << " | Error: " << error;
+        messages.push_back(msg.str());
+
+        if (error <= tolerance_factor)
         {
             total_passed++;
         }
         else
         {
             total_failed++;
-            std::ostringstream msg;
-            msg << "Mismatch at observer index " << index
-                << " | Analytical: " << vel_x_analytical
-                << " | Simulation: " << vel_x_simulation
-                << " | Error: " << std::abs((vel_x_simulation - vel_x_analytical) / vel_x_analytical);
-            failure_messages.push_back(msg.str());
         }
     }
 
     // Print summary
+    std::cout << "Detailed error measures:\n";
+    for (const auto &msg : messages)
+    {
+        std::cout << msg << "\n";
+    }
     std::cout << "[TEST SUMMARY] Velocity Validation:\n"
               << "Total Observations: " << observer_location.size() << "\n"
               << "Passed: " << total_passed << "\n"
               << "Failed: " << total_failed << "\n";
 
-    // Print detailed failure messages if any
-    if (!failure_messages.empty())
-    {
-        std::cout << "Detailed Failures:\n";
-        for (const auto &msg : failure_messages)
-        {
-            std::cout << msg << "\n";
-        }
-    }
-
+    // Final assertion for unit testing
     if (total_failed != 0)
     {
         std::cout << "Test failed with " << total_failed << " mismatches. Check log for details.";
@@ -296,8 +293,6 @@ int main(int ac, char *av[])
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK<>> fluid_acoustic_time_step(water_body);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::ViscousForceWithWallCK>
         fluid_viscous_force(water_body_inner, water_wall_contact);
-    InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityLimitedCorrectionCorrectedComplexBulkParticlesCKWithoutUpdate>
-        zero_gradient_ck(water_body_inner, water_wall_contact);
     fluid_dynamics::BidirectionalBoundaryCK<MainExecutionPolicy, LinearCorrectionCK, InflowVelocityPrescribed>
         bidirectional_velocity_condition_left(left_emitter_by_cell, particle_buffer, DH, U_f, mu_f);
     fluid_dynamics::BidirectionalBoundaryCK<MainExecutionPolicy, LinearCorrectionCK, PressurePrescribed<>>
@@ -359,10 +354,10 @@ int main(int ac, char *av[])
             tick_instance = TickCount::now();
             fluid_density_regularization.exec();
             water_advection_step_setup.exec();
-            fluid_viscous_force.exec();
-            transport_correction_ck.exec();
-            Real advection_dt = fluid_advection_time_step.exec();
             fluid_linear_correction_matrix.exec();
+            transport_correction_ck.exec();
+            fluid_viscous_force.exec();
+            Real advection_dt = fluid_advection_time_step.exec();
             interval_outer_loop += TickCount::now() - tick_instance;
 
             tick_instance = TickCount::now();
@@ -372,7 +367,6 @@ int main(int ac, char *av[])
             {
                 acoustic_dt = SMIN(fluid_acoustic_time_step.exec(), advection_dt);
                 fluid_acoustic_step_1st_half.exec(acoustic_dt);
-                zero_gradient_ck.exec();
                 bidirectional_velocity_condition_left.applyBoundaryCondition(acoustic_dt);
                 bidirectional_pressure_condition_right.applyBoundaryCondition(acoustic_dt);
                 fluid_acoustic_step_2nd_half.exec(acoustic_dt);


### PR DESCRIPTION
This pull request introduces improvements to the velocity validation logic, updates the execution order of fluid dynamics operations, and modifies a parameter in the 3D Poiseuille flow test. The changes enhance error reporting, improve code clarity, and adjust simulation parameters for better accuracy.

### Improvements to velocity validation:

* Replaced `failure_messages` with a generic `messages` vector to store both success and failure messages, improving clarity and consistency in error reporting in `velocity_validation` for both 2D and 3D examples (`mixed_poiseuille_flow.cpp`). [[1]](diffhunk://#diff-4556e25ac5eae9cbd67af079364c34fe8e43cba69176b417950c7f721a528689L175-R175) [[2]](diffhunk://#diff-4796d7787f75c5019cf18f8b00f880623f54f4101135b2f445f39996fcfeceebL133-R133)
* Enhanced error reporting by introducing detailed error messages for each observer point and printing all messages, regardless of pass/fail status. This provides more comprehensive feedback during validation (`mixed_poiseuille_flow.cpp`). [[1]](diffhunk://#diff-4556e25ac5eae9cbd67af079364c34fe8e43cba69176b417950c7f721a528689L184-L216) [[2]](diffhunk://#diff-4796d7787f75c5019cf18f8b00f880623f54f4101135b2f445f39996fcfeceebL143-R172)

### Adjustments to fluid dynamics execution order:

* Changed the order of operations in the main simulation loop by moving `fluid_linear_correction_matrix` before `fluid_viscous_force`. This ensures that the linear correction matrix is applied before computing viscous forces in both 2D and 3D examples (`mixed_poiseuille_flow.cpp`). [[1]](diffhunk://#diff-4556e25ac5eae9cbd67af079364c34fe8e43cba69176b417950c7f721a528689L380-L383) [[2]](diffhunk://#diff-4796d7787f75c5019cf18f8b00f880623f54f4101135b2f445f39996fcfeceebL362-L365)

### Parameter update for 3D Poiseuille flow:

* Increased the Reynolds number (`Re`) from 10 to 50 in the 3D Poiseuille flow test, resulting in a more dynamic flow regime for testing purposes (`mixed_poiseuille_flow.cpp`).