### PR TITLE
body name information with variable registering error

### DIFF
--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -27,11 +27,16 @@ SPHAdaptation &BaseParticles::getSPHAdaptation()
     return sph_body_.getSPHAdaptation();
 }
 //=================================================================================================//
+void BaseParticles::printBodyName()
+{
+    std::cout << "\nBodyName: " << sph_body_.getName() << std::endl;
+}
+//=================================================================================================//
 void BaseParticles::initializeBasicParticleVariables()
 {
     addEvolvingVariable<Vecd>("Position");
     addEvolvingVariable<Real>("VolumetricMeasure");
-     //----------------------------------------------------------------------
+    //----------------------------------------------------------------------
     //		register non-geometric variables
     //----------------------------------------------------------------------
     rho_ = registerStateVariable<Real>("Density", base_material_.ReferenceDensity());

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -93,6 +93,7 @@ class BaseParticles
     SPHBody &getSPHBody() { return sph_body_; };
     BaseMaterial &getBaseMaterial() { return base_material_; };
     SPHAdaptation &getSPHAdaptation();
+    void printBodyName();
     //----------------------------------------------------------------------
     // Global information for defining particle groups
     // total_real_particles_ gives the run-time total number of real particles.

--- a/src/shared/particles/base_particles.hpp
+++ b/src/shared/particles/base_particles.hpp
@@ -150,7 +150,7 @@ DataType *BaseParticles::registerStateVariableFrom(
     if (variable == nullptr)
     {
         std::cout << "\nError: the old variable '" << old_name << "' is not registered!\n";
-        std::cout << __FILE__ << ':' << __LINE__ << std::endl;
+        printBodyName();
         exit(1);
     }
 
@@ -196,7 +196,7 @@ DiscreteVariable<DataType> *BaseParticles::registerStateVariableOnlyFrom(
     if (variable == nullptr)
     {
         std::cout << "\nError: the old variable '" << old_name << "' is not registered!\n";
-        std::cout << __FILE__ << ':' << __LINE__ << std::endl;
+        printBodyName();
         exit(1);
     }
 
@@ -241,7 +241,7 @@ DiscreteVariable<DataType> *BaseParticles::getVariableByName(const std::string &
     if (variable == nullptr)
     {
         std::cout << "\nError: the variable '" << name << "' is not registered!\n";
-        std::cout << __FILE__ << ':' << __LINE__ << std::endl;
+        printBodyName();
         exit(1);
     }
     return variable;
@@ -255,7 +255,7 @@ DataType *BaseParticles::getVariableDataByName(const std::string &name)
     if (variable->Data() == nullptr)
     {
         std::cout << "\nError: the variable '" << name << "' has not been allocated yet!\n";
-        std::cout << __FILE__ << ':' << __LINE__ << std::endl;
+        printBodyName();
         exit(1);
     }
 
@@ -318,7 +318,7 @@ SingularVariable<DataType> *BaseParticles::getSingularVariableByName(const std::
     if (variable == nullptr)
     {
         std::cout << "\nError: the variable '" << name << "' is not registered!\n";
-        std::cout << __FILE__ << ':' << __LINE__ << std::endl;
+        printBodyName();
     }
 
     return variable;
@@ -333,7 +333,7 @@ DiscreteVariable<DataType> *BaseParticles::
     if (variable == nullptr)
     {
         std::cout << "\n Error: the variable '" << name << "' is  not exist!" << std::endl;
-        std::cout << __FILE__ << ':' << __LINE__ << std::endl;
+        printBodyName();
         exit(1);
     }
 
@@ -348,7 +348,7 @@ DiscreteVariable<DataType> *BaseParticles::
     {
         std::cout << "\n Error: The variable '" << variable->Name() << "' can not be treated as a particle variable," << std::endl;
         std::cout << "\n because the data size " << variable->getDataSize() << " is too less!" << std::endl;
-        std::cout << __FILE__ << ':' << __LINE__ << std::endl;
+        printBodyName();
         exit(1);
     }
 


### PR DESCRIPTION
This pull request introduces a new `printBodyName` method in the `BaseParticles` class to improve error reporting by including the SPH body name in error messages. It replaces file and line number outputs in several error-handling scenarios with calls to this new method, making the error messages more informative and context-specific.

### New functionality:
* Added a `printBodyName` method to the `BaseParticles` class, which outputs the SPH body name to the console. (`src/shared/particles/base_particles.cpp` - [[1]](diffhunk://#diff-d7dc99d92f4fd7062b15aacdd54fc73984fe85ae9b0408fc5caead8de70bfa93R30-R34) `src/shared/particles/base_particles.h` - [[2]](diffhunk://#diff-429fe4c2d7d343634cb6b8f381e45b91cecbd79fa65b86c343c0b0318c70606eR96)

### Error reporting improvements:
* Replaced file and line number outputs in error-handling code with calls to the new `printBodyName` method across multiple methods in `BaseParticles`. This change enhances the clarity of error messages by including the SPH body name:
  - `registerStateVariableFrom` (`src/shared/particles/base_particles.hpp` - [src/shared/particles/base_particles.hppL153-R153](diffhunk://#diff-16ad8c0941eb1e568b8f4282768a4a7d6c18972873003e6e539d4f3756078777L153-R153))
  - `registerStateVariableOnlyFrom` (`src/shared/particles/base_particles.hpp` - [src/shared/particles/base_particles.hppL199-R199](diffhunk://#diff-16ad8c0941eb1e568b8f4282768a4a7d6c18972873003e6e539d4f3756078777L199-R199))
  - `getVariableByName` (`src/shared/particles/base_particles.hpp` - [src/shared/particles/base_particles.hppL244-R244](diffhunk://#diff-16ad8c0941eb1e568b8f4282768a4a7d6c18972873003e6e539d4f3756078777L244-R244))
  - `getVariableDataByName` (`src/shared/particles/base_particles.hpp` - [src/shared/particles/base_particles.hppL258-R258](diffhunk://#diff-16ad8c0941eb1e568b8f4282768a4a7d6c18972873003e6e539d4f3756078777L258-R258))
  - `getSingularVariableByName` (`src/shared/particles/base_particles.hpp` - [src/shared/particles/base_particles.hppL321-R321](diffhunk://#diff-16ad8c0941eb1e568b8f4282768a4a7d6c18972873003e6e539d4f3756078777L321-R321))
  - Other variable-related methods (`src/shared/particles/base_particles.hpp` - [[1]](diffhunk://#diff-16ad8c0941eb1e568b8f4282768a4a7d6c18972873003e6e539d4f3756078777L336-R336) [[2]](diffhunk://#diff-16ad8c0941eb1e568b8f4282768a4a7d6c18972873003e6e539d4f3756078777L351-R351)