### PR TITLE
Xinagyu/clean simbody dependency

### DIFF
--- a/src/for_2D_build/simbody_sphinxsys/body_part_for_simbody_2d.cpp
+++ b/src/for_2D_build/simbody_sphinxsys/body_part_for_simbody_2d.cpp
@@ -1,4 +1,4 @@
-#include "solid_body.h"
+#include "body_part_for_simbody.h"
 
 #include "base_particles.hpp"
 

--- a/src/for_3D_build/geometries/triangle_mesh_shape.h
+++ b/src/for_3D_build/geometries/triangle_mesh_shape.h
@@ -31,8 +31,8 @@
 #define TRIANGULAR_MESH_SHAPE_H
 
 #include "TriangleMeshDistance.h"
-#include "all_simbody.h"
 #include "base_geometry.h"
+#include "simtk_wrapper.h"
 
 #include <filesystem>
 #include <fstream>

--- a/src/for_3D_build/simbody_sphinxsys/body_part_for_simbody_3d.cpp
+++ b/src/for_3D_build/simbody_sphinxsys/body_part_for_simbody_3d.cpp
@@ -1,4 +1,4 @@
-#include "solid_body.h"
+#include "body_part_for_simbody.h"
 
 #include "base_particles.hpp"
 namespace SPH

--- a/src/shared/bodies/base_body.cpp
+++ b/src/shared/bodies/base_body.cpp
@@ -2,7 +2,6 @@
 
 #include "base_body_relation.h"
 #include "base_particles.hpp"
-#include "sph_system.h"
 
 namespace SPH
 {

--- a/src/shared/bodies/base_body_part.h
+++ b/src/shared/bodies/base_body_part.h
@@ -32,8 +32,6 @@
 
 #include "base_body.h"
 
-#include <string>
-
 namespace SPH
 {
 /**

--- a/src/shared/bodies/solid_body.cpp
+++ b/src/shared/bodies/solid_body.cpp
@@ -7,17 +7,5 @@
 namespace SPH
 {
 //=================================================================================================//
-SolidBodyPartForSimbody::
-    SolidBodyPartForSimbody(SPHBody &body, Shape &body_part_shape)
-    : BodyRegionByParticle(body, body_part_shape),
-      rho0_(DynamicCast<Solid>(this, body.getBaseMaterial()).ReferenceDensity()),
-      Vol_(base_particles_.getVariableDataByName<Real>("VolumetricMeasure")),
-      pos_(base_particles_.getVariableDataByName<Vecd>("Position"))
-{
-    setMassProperties();
-}
-//=================================================================================================//
-SolidBodyPartForSimbody::SolidBodyPartForSimbody(SPHBody &body, SharedPtr<Shape> shape_ptr)
-    : SolidBodyPartForSimbody(body, *shape_ptr.get()) {}
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/bodies/solid_body.h
+++ b/src/shared/bodies/solid_body.h
@@ -53,35 +53,7 @@ class SolidBody : public RealBody
         sph_system_.solid_bodies_.push_back(this);
         defineAdaptation<SPHAdaptation>(1.15);
     };
-    virtual ~SolidBody(){};
-};
-
-/**
- * @class SolidBodyPartForSimbody
- * @brief A SolidBodyPart for coupling with Simbody.
- * The mass, origin, and unit inertial matrix are computed.
- * Note: In Simbody, all spatial vectors are three dimensional.
- */
-class SolidBodyPartForSimbody : public BodyRegionByParticle
-{
-  protected:
-    UniquePtrKeeper<SimTK::MassProperties> mass_properties_ptr_keeper_;
-
-  public:
-    Vecd initial_mass_center_;
-    SimTK::MassProperties *body_part_mass_properties_;
-
-    SolidBodyPartForSimbody(SPHBody &body, Shape &body_part_shape);
-    SolidBodyPartForSimbody(SPHBody &body, SharedPtr<Shape> shape_ptr);
-    virtual ~SolidBodyPartForSimbody(){};
-
-  protected:
-    Real rho0_;
-    Real *Vol_;
-    Vecd *pos_;
-
-  private:
-    void setMassProperties();
+    virtual ~SolidBody() {};
 };
 } // namespace SPH
 #endif // SOLID_BODY_H

--- a/src/shared/simbody_sphinxsys/all_simbody.h
+++ b/src/shared/simbody_sphinxsys/all_simbody.h
@@ -30,75 +30,10 @@
 #define ALL_SIMBODY_H
 
 #include "simbody_middle.h"
+#include "simtk_wrapper.h"
 #include "state_engine.h"
-#include "type_wrapper.h"
 #include "xml_engine.h"
 
 #include "base_data_type.h"
-
-namespace SPH
-{
-template <>
-struct ZeroData<SimTK::SpatialVec>
-{
-    static inline const SimTK::SpatialVec value = SimTK::SpatialVec(SimTKVec3(0), SimTKVec3(0));
-};
-
-template <>
-struct ZeroData<SimTKVec3>
-{
-    static inline const SimTKVec3 value = SimTKVec3(0);
-};
-
-struct SimbodyState
-{
-    Vec3d initial_origin_location_;
-    Vec3d origin_location_, origin_velocity_, origin_acceleration_;
-    Vec3d angular_velocity_, angular_acceleration_;
-    Mat3d rotation_;
-
-    SimbodyState()
-        : initial_origin_location_(Vec3d::Zero()),
-          origin_location_(Vec3d::Zero()),
-          origin_velocity_(Vec3d::Zero()),
-          origin_acceleration_(Vec3d::Zero()),
-          angular_velocity_(Vec3d::Zero()),
-          angular_acceleration_(Vec3d::Zero()),
-          rotation_(Mat3d::Identity()) {}
-    SimbodyState(const SimTKVec3 &sim_tk_initial_origin_location, SimTK::MobilizedBody &mobod, const SimTK::State &state)
-        : initial_origin_location_(SimTKToEigen(sim_tk_initial_origin_location)),
-          origin_location_(SimTKToEigen(mobod.getBodyOriginLocation(state))),
-          origin_velocity_(SimTKToEigen(mobod.getBodyOriginVelocity(state))),
-          origin_acceleration_(SimTKToEigen(mobod.getBodyOriginAcceleration(state))),
-          angular_velocity_(SimTKToEigen(mobod.getBodyAngularVelocity(state))),
-          angular_acceleration_(SimTKToEigen(mobod.getBodyAngularAcceleration(state))),
-          rotation_(SimTKToEigen(mobod.getBodyRotation(state))) {};
-
-    // implemented according to the Simbody API function with the same name
-    void findStationLocationVelocityAndAccelerationInGround(
-        const Vec3d &initial_location,
-        const Vec3d &initial_normal,
-        Vec3d &locationOnGround,
-        Vec3d &velocityInGround,
-        Vec3d &accelerationInGround,
-        Vec3d &normalInGround)
-    {
-        Vec3d temp_location = rotation_ * (initial_location - initial_origin_location_);
-        locationOnGround = origin_location_ + temp_location;
-
-        Vec3d temp_velocity = angular_velocity_.cross(temp_location);
-        velocityInGround = origin_velocity_ + temp_velocity;
-        accelerationInGround = origin_acceleration_ +
-                               angular_acceleration_.cross(temp_location) +
-                               angular_velocity_.cross(temp_velocity);
-        normalInGround = rotation_ * initial_normal;
-    };
-};
-
-template <>
-struct ZeroData<SimbodyState>
-{
-    static inline const SimbodyState value = SimbodyState();
-};
-} // namespace SPH
+#include "body_part_for_simbody.h"
 #endif // ALL_SIMBODY_H

--- a/src/shared/simbody_sphinxsys/body_part_for_simbody.cpp
+++ b/src/shared/simbody_sphinxsys/body_part_for_simbody.cpp
@@ -1,0 +1,21 @@
+#include "body_part_for_simbody.h"
+
+#include "base_particles.hpp"
+
+namespace SPH
+{
+//=================================================================================================//
+SolidBodyPartForSimbody::
+    SolidBodyPartForSimbody(SPHBody &body, Shape &body_part_shape)
+    : BodyRegionByParticle(body, body_part_shape),
+      rho0_(DynamicCast<Solid>(this, body.getBaseMaterial()).ReferenceDensity()),
+      Vol_(base_particles_.getVariableDataByName<Real>("VolumetricMeasure")),
+      pos_(base_particles_.getVariableDataByName<Vecd>("Position"))
+{
+    setMassProperties();
+}
+//=================================================================================================//
+SolidBodyPartForSimbody::SolidBodyPartForSimbody(SPHBody &body, SharedPtr<Shape> shape_ptr)
+    : SolidBodyPartForSimbody(body, *shape_ptr.get()) {}
+//=================================================================================================//
+} // namespace SPH

--- a/src/shared/simbody_sphinxsys/body_part_for_simbody.h
+++ b/src/shared/simbody_sphinxsys/body_part_for_simbody.h
@@ -10,9 +10,9 @@
  *                                                                           *
  * SPHinXsys is partially funded by German Research Foundation               *
  * (Deutsche Forschungsgemeinschaft) DFG HU1527/6-1, HU1527/10-1,            *
- *  HU1527/12-1 and HU1527/12-4                                              *
+ *  HU1527/12-1 and HU1527/12-4.                                             *
  *                                                                           *
- * Portions copyright (c) 2017-2022 Technical University of Munich and       *
+ * Portions copyright (c) 2017-2023 Technical University of Munich and       *
  * the authors' affiliations.                                                *
  *                                                                           *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may   *
@@ -21,36 +21,44 @@
  *                                                                           *
  * ------------------------------------------------------------------------- */
 /**
- * @file 	device_copyable_variable.h
- * @brief 	TBD.
+ * @file    body_part_for_simbody.h
+ * @brief 	This is the class for bodies used for solid BCs or Elastic structure.
  * @author	Xiangyu Hu
  */
-#ifndef DEVICE_COPYABLE_VARIABLE_H
-#define DEVICE_COPYABLE_VARIABLE_H
 
-#include "base_data_package.h"
-#include "simtk_wrapper.h"
+#ifndef BODY_PART_FOR_SIMBODY_H
+#define BODY_PART_FOR_SIMBODY_H
 
-namespace sycl
+#include "base_body_part.h"
+
+namespace SPH
 {
-template <>
-struct is_device_copyable<SPH::SimTKVec3> : std::true_type
+/**
+ * @class SolidBodyPartForSimbody
+ * @brief A SolidBodyPart for coupling with Simbody.
+ * The mass, origin, and unit inertial matrix are computed.
+ * Note: In Simbody, all spatial vectors are three dimensional.
+ */
+class SolidBodyPartForSimbody : public BodyRegionByParticle
 {
+  protected:
+    UniquePtrKeeper<SimTK::MassProperties> mass_properties_ptr_keeper_;
+
+  public:
+    Vecd initial_mass_center_;
+    SimTK::MassProperties *body_part_mass_properties_;
+
+    SolidBodyPartForSimbody(SPHBody &body, Shape &body_part_shape);
+    SolidBodyPartForSimbody(SPHBody &body, SharedPtr<Shape> shape_ptr);
+    virtual ~SolidBodyPartForSimbody() {};
+
+  protected:
+    Real rho0_;
+    Real *Vol_;
+    Vecd *pos_;
+
+  private:
+    void setMassProperties();
 };
-
-template <>
-struct is_device_copyable<SimTK::Vec<2, SPH::SimTKVec3>> : std::true_type
-{
-};
-
-template <int N, int M>
-struct is_device_copyable<Eigen::Matrix<SPH::Real, N, M>> : std::true_type
-{
-};
-
-template <>
-struct is_device_copyable<SPH::Mat2d> : std::true_type
-{
-};
-} // namespace sycl
-#endif // DEVICE_COPYABLE_VARIABLE_H
+} // namespace SPH
+#endif // BODY_PART_FOR_SIMBODY_H

--- a/src/shared/simbody_sphinxsys/xml_engine.h
+++ b/src/shared/simbody_sphinxsys/xml_engine.h
@@ -32,8 +32,8 @@
 #include "SimTKcommon/internal/Xml.h"
 #include "base_data_package.h"
 #include "simbody_middle.h"
+#include "simtk_wrapper.h"
 #include "sphinxsys_containers.h"
-#include "type_wrapper.h"
 
 #include <filesystem>
 #include <fstream>
@@ -51,7 +51,7 @@ class XmlEngine
     /** Constructor for XML output.  */
     XmlEngine(const std::string &xml_name, const std::string &root_tag);
     /** Default destructor. */
-    virtual ~XmlEngine(){};
+    virtual ~XmlEngine() {};
 
     SimTK::Xml::Element root_element_; /**< Root element of document. */
 

--- a/tests/tests_sycl/unit_test_src/shared/particle_dynamics/test_particle_reduce_sycl/test_particle_reduce.cpp
+++ b/tests/tests_sycl/unit_test_src/shared/particle_dynamics/test_particle_reduce_sycl/test_particle_reduce.cpp
@@ -1,9 +1,9 @@
-#include "all_simbody.h"
+#include "device_copyable_variable.h"
 #include "loop_range.h"
 #include "particle_iterators.h"
 #include "particle_iterators_sycl.h"
 #include "reduce_functors.h"
-#include "device_copyable_variable.h"
+#include "simtk_wrapper.h"
 #include "sphinxsys_variable_sycl.hpp"
 
 #include <gtest/gtest.h>


### PR DESCRIPTION
This pull request introduces significant structural and organizational changes to the codebase, focusing on modularizing the handling of Simbody-related functionality and improving code clarity. Key changes include the creation of a dedicated `body_part_for_simbody` module, renaming and restructuring files for better alignment with their purpose, and removing redundant or misplaced code.

### Modularization of Simbody-related functionality:
* Introduced a new module `body_part_for_simbody`, including the header file `body_part_for_simbody.h` and implementation file `body_part_for_simbody.cpp`, to encapsulate the `SolidBodyPartForSimbody` class and its related functionality. This class was moved from `solid_body.h` and `solid_body.cpp` into this new module. [[1]](diffhunk://#diff-37a02ea040533fe410ef6499d70673faf3e60383b74844604b7e8e110b2b0b95R1-R64) [[2]](diffhunk://#diff-0471ad34f5074dd6e601d6b36df1e125509adea7bfd0c30f9b9e2b474587f0b2R1-R21)

### File renaming and restructuring:
* Renamed `type_wrapper.h` to `simtk_wrapper.h` to better reflect its purpose as a wrapper between Eigen and SimTK types.
* Renamed `solid_body_2d.cpp` and `solid_body_3d.cpp` to `body_part_for_simbody_2d.cpp` and `body_part_for_simbody_3d.cpp`, respectively, to align with the new module structure. [[1]](diffhunk://#diff-65a0017b303897559987066d5791c5e1d151fbbac8f134eada3c132ce4c3a651L1-R1) [[2]](diffhunk://#diff-60af54affbd528a59d20b66c3d0475d0ed112a14161db36b55a2e33374827a70L1-R1)

### Code cleanup and removal:
* Removed the `SolidBodyPartForSimbody` class definition and implementation from `solid_body.h` and `solid_body.cpp`, as it has been migrated to the new `body_part_for_simbody` module. [[1]](diffhunk://#diff-db44f0b1169e32ff0935d6d17b08e131f98a840295877a0a616b9a1622e17b2eL58-L85) [[2]](diffhunk://#diff-db1e55fd74c76c04a88dd50a94ebe55959a48d67d1567c7ff65ad4590f3326b4L10-L21)
* Removed redundant `ZeroData` and `SimbodyState` definitions from `all_simbody.h` and moved them to `simtk_wrapper.h`. [[1]](diffhunk://#diff-a632d9e3e467e46fdd5706ab11fa7d0e1d2ba76aabe52dfd2f030e931a7d135bR33-R38) [[2]](diffhunk://#diff-db940ed03aa163d1491cc74b6e9ee9f9f2c56e2169f2f3094359b99a24eab2c0R88-R152)

### Dependency updates:
* Replaced `#include "all_simbody.h"` with more specific includes such as `simtk_wrapper.h` and `body_part_for_simbody.h` across multiple files to reduce unnecessary dependencies. [[1]](diffhunk://#diff-cf1658a06325b29dc54534e5a9225e7a66ddde9b837f9468f545b405d1f19d10L34-R35) [[2]](diffhunk://#diff-be9a21413225b727a7933f71eec1b4b05673ea82d9ce0dae363893c75321861bR35-L36) [[3]](diffhunk://#diff-3c879fe63aa1de823cf0ffb5df4750d02793821988feb58dd00d940ee12210deL31-R32) [[4]](diffhunk://#diff-c592b1f2f7cd03f7699cc3c4ed08ce3b89cde411a01a5392f9c25ec850b0089eL1-R6)

### Minor adjustments:
* Removed unused includes such as `sph_system.h` and `<string>` from various files for cleaner code. [[1]](diffhunk://#diff-aef936194c31d0a7903c589e47bd565ff0ef4527f569110cbccebc9574c45c94L5) [[2]](diffhunk://#diff-d6e7fed8f35c0f6a75461bc22dbb6dfeb49c4165d573ddab5e0f2187945fcf51L35-L36)