### PR TITLE
generalize interaction template

### DIFF
--- a/src/shared/shared_ck/particle_dynamics/interaction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/interaction_ck.h
@@ -44,11 +44,12 @@ class InteractionOnly;
 template <typename... T>
 class Interaction;
 
-template <class DynamicsIdentifier, typename... Parameters>
-class Interaction<Inner<DynamicsIdentifier, Parameters...>>
-    : public BaseLocalDynamics<DynamicsIdentifier>
+template <typename... Parameters>
+class Interaction<Inner<Parameters...>>
+    : public BaseLocalDynamics<typename Inner<Parameters...>::SourceType>
 {
-    typedef Inner<DynamicsIdentifier, Parameters...> InnerRelationType;
+    using BaseLocalDynamicsType = BaseLocalDynamics<typename Inner<Parameters...>::SourceType>;
+    typedef Inner<Parameters...> InnerRelationType;
     using NeighborList = typename InnerRelationType::NeighborList;
     using NeighborMethod = typename InnerRelationType::NeighborMethodType;
     using Neighborhood = Neighbor<NeighborMethod>;
@@ -72,20 +73,12 @@ class Interaction<Inner<DynamicsIdentifier, Parameters...>>
     InnerRelationType &inner_relation_;
 };
 
-template <>
-class Interaction<Inner<>> : public Interaction<Inner<RealBody, SmoothingLength<SingleValued>>>
+template <typename... Parameters>
+class Interaction<Contact<Parameters...>>
+    : public BaseLocalDynamics<typename Contact<Parameters...>::SourceType>
 {
-  public:
-    explicit Interaction(Inner<RealBody, SmoothingLength<SingleValued>> &inner_relation)
-        : Interaction<Inner<RealBody, SmoothingLength<SingleValued>>>(inner_relation) {};
-    virtual ~Interaction() {};
-};
-
-template <class SourceIdentifier, typename... Parameters>
-class Interaction<Contact<SourceIdentifier, Parameters...>>
-    : public BaseLocalDynamics<SourceIdentifier>
-{
-    typedef Contact<SourceIdentifier, Parameters...> ContactRelationType;
+    using BaseLocalDynamicsType = BaseLocalDynamics<typename Contact<Parameters...>::SourceType>;
+    typedef Contact<Parameters...> ContactRelationType;
     using NeighborList = typename ContactRelationType::NeighborList;
     using NeighborMethod = typename ContactRelationType::NeighborMethodType;
     using Neighborhood = Neighbor<NeighborMethod>;
@@ -111,15 +104,6 @@ class Interaction<Contact<SourceIdentifier, Parameters...>>
     StdVec<SPHBody *> contact_bodies_;
     StdVec<BaseParticles *> contact_particles_;
     StdVec<SPHAdaptation *> contact_adaptations_;
-};
-
-template <>
-class Interaction<Contact<>> : public Interaction<Contact<SPHBody, RealBody, SmoothingLength<SingleValued>>>
-{
-  public:
-    explicit Interaction(Contact<> &contact_relation)
-        : Interaction<Contact<SPHBody, RealBody, SmoothingLength<SingleValued>>>(contact_relation) {};
-    virtual ~Interaction() {};
 };
 
 template <>

--- a/src/shared/shared_ck/particle_dynamics/interaction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/interaction_ck.hpp
@@ -6,58 +6,58 @@
 namespace SPH
 {
 //=================================================================================================//
-template <class DynamicsIdentifier, typename... Parameters>
-Interaction<Inner<DynamicsIdentifier, Parameters...>>::
+template <typename... Parameters>
+Interaction<Inner<Parameters...>>::
     Interaction(InnerRelationType &inner_relation)
-    : BaseLocalDynamics<DynamicsIdentifier>(inner_relation.getDynamicsIdentifier()),
+    : BaseLocalDynamicsType(inner_relation.getDynamicsIdentifier()),
       inner_relation_(inner_relation) {}
 //=================================================================================================//
-template <class DynamicsIdentifier, typename... Parameters>
-void Interaction<Inner<DynamicsIdentifier, Parameters...>>::
+template <typename... Parameters>
+void Interaction<Inner<Parameters...>>::
     registerComputingKernel(Implementation<Base> *implementation)
 {
     inner_relation_.registerComputingKernel(implementation);
 }
 //=================================================================================================//
-template <class DynamicsIdentifier, typename... Parameters>
-void Interaction<Inner<DynamicsIdentifier, Parameters...>>::resetComputingKernelUpdated()
+template <typename... Parameters>
+void Interaction<Inner<Parameters...>>::resetComputingKernelUpdated()
 {
     inner_relation_.resetComputingKernelUpdated();
 }
 //=================================================================================================//
-template <class DynamicsIdentifier, typename... Parameters>
+template <typename... Parameters>
 template <class ExecutionPolicy, class EncloserType>
-Interaction<Inner<DynamicsIdentifier, Parameters...>>::InteractKernel::
+Interaction<Inner<Parameters...>>::InteractKernel::
     InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
     : NeighborList(ex_policy, encloser.inner_relation_),
       Neighborhood(ex_policy, encloser.inner_relation_.getNeighborMethod()) {}
 //=================================================================================================//
-template <class SourceIdentifier, typename... Parameters>
-Interaction<Contact<SourceIdentifier, Parameters...>>::
+template <typename... Parameters>
+Interaction<Contact<Parameters...>>::
     Interaction(ContactRelationType &contact_relation)
-    : BaseLocalDynamics<SourceIdentifier>(contact_relation.getSourceIdentifier()),
+    : BaseLocalDynamicsType(contact_relation.getSourceIdentifier()),
       contact_relation_(contact_relation),
       contact_bodies_(contact_relation.getContactBodies()),
       contact_particles_(contact_relation.getContactParticles()),
       contact_adaptations_(contact_relation.getContactAdaptations()) {}
 //=================================================================================================//
-template <class SourceIdentifier, typename... Parameters>
-void Interaction<Contact<SourceIdentifier, Parameters...>>::
+template <typename... Parameters>
+void Interaction<Contact<Parameters...>>::
     registerComputingKernel(Implementation<Base> *implementation, UnsignedInt contact_index)
 {
     contact_relation_.registerComputingKernel(implementation, contact_index);
 }
 //=================================================================================================//
-template <class SourceIdentifier, typename... Parameters>
-void Interaction<Contact<SourceIdentifier, Parameters...>>::
+template <typename... Parameters>
+void Interaction<Contact<Parameters...>>::
     resetComputingKernelUpdated(UnsignedInt contact_index)
 {
     contact_relation_.resetComputingKernelUpdated(contact_index);
 }
 //=================================================================================================//
-template <class SourceIdentifier, typename... Parameters>
+template <typename... Parameters>
 template <class ExecutionPolicy, class EncloserType>
-Interaction<Contact<SourceIdentifier, Parameters...>>::InteractKernel::
+Interaction<Contact<Parameters...>>::InteractKernel::
     InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt contact_index)
     : NeighborList(ex_policy, encloser.contact_relation_, contact_index),
       Neighborhood(ex_policy, encloser.contact_relation_.getNeighborMethod(contact_index)) {}


### PR DESCRIPTION
This pull request refactors the `Interaction` class template in the `particle_dynamics` module to simplify its implementation and improve maintainability. The changes primarily focus on replacing specific template parameters (`DynamicsIdentifier` and `SourceIdentifier`) with generic type placeholders (`typename... Parameters`) and introducing type aliases for better readability and consistency.

### Refactoring of `Interaction` class templates:

* **Generic template parameters for `Inner` and `Contact`:**
  - Updated `Interaction<Inner<DynamicsIdentifier, Parameters...>>` to `Interaction<Inner<Parameters...>>`, and `Interaction<Contact<SourceIdentifier, Parameters...>>` to `Interaction<Contact<Parameters...>>`. This change removes the need for specific identifiers and uses generic placeholders for flexibility. (`src/shared/shared_ck/particle_dynamics/interaction_ck.h`, [[1]](diffhunk://#diff-fb09046ca81862e54cf13c0704258ea8561246806e6ebfd3e524afd90237f574L47-R52) [[2]](diffhunk://#diff-fb09046ca81862e54cf13c0704258ea8561246806e6ebfd3e524afd90237f574L75-R81) [[3]](diffhunk://#diff-b8c4baf8d936c5fc0e9c7587606bd7da814562ab43fa468c4a13d59737dcfa2aL9-R60)
  - Added type aliases (`BaseLocalDynamicsType`) to encapsulate the base dynamics type derived from the `SourceType` of `Inner` or `Contact`. (`src/shared/shared_ck/particle_dynamics/interaction_ck.h`, [[1]](diffhunk://#diff-fb09046ca81862e54cf13c0704258ea8561246806e6ebfd3e524afd90237f574L47-R52) [[2]](diffhunk://#diff-fb09046ca81862e54cf13c0704258ea8561246806e6ebfd3e524afd90237f574L75-R81)

* **Removal of specialized template instantiations:**
  - Removed specialized template implementations for empty `Inner<>` and `Contact<>` types, which were redundant and added unnecessary complexity. (`src/shared/shared_ck/particle_dynamics/interaction_ck.h`, [[1]](diffhunk://#diff-fb09046ca81862e54cf13c0704258ea8561246806e6ebfd3e524afd90237f574L75-R81) [[2]](diffhunk://#diff-fb09046ca81862e54cf13c0704258ea8561246806e6ebfd3e524afd90237f574L116-L124)

### Updates to member functions:

* **Refactored constructors and methods:**
  - Updated constructors and methods to use the new generic template parameters and type aliases (`BaseLocalDynamicsType`). This improves consistency and reduces code duplication. (`src/shared/shared_ck/particle_dynamics/interaction_ck.hpp`, [src/shared/shared_ck/particle_dynamics/interaction_ck.hppL9-R60](diffhunk://#diff-b8c4baf8d936c5fc0e9c7587606bd7da814562ab43fa468c4a13d59737dcfa2aL9-R60))

These changes streamline the codebase, making it more maintainable while retaining its functionality. The use of generic placeholders enhances the adaptability of the `Interaction` class templates for various use cases.