### PR TITLE
last particle needs to be movable if it is moved to replace the delet…

### DIFF
--- a/src/shared/particles/particle_operation.h
+++ b/src/shared/particles/particle_operation.h
@@ -67,7 +67,7 @@ class SpawnRealParticle
             {
                 UnsignedInt new_original_id = original_id_[last_real_particle_index];
                 copy_particle_state_(copyable_state_data_arrays_, last_real_particle_index, index_i);
-                original_id_[last_real_particle_index] = new_original_id; //keep the original id
+                original_id_[last_real_particle_index] = new_original_id; // keep the original id
             }
             return last_real_particle_index;
         };
@@ -97,12 +97,12 @@ class RemoveRealParticle
         template <class ExecutionPolicy, class EncloserType>
         ComputingKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
 
-        template <class IsDeletable>
-        void operator()(UnsignedInt index_i, const IsDeletable &is_deletable)
+        template <class IsDeletable, class IsMovable>
+        void operator()(UnsignedInt index_i, const IsDeletable &is_deletable, const IsMovable &is_movable)
         {
             AtomicRef<UnsignedInt> total_real_particles_ref(*total_real_particles_);
             UnsignedInt last_real_particle_index = total_real_particles_ref.fetch_sub(1) - 1;
-            while (is_deletable(last_real_particle_index))
+            while (is_deletable(last_real_particle_index) || !is_movable(last_real_particle_index))
             {
                 last_real_particle_index = total_real_particles_ref.fetch_sub(1) - 1;
             }

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.cpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.cpp
@@ -27,9 +27,13 @@ BufferOutflowDeletionCK::BufferOutflowDeletionCK(AlignedBoxByCell &aligned_box_p
 //=================================================================================================//
 BufferOutflowDeletionCK::UpdateKernel::
     IsDeletable::IsDeletable(int part_id, AlignedBox *aligned_box,
-                             Vecd *pos, int *buffer_particle_indicator)
+                             Vecd *pos, int *buffer_indicator)
     : part_id_(part_id), aligned_box_(aligned_box), pos_(pos),
-      buffer_indicator_(buffer_particle_indicator) {}
+      buffer_indicator_(buffer_indicator) {}
+//=================================================================================================//
+BufferOutflowDeletionCK::UpdateKernel::
+    IsMovable::IsMovable(int *buffer_indicator)
+    : buffer_indicator_(buffer_indicator) {}
 //=================================================================================================//
 } // namespace fluid_dynamics
 } // namespace SPH

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.h
@@ -52,7 +52,7 @@ class BufferIndicationCK : public BaseLocalDynamics<AlignedBoxByCell>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void update(UnsignedInt index_i, Real dt = 0.0);
 
       protected:
         int part_id_;
@@ -98,7 +98,7 @@ class BufferInflowInjectionCK : public BaseLocalDynamics<AlignedBoxByCell>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void update(UnsignedInt index_i, Real dt = 0.0);
 
       private:
         int part_id_;
@@ -145,24 +145,37 @@ class BufferOutflowDeletionCK : public BaseLocalDynamics<AlignedBoxByCell>
             AlignedBox *aligned_box_;
             Vecd *pos_;
             int *buffer_indicator_;
-            IsDeletable(int part_id, AlignedBox *aligned_box, Vecd *pos, int *buffer_particle_indicator);
+            IsDeletable(int part_id, AlignedBox *aligned_box, Vecd *pos, int *buffer_indicator);
 
-            bool operator()(size_t index_i) const
+            bool operator()(UnsignedInt index_i) const
             {
                 return buffer_indicator_[index_i] == part_id_ &&
                        aligned_box_->checkLowerBound(pos_[index_i]);
             };
         };
 
+        class IsMovable
+        {
+            int *buffer_indicator_;
+
+          public:
+            IsMovable(int *buffer_indicator);
+            bool operator()(UnsignedInt index_i) const
+            {
+                return buffer_indicator_[index_i] == 0; // not a buffer particle
+            };
+        };
+
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void update(UnsignedInt index_i, Real dt = 0.0);
 
       protected:
         AlignedBox *aligned_box_;
         Vecd *pos_;
         IsDeletable is_deltable_;
+        IsMovable is_movable_;
         UnsignedInt *total_real_particles_;
         RemoveRealParticleKernel remove_real_particle_;
     };
@@ -191,7 +204,7 @@ class PressureVelocityCondition : public BaseLocalDynamics<AlignedBoxByCell>,
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void update(UnsignedInt index_i, Real dt = 0.0);
 
       protected:
         AlignedBox *aligned_box_;

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.hpp
@@ -16,7 +16,7 @@ BufferIndicationCK::UpdateKernel::
       pos_(encloser.dv_pos_->DelegatedData(ex_policy)),
       buffer_indicator_(encloser.dv_buffer_indicator_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
-void BufferIndicationCK::UpdateKernel::update(size_t index_i, Real dt)
+void BufferIndicationCK::UpdateKernel::update(UnsignedInt index_i, Real dt)
 {
     if (aligned_box_->checkContain(pos_[index_i]))
     {
@@ -62,7 +62,7 @@ BufferInflowInjectionCK<ConditionType>::
       upper_bound_fringe_(encloser.upper_bound_fringe_) {}
 //=================================================================================================//
 template <class ConditionType>
-void BufferInflowInjectionCK<ConditionType>::UpdateKernel::update(size_t index_i, Real dt)
+void BufferInflowInjectionCK<ConditionType>::UpdateKernel::update(UnsignedInt index_i, Real dt)
 {
     if (!aligned_box_->checkInBounds(pos_[index_i]))
     {
@@ -86,16 +86,17 @@ BufferOutflowDeletionCK::UpdateKernel::
       pos_(encloser.dv_pos_->DelegatedData(ex_policy)),
       is_deltable_(encloser.part_id_, aligned_box_, pos_,
                    encloser.dv_buffer_indicator_->DelegatedData(ex_policy)),
+      is_movable_(encloser.dv_buffer_indicator_->DelegatedData(ex_policy)),
       total_real_particles_(encloser.sv_total_real_particles_->DelegatedData(ex_policy)),
       remove_real_particle_(ex_policy, encloser.remove_real_particle_method_) {}
 //=================================================================================================//
-void BufferOutflowDeletionCK::UpdateKernel::update(size_t index_i, Real dt)
+void BufferOutflowDeletionCK::UpdateKernel::update(UnsignedInt index_i, Real dt)
 {
     if (!aligned_box_->checkInBounds(pos_[index_i]))
     {
         if (is_deltable_(index_i) && index_i < *total_real_particles_)
         {
-            remove_real_particle_(index_i, is_deltable_);
+            remove_real_particle_(index_i, is_deltable_, is_movable_);
         }
     }
 }
@@ -126,7 +127,7 @@ PressureVelocityCondition<KernelCorrectionType, ConditionType>::UpdateKernel::
 //=================================================================================================//
 template <class KernelCorrectionType, typename ConditionType>
 void PressureVelocityCondition<KernelCorrectionType, ConditionType>::
-    UpdateKernel::update(size_t index_i, Real dt)
+    UpdateKernel::update(UnsignedInt index_i, Real dt)
 {
     if (aligned_box_->checkContain(pos_[index_i]))
     {


### PR DESCRIPTION
This pull request introduces several updates to the particle dynamics codebase, focusing on enhancing particle deletion logic, improving type consistency, and adding a new "movable" condition for particles. The key changes include the addition of the `IsMovable` class to refine particle operations, replacing `size_t` with `UnsignedInt` for index parameters, and refactoring buffer indicator handling.

### Enhancements to Particle Deletion Logic:
* Added a new `IsMovable` class to determine if a particle is movable, ensuring that non-movable particles are not mistakenly deleted. This logic was integrated into the `RemoveRealParticleKernel` and `BufferOutflowDeletionCK::UpdateKernel` classes (`src/shared/particles/particle_operation.h`, `src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.hpp`, `src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.h`). [[1]](diffhunk://#diff-f2bb99cb8cf3624022cac413fb502b7ca2f0698e257630172a88e397fea63a7eL100-R105) [[2]](diffhunk://#diff-c3263ac0eee833c8ca0c31374dee93c4e59a2c04513d868a870d550fd912b685L148-R178) [[3]](diffhunk://#diff-b954f48bf1e83927957e63129708fecf5a675c89fdd9ef8418a717d207423540R89-R99)

* Updated the `RemoveRealParticleKernel` method to include `is_movable` as an additional condition for particle deletion, preventing unintended removal of non-movable particles (`src/shared/particles/particle_operation.h`).

### Type Consistency Improvements:
* Replaced `size_t` with `UnsignedInt` for particle index parameters in several `update` methods across multiple classes, improving type consistency and alignment with the rest of the codebase (`src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.h`, `src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.hpp`). [[1]](diffhunk://#diff-c3263ac0eee833c8ca0c31374dee93c4e59a2c04513d868a870d550fd912b685L55-R55) [[2]](diffhunk://#diff-c3263ac0eee833c8ca0c31374dee93c4e59a2c04513d868a870d550fd912b685L101-R101) [[3]](diffhunk://#diff-c3263ac0eee833c8ca0c31374dee93c4e59a2c04513d868a870d550fd912b685L194-R207) [[4]](diffhunk://#diff-b954f48bf1e83927957e63129708fecf5a675c89fdd9ef8418a717d207423540L19-R19) [[5]](diffhunk://#diff-b954f48bf1e83927957e63129708fecf5a675c89fdd9ef8418a717d207423540L65-R65) [[6]](diffhunk://#diff-b954f48bf1e83927957e63129708fecf5a675c89fdd9ef8418a717d207423540L129-R130)

### Refactoring and Cleanup:
* Renamed the `buffer_particle_indicator` parameter to `buffer_indicator` for consistency across the codebase (`src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.cpp`, `src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.h`). [[1]](diffhunk://#diff-bd3740c1645ef38af43657dad16d280b11b7793746285b9362561554b4b4d3f0L30-R36) [[2]](diffhunk://#diff-c3263ac0eee833c8ca0c31374dee93c4e59a2c04513d868a870d550fd912b685L148-R178)…ed particle