### PR TITLE
change data type in io_base.cpp from int to size_t

### DIFF
--- a/src/shared/io_system/io_base.cpp
+++ b/src/shared/io_system/io_base.cpp
@@ -11,15 +11,14 @@ BaseIO::BaseIO(SPHSystem &sph_system)
 //=============================================================================================//
 std::string BaseIO::convertPhysicalTimeToString(Real convertPhysicalTimeToStream)
 {
-    int i_time = int(sv_physical_time_->getValue() * 1.0e6);
+    size_t i_time = size_t(sv_physical_time_->getValue() * 1.0e6);
     return padValueWithZeros(i_time);
 }
 //=============================================================================================/
 bool BaseIO::isBodyIncluded(const SPHBodyVector &bodies, SPHBody *sph_body)
 {
     auto result = std::find_if(bodies.begin(), bodies.end(),
-                               [&](auto &body) -> bool
-                               { return body == sph_body; });
+                               [&](auto &body) -> bool { return body == sph_body; });
     return result != bodies.end() ? true : false;
 }
 //=============================================================================================//


### PR DESCRIPTION
For long time simulation, such as end_time=4000, int may overflow.