### PR TITLE
revise the particle method container

### DIFF
--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/general_assignment.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/general_assignment.h
@@ -33,7 +33,7 @@
 
 namespace SPH
 {
-template <class DynamicsIdentifier, typename AssignmentFunctionType>
+template <typename AssignmentFunctionType, class DynamicsIdentifier>
 class VariableAssignment : public BaseLocalDynamics<DynamicsIdentifier>
 {
     using DataType = typename AssignmentFunctionType::ReturnType;

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/general_constraint_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/general_constraint_ck.h
@@ -34,7 +34,7 @@
 
 namespace SPH
 {
-template <class DynamicsIdentifier, typename DataType>
+template <typename DataType, class DynamicsIdentifier>
 class ConstantConstraintCK : public BaseLocalDynamics<DynamicsIdentifier>
 {
   public:
@@ -42,8 +42,8 @@ class ConstantConstraintCK : public BaseLocalDynamics<DynamicsIdentifier>
                          const DataType &constrained_value)
         : BaseLocalDynamics<DynamicsIdentifier>(identifier),
           dv_variable_(this->particles_->template getVariableByName<DataType>(variable_name)),
-          constrained_value_(constrained_value){};
-    virtual ~ConstantConstraintCK(){};
+          constrained_value_(constrained_value) {};
+    virtual ~ConstantConstraintCK() {};
 
     class UpdateKernel
     {

--- a/src/shared/shared_ck/particle_dynamics/particle_method_container.h
+++ b/src/shared/shared_ck/particle_dynamics/particle_method_container.h
@@ -31,8 +31,10 @@
 #define PARTICLE_METHOD_CONTAINER_H
 
 #include "base_particle_dynamics.h"
+#include "complex_algorithms_ck.h"
 #include "interaction_algorithms_ck.h"
 #include "io_base.h"
+#include "io_observation_ck.h"
 #include "ownership.h"
 #include "particle_sort_ck.h"
 #include "simple_algorithms_ck.h"
@@ -91,6 +93,15 @@ class ParticleMethodContainer : public BaseMethodContainer
             StateDynamics<ExecutionPolicy, UpdateType>>(std::forward<Args>(args)...);
     };
 
+    template <template <typename...> class UpdateType, typename... ControlParameters,
+              class DynamicsIdentifier, typename... Args>
+    auto &addStateDynamics(DynamicsIdentifier &dynamics_identifier, Args &&...args)
+    {
+        return *particle_dynamics_keeper_.createPtr<
+            StateDynamics<ExecutionPolicy, UpdateType<ControlParameters..., DynamicsIdentifier>>>(
+            dynamics_identifier, std::forward<Args>(args)...);
+    };
+
     template <class ReduceType, typename... Args>
     auto &addReduceDynamics(Args &&...args)
     {
@@ -105,8 +116,7 @@ class ParticleMethodContainer : public BaseMethodContainer
             InteractionDynamicsCK<ExecutionPolicy, InteractionType>>(std::forward<Args>(args)...);
     };
 
-    template <template <typename...> class InteractionType,
-              typename... ControlParameters,
+    template <template <typename...> class InteractionType, typename... ControlParameters,
               template <typename...> class RelationType, typename... RelationParameters, typename... Args>
     auto &addInteractionDynamics(
         RelationType<RelationParameters...> &relation, Args &&...args)
@@ -117,18 +127,47 @@ class ParticleMethodContainer : public BaseMethodContainer
             relation, std::forward<Args>(args)...);
     };
 
+    template <template <typename...> class InteractionType, typename... ControlParameters,
+              template <typename...> class RelationType, typename... RelationParameters, typename... Args>
+    auto &add2ndRungeKuttaSequence(
+        RelationType<RelationParameters...> &relation, Args &&...args)
+    {
+        return *particle_dynamics_keeper_.createPtr<
+            RungeKuttaSequence<InteractionDynamicsCK<
+                ExecutionPolicy,
+                InteractionType<RelationType<OneLevel, RungeKutta1stStage, ControlParameters..., RelationParameters...>>,
+                InteractionType<RelationType<OneLevel, RungeKutta2ndStage, ControlParameters..., RelationParameters...>>>>>(
+            relation, std::forward<Args>(args)...);
+    };
+
     template <template <typename...> class RecorderType, typename... Args>
     auto &addBodyStateRecorder(Args &&...args)
     {
         return *state_recorders_keeper_.createPtr<RecorderType<ExecutionPolicy>>(std::forward<Args>(args)...);
     };
 
-    template <template <typename...> class RegressionType,
-              template <typename...> class ObservationType, typename... Parameters, typename... Args>
-    auto &addRegressionTest(Args &&...args)
+    template <template <typename...> class RegressionType, typename... Parameters, typename... Args>
+    auto &addObserveRegression(Args &&...args)
     {
         return *other_io_keeper_.createPtr<
-            RegressionType<ObservationType<ExecutionPolicy, Parameters...>>>(std::forward<Args>(args)...);
+            RegressionType<ObservedQuantityRecording<ExecutionPolicy, Parameters...>>>(std::forward<Args>(args)...);
+    };
+
+    template <template <typename...> class RegressionType, template <typename...> class LocalReduceMethodType,
+              typename DataType, class DynamicsIdentifier, typename... Args>
+    auto &addReduceRegression(DynamicsIdentifier &dynamics_identifier, Args &&...args)
+    {
+        return *other_io_keeper_.createPtr<
+            RegressionType<ReducedQuantityRecording<
+                ExecutionPolicy, LocalReduceMethodType<DataType, DynamicsIdentifier>>>>(
+            dynamics_identifier, std::forward<Args>(args)...);
+    };
+
+    template <template <typename...> class RegressionType, class LocalReduceMethodType, typename... Args>
+    auto &addReduceRegression(Args &&...args)
+    {
+        return *other_io_keeper_.createPtr<
+            RegressionType<ReducedQuantityRecording<ExecutionPolicy, LocalReduceMethodType>>>(std::forward<Args>(args)...);
     };
 
     template <template <typename...> class IOType, typename... Parameters, typename... Args>

--- a/src/shared/shared_ck/particle_dynamics/particle_method_container.h
+++ b/src/shared/shared_ck/particle_dynamics/particle_method_container.h
@@ -129,7 +129,7 @@ class ParticleMethodContainer : public BaseMethodContainer
 
     template <template <typename...> class InteractionType, typename... ControlParameters,
               template <typename...> class RelationType, typename... RelationParameters, typename... Args>
-    auto &add2ndRungeKuttaSequence(
+    auto &addRK2Sequence(
         RelationType<RelationParameters...> &relation, Args &&...args)
     {
         return *particle_dynamics_keeper_.createPtr<

--- a/tests/2d_examples/2d_examples_ck/test_0d_regression_test_ck/regression_test.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_0d_regression_test_ck/regression_test.cpp
@@ -134,6 +134,12 @@ int main(int ac, char *av[])
     ObserverBody temperature_observer(sph_system, "TemperatureObserver");
     temperature_observer.generateParticles<ObserverParticles>(createObservationPoints());
     //----------------------------------------------------------------------
+    //	Creating body parts.
+    //----------------------------------------------------------------------
+    BodyRegionByParticle left_boundary(diffusion_body, makeShared<MultiPolygonShape>(createLeftSideBoundary()));
+    BodyRegionByParticle other_boundary(diffusion_body, makeShared<MultiPolygonShape>(createOtherSideBoundary()));
+    BodyRegionByParticle inner_domain(diffusion_body, makeShared<MultiPolygonShape>(createInnerDomain(), "InnerDomain"));
+    //----------------------------------------------------------------------
     //	Define body relation map.
     //	The contact map gives the topological connections between the bodies.
     //	Basically the the range of bodies to build neighbor particle lists.
@@ -142,9 +148,10 @@ int main(int ac, char *av[])
     Inner<> diffusion_body_inner(diffusion_body);
     Contact<> observer_contact(temperature_observer, {&diffusion_body});
     //----------------------------------------------------------------------
-    // Define the main execution policy for this case.
+    // Define SPH solver with particle methods and execution policies.
     //----------------------------------------------------------------------
-    using MainExecutionPolicy = execution::ParallelPolicy;
+    SPHSolver sph_solver(sph_system);
+    auto &main_methods = sph_solver.addParticleMethodContainer(par);
     //----------------------------------------------------------------------
     // Define the numerical methods used in the simulation.
     // Note that there may be data dependence on the sequence of constructions.
@@ -156,37 +163,40 @@ int main(int ac, char *av[])
     // Finally, the auxiliary models such as time step estimator, initial condition,
     // boundary condition and other constraints should be defined.
     //----------------------------------------------------------------------
-    UpdateCellLinkedList<MainExecutionPolicy, RealBody> diffusion_body_cell_linked_list(diffusion_body);
-    UpdateRelation<MainExecutionPolicy, Inner<>> water_block_update_complex_relation(diffusion_body_inner);
-    UpdateRelation<MainExecutionPolicy, Contact<>> observer_update_contact_relation(observer_contact);
+    auto &diffusion_body_cell_linked_list = main_methods.addCellLinkedListDynamics(diffusion_body);
+    auto &water_block_update_complex_relation = main_methods.addRelationDynamics(diffusion_body_inner);
+    auto &observer_update_contact_relation = main_methods.addRelationDynamics(observer_contact);
 
-    InteractionDynamicsCK<MainExecutionPolicy, LinearCorrectionMatrixInner> correct_configuration(diffusion_body_inner);
+    auto &correct_configuration = main_methods.addInteractionDynamics<LinearCorrectionMatrixInner>(diffusion_body_inner);
+    auto &diffusion_initial_condition = main_methods.addStateDynamics<VariableAssignment, ConstantValue<Real>>(
+        diffusion_body, diffusion_species_name, initial_temperature);
 
-    StateDynamics<MainExecutionPolicy, VariableAssignment<SPHBody, ConstantValue<Real>>>
-        diffusion_initial_condition(diffusion_body, diffusion_species_name, initial_temperature);
     GetDiffusionTimeStepSize get_time_step_size(diffusion_body);
-    RungeKuttaSequence<InteractionDynamicsCK<
-        MainExecutionPolicy,
-        DiffusionRelaxationCK<Inner<OneLevel, RungeKutta1stStage, DirectionalDiffusion, LinearCorrectionCK>>,
-        DiffusionRelaxationCK<Inner<OneLevel, RungeKutta2ndStage, DirectionalDiffusion, LinearCorrectionCK>>>>
-        diffusion_relaxation_rk2(diffusion_body_inner);
+    auto &diffusion_relaxation_rk2 =
+        main_methods.add2ndRungeKuttaSequence<
+            DiffusionRelaxationCK, DirectionalDiffusion, LinearCorrectionCK>(diffusion_body_inner);
 
-    BodyRegionByParticle left_boundary(diffusion_body, makeShared<MultiPolygonShape>(createLeftSideBoundary()));
-    StateDynamics<MainExecutionPolicy, ConstantConstraintCK<BodyRegionByParticle, Real>>
-        left_boundary_condition(left_boundary, diffusion_species_name, high_temperature);
-    BodyRegionByParticle other_boundary(diffusion_body, makeShared<MultiPolygonShape>(createOtherSideBoundary()));
-    StateDynamics<MainExecutionPolicy, ConstantConstraintCK<BodyRegionByParticle, Real>>
-        other_boundary_condition(other_boundary, diffusion_species_name, low_temperature);
+    auto &left_boundary_condition =
+        main_methods.addStateDynamics<ConstantConstraintCK, Real>(left_boundary, diffusion_species_name, high_temperature);
+    auto &other_boundary_condition =
+        main_methods.addStateDynamics<ConstantConstraintCK, Real>(other_boundary, diffusion_species_name, low_temperature);
     //----------------------------------------------------------------------
     //	Define the methods for I/O operations, observations of the simulation.
     //	Regression tests are also defined here.
     //----------------------------------------------------------------------
-    BodyStatesRecordingToVtpCK<MainExecutionPolicy> write_states(sph_system);
-    RegressionTestEnsembleAverage<ObservedQuantityRecording<MainExecutionPolicy, Real>>
-        write_solid_temperature(diffusion_species_name, observer_contact);
-    BodyRegionByParticle inner_domain(diffusion_body, makeShared<MultiPolygonShape>(createInnerDomain(), "InnerDomain"));
-    RegressionTestDynamicTimeWarping<ReducedQuantityRecording<MainExecutionPolicy, QuantityAverage<Real, BodyPartByParticle>>>
-        write_solid_average_temperature_part(inner_domain, diffusion_species_name);
+    auto &write_states = main_methods.addBodyStateRecorder<BodyStatesRecordingToVtpCK>(sph_system);
+    auto &write_solid_temperature =
+        main_methods.addObserveRegression<RegressionTestEnsembleAverage, Real>(
+            diffusion_species_name, observer_contact);
+    auto &write_solid_average_temperature_part =
+        main_methods.addReduceRegression<RegressionTestDynamicTimeWarping, QuantityAverage, Real>(
+            inner_domain, diffusion_species_name);
+    //----------------------------------------------------------------------
+    //	Define time stepper with end and start time.
+    //----------------------------------------------------------------------
+    TimeStepper &time_stepper = sph_solver.defineTimeStepper(20.0);
+    size_t iteration_steps = 0;
+    auto &state_recording = time_stepper.addTriggerByInterval(0.2);
     //----------------------------------------------------------------------
     //	Prepare the simulation with cell linked list, configuration
     //	and case specified initial condition if necessary.
@@ -200,67 +210,38 @@ int main(int ac, char *av[])
     left_boundary_condition.exec();
     other_boundary_condition.exec();
     //----------------------------------------------------------------------
-    //	Setup for time-stepping control
-    //----------------------------------------------------------------------
-    SingularVariable<Real> *sv_physical_time = sph_system.getSystemVariableByName<Real>("PhysicalTime");
-    int ite = 0;
-    Real T0 = 20.0;
-    Real end_time = T0;
-    Real Output_Time = 0.1 * end_time;
-    Real Observe_time = 0.1 * Output_Time;
-    Real dt = 0.0;
-    //----------------------------------------------------------------------
-    //	Statistics for CPU time
-    //----------------------------------------------------------------------
-    TickCount t1 = TickCount::now();
-    TimeInterval interval;
-    //----------------------------------------------------------------------
     //	First output before the main loop.
     //----------------------------------------------------------------------
     write_states.writeToFile();
-    write_solid_temperature.writeToFile(ite);
+    write_solid_temperature.writeToFile(iteration_steps);
     //----------------------------------------------------------------------
     //	Main loop starts here.
     //----------------------------------------------------------------------
-    while (sv_physical_time->getValue() < end_time)
+    while (!time_stepper.isEndTime())
     {
-        Real integration_time = 0.0;
-        while (integration_time < Output_Time)
+        Real dt = time_stepper.incrementPhysicalTime(get_time_step_size);
+        diffusion_relaxation_rk2.exec(dt);
+        left_boundary_condition.exec();
+        other_boundary_condition.exec();
+        iteration_steps++;
+
+        if (iteration_steps % 10 == 0)
         {
-            Real relaxation_time = 0.0;
-            while (relaxation_time < Observe_time)
-            {
-                if (ite % 1 == 0)
-                {
-                    std::cout << "N=" << ite << " Time: " << sv_physical_time->getValue() << "	dt: " << dt << "\n";
-                }
-
-                diffusion_relaxation_rk2.exec(dt);
-                left_boundary_condition.exec();
-                other_boundary_condition.exec();
-                ite++;
-                dt = get_time_step_size.exec();
-                relaxation_time += dt;
-                integration_time += dt;
-                sv_physical_time->incrementValue(dt);
-
-                if (ite % 100 == 0)
-                {
-                    write_solid_temperature.writeToFile(ite);
-                    write_solid_average_temperature_part.writeToFile(ite);
-                    write_states.writeToFile();
-                }
-            }
+            std::cout << "N=" << iteration_steps << " Time: " << time_stepper.getPhysicalTime()
+                      << "	dt: " << time_stepper.getGlobalTimeStepSize() << "\n";
         }
 
-        TickCount t2 = TickCount::now();
-        TickCount t3 = TickCount::now();
-        interval += t3 - t2;
+        if (iteration_steps % 100 == 0)
+        {
+            write_solid_temperature.writeToFile(iteration_steps);
+            write_solid_average_temperature_part.writeToFile(iteration_steps);
+        }
+
+        if (state_recording())
+        {
+            write_states.writeToFile();
+        }
     }
-    TickCount t4 = TickCount::now();
-    TimeInterval tt;
-    tt = t4 - t1 - interval;
-    std::cout << "Total wall time for computation: " << tt.seconds() << " seconds." << std::endl;
     //----------------------------------------------------------------------
     //	@ensemble_average_method.
     //	The first argument is the threshold of mean value convergence.

--- a/tests/2d_examples/2d_examples_ck/test_0d_regression_test_ck/regression_test.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_0d_regression_test_ck/regression_test.cpp
@@ -173,8 +173,7 @@ int main(int ac, char *av[])
 
     GetDiffusionTimeStepSize get_time_step_size(diffusion_body);
     auto &diffusion_relaxation_rk2 =
-        main_methods.add2ndRungeKuttaSequence<
-            DiffusionRelaxationCK, DirectionalDiffusion, LinearCorrectionCK>(diffusion_body_inner);
+        main_methods.addRK2Sequence<DiffusionRelaxationCK, DirectionalDiffusion, LinearCorrectionCK>(diffusion_body_inner);
 
     auto &left_boundary_condition =
         main_methods.addStateDynamics<ConstantConstraintCK, Real>(left_boundary, diffusion_species_name, high_temperature);

--- a/tests/2d_examples/2d_examples_ck/test_2d_dambreak_ck/dambreak_ck.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_dambreak_ck/dambreak_ck.cpp
@@ -124,10 +124,10 @@ int main(int ac, char *av[])
     body_state_recorder.addToWrite<Vecd>(wall_boundary, "NormalDirection");
     body_state_recorder.addToWrite<Real>(water_block, "Density");
     auto &restart_io = main_methods.addIODynamics<RestartIOCK>(sph_system);
-    auto &record_water_mechanical_energy = main_methods.addRegressionTest<
-        RegressionTestDynamicTimeWarping, ReducedQuantityRecording, TotalMechanicalEnergyCK>(water_block, gravity);
-    auto &fluid_observer_pressure = main_methods.addRegressionTest<
-        RegressionTestDynamicTimeWarping, ObservedQuantityRecording, Real>("Pressure", fluid_observer_contact);
+    auto &record_water_mechanical_energy = main_methods.addReduceRegression<
+        RegressionTestDynamicTimeWarping, TotalMechanicalEnergyCK>(water_block, gravity);
+    auto &fluid_observer_pressure = main_methods.addObserveRegression<
+        RegressionTestDynamicTimeWarping, Real>("Pressure", fluid_observer_contact);
     //----------------------------------------------------------------------
     //	Define time stepper with end and start time.
     //----------------------------------------------------------------------

--- a/tests/2d_examples/2d_examples_ck/test_2d_diffusion_NeumannBC_ck/diffusion_NeumannBC.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_diffusion_NeumannBC_ck/diffusion_NeumannBC.cpp
@@ -163,13 +163,13 @@ int main(int ac, char *av[])
     UpdateRelation<MainExecutionPolicy, Contact<>> observer_contact_relation(temperature_observer_contact);
 
     StateDynamics<execution::ParallelPolicy, NormalFromBodyShapeCK> wall_boundary_normal_direction(wall_Neumann);
-    StateDynamics<MainExecutionPolicy, VariableAssignment<SPHBody, ConstantValue<Real>>>
+    StateDynamics<MainExecutionPolicy, VariableAssignment<ConstantValue<Real>, SPHBody>>
         diffusion_initial_condition(diffusion_body, diffusion_species_name, initial_temperature);
-    StateDynamics<MainExecutionPolicy, VariableAssignment<BodyRegionByParticle, ConstantValue<Real>>>
+    StateDynamics<MainExecutionPolicy, VariableAssignment<ConstantValue<Real>, BodyRegionByParticle>>
         left_initial_condition(wall_Dirichlet_left_region, diffusion_species_name, left_temperature);
-    StateDynamics<MainExecutionPolicy, VariableAssignment<BodyRegionByParticle, ConstantValue<Real>>>
+    StateDynamics<MainExecutionPolicy, VariableAssignment<ConstantValue<Real>, BodyRegionByParticle>>
         right_initial_condition(wall_Dirichlet_right_region, diffusion_species_name, right_temperature);
-    StateDynamics<MainExecutionPolicy, VariableAssignment<SPHBody, ConstantValue<Real>>>
+    StateDynamics<MainExecutionPolicy, VariableAssignment<ConstantValue<Real>, SPHBody>>
         wall_Neumann_initial_condition(wall_Neumann, diffusion_species_name + "Flux", heat_flux);
 
     IsotropicDiffusion isotropic_diffusion(diffusion_species_name, diffusion_coeff);

--- a/tests/tests_sycl/2d_examples/test_0d_regression_test_sycl/regression_test.cpp
+++ b/tests/tests_sycl/2d_examples/test_0d_regression_test_sycl/regression_test.cpp
@@ -173,8 +173,7 @@ int main(int ac, char *av[])
 
     GetDiffusionTimeStepSize get_time_step_size(diffusion_body);
     auto &diffusion_relaxation_rk2 =
-        main_methods.add2ndRungeKuttaSequence<
-            DiffusionRelaxationCK, DirectionalDiffusion, LinearCorrectionCK>(diffusion_body_inner);
+        main_methods.addRK2Sequence<DiffusionRelaxationCK, DirectionalDiffusion, LinearCorrectionCK>(diffusion_body_inner);
 
     auto &left_boundary_condition =
         main_methods.addStateDynamics<ConstantConstraintCK, Real>(left_boundary, diffusion_species_name, high_temperature);

--- a/tests/tests_sycl/2d_examples/test_0d_regression_test_sycl/regression_test.cpp
+++ b/tests/tests_sycl/2d_examples/test_0d_regression_test_sycl/regression_test.cpp
@@ -134,6 +134,12 @@ int main(int ac, char *av[])
     ObserverBody temperature_observer(sph_system, "TemperatureObserver");
     temperature_observer.generateParticles<ObserverParticles>(createObservationPoints());
     //----------------------------------------------------------------------
+    //	Creating body parts.
+    //----------------------------------------------------------------------
+    BodyRegionByParticle left_boundary(diffusion_body, makeShared<MultiPolygonShape>(createLeftSideBoundary()));
+    BodyRegionByParticle other_boundary(diffusion_body, makeShared<MultiPolygonShape>(createOtherSideBoundary()));
+    BodyRegionByParticle inner_domain(diffusion_body, makeShared<MultiPolygonShape>(createInnerDomain(), "InnerDomain"));
+    //----------------------------------------------------------------------
     //	Define body relation map.
     //	The contact map gives the topological connections between the bodies.
     //	Basically the the range of bodies to build neighbor particle lists.
@@ -142,9 +148,10 @@ int main(int ac, char *av[])
     Inner<> diffusion_body_inner(diffusion_body);
     Contact<> observer_contact(temperature_observer, {&diffusion_body});
     //----------------------------------------------------------------------
-    // Define the main execution policy for this case.
+    // Define SPH solver with particle methods and execution policies.
     //----------------------------------------------------------------------
-    using MainExecutionPolicy = execution::ParallelDevicePolicy;
+    SPHSolver sph_solver(sph_system);
+    auto &main_methods = sph_solver.addParticleMethodContainer(par_device);
     //----------------------------------------------------------------------
     // Define the numerical methods used in the simulation.
     // Note that there may be data dependence on the sequence of constructions.
@@ -156,38 +163,40 @@ int main(int ac, char *av[])
     // Finally, the auxiliary models such as time step estimator, initial condition,
     // boundary condition and other constraints should be defined.
     //----------------------------------------------------------------------
-    UpdateCellLinkedList<MainExecutionPolicy, RealBody> diffusion_body_cell_linked_list(diffusion_body);
+    auto &diffusion_body_cell_linked_list = main_methods.addCellLinkedListDynamics(diffusion_body);
+    auto &water_block_update_complex_relation = main_methods.addRelationDynamics(diffusion_body_inner);
+    auto &observer_update_contact_relation = main_methods.addRelationDynamics(observer_contact);
 
-    UpdateRelation<MainExecutionPolicy, Inner<>> water_block_update_complex_relation(diffusion_body_inner);
-    UpdateRelation<MainExecutionPolicy, Contact<>> observer_update_contact_relation(observer_contact);
+    auto &correct_configuration = main_methods.addInteractionDynamics<LinearCorrectionMatrixInner>(diffusion_body_inner);
+    auto &diffusion_initial_condition = main_methods.addStateDynamics<VariableAssignment, ConstantValue<Real>>(
+        diffusion_body, diffusion_species_name, initial_temperature);
 
-    InteractionDynamicsCK<MainExecutionPolicy, LinearCorrectionMatrixInner> correct_configuration(diffusion_body_inner);
-
-    StateDynamics<MainExecutionPolicy, VariableAssignment<SPHBody, ConstantValue<Real>>>
-        diffusion_initial_condition(diffusion_body, diffusion_species_name, initial_temperature);
     GetDiffusionTimeStepSize get_time_step_size(diffusion_body);
-    DynamicsSequence<InteractionDynamicsCK<
-        MainExecutionPolicy,
-        DiffusionRelaxationCK<Inner<OneLevel, RungeKutta1stStage, DirectionalDiffusion, LinearCorrectionCK>>,
-        DiffusionRelaxationCK<Inner<OneLevel, RungeKutta2ndStage, DirectionalDiffusion, LinearCorrectionCK>>>>
-        diffusion_relaxation_rk2(diffusion_body_inner, diffusion_body_inner);
+    auto &diffusion_relaxation_rk2 =
+        main_methods.add2ndRungeKuttaSequence<
+            DiffusionRelaxationCK, DirectionalDiffusion, LinearCorrectionCK>(diffusion_body_inner);
 
-    BodyRegionByParticle left_boundary(diffusion_body, makeShared<MultiPolygonShape>(createLeftSideBoundary()));
-    StateDynamics<MainExecutionPolicy, ConstantConstraintCK<BodyRegionByParticle, Real>>
-        left_boundary_condition(left_boundary, diffusion_species_name, high_temperature);
-    BodyRegionByParticle other_boundary(diffusion_body, makeShared<MultiPolygonShape>(createOtherSideBoundary()));
-    StateDynamics<MainExecutionPolicy, ConstantConstraintCK<BodyRegionByParticle, Real>>
-        other_boundary_condition(other_boundary, diffusion_species_name, low_temperature);
+    auto &left_boundary_condition =
+        main_methods.addStateDynamics<ConstantConstraintCK, Real>(left_boundary, diffusion_species_name, high_temperature);
+    auto &other_boundary_condition =
+        main_methods.addStateDynamics<ConstantConstraintCK, Real>(other_boundary, diffusion_species_name, low_temperature);
     //----------------------------------------------------------------------
     //	Define the methods for I/O operations, observations of the simulation.
     //	Regression tests are also defined here.
     //----------------------------------------------------------------------
-    BodyStatesRecordingToVtpCK<MainExecutionPolicy> write_states(sph_system);
-    RegressionTestEnsembleAverage<ObservedQuantityRecording<MainExecutionPolicy, Real>>
-        write_solid_temperature(diffusion_species_name, observer_contact);
-    BodyRegionByParticle inner_domain(diffusion_body, makeShared<MultiPolygonShape>(createInnerDomain(), "InnerDomain"));
-    RegressionTestDynamicTimeWarping<ReducedQuantityRecording<MainExecutionPolicy, QuantityAverage<Real, BodyPartByParticle>>>
-        write_solid_average_temperature_part(inner_domain, diffusion_species_name);
+    auto &write_states = main_methods.addBodyStateRecorder<BodyStatesRecordingToVtpCK>(sph_system);
+    auto &write_solid_temperature =
+        main_methods.addObserveRegression<RegressionTestEnsembleAverage, Real>(
+            diffusion_species_name, observer_contact);
+    auto &write_solid_average_temperature_part =
+        main_methods.addReduceRegression<RegressionTestDynamicTimeWarping, QuantityAverage, Real>(
+            inner_domain, diffusion_species_name);
+    //----------------------------------------------------------------------
+    //	Define time stepper with end and start time.
+    //----------------------------------------------------------------------
+    TimeStepper &time_stepper = sph_solver.defineTimeStepper(20.0);
+    size_t iteration_steps = 0;
+    auto &state_recording = time_stepper.addTriggerByInterval(0.2);
     //----------------------------------------------------------------------
     //	Prepare the simulation with cell linked list, configuration
     //	and case specified initial condition if necessary.
@@ -201,67 +210,38 @@ int main(int ac, char *av[])
     left_boundary_condition.exec();
     other_boundary_condition.exec();
     //----------------------------------------------------------------------
-    //	Setup for time-stepping control
-    //----------------------------------------------------------------------
-    SingularVariable<Real> *sv_physical_time = sph_system.getSystemVariableByName<Real>("PhysicalTime");
-    int ite = 0;
-    Real T0 = 20.0;
-    Real end_time = T0;
-    Real Output_Time = 0.1 * end_time;
-    Real Observe_time = 0.1 * Output_Time;
-    Real dt = 0.0;
-    //----------------------------------------------------------------------
-    //	Statistics for CPU time
-    //----------------------------------------------------------------------
-    TickCount t1 = TickCount::now();
-    TimeInterval interval;
-    //----------------------------------------------------------------------
     //	First output before the main loop.
     //----------------------------------------------------------------------
     write_states.writeToFile();
-    write_solid_temperature.writeToFile(ite);
+    write_solid_temperature.writeToFile(iteration_steps);
     //----------------------------------------------------------------------
     //	Main loop starts here.
     //----------------------------------------------------------------------
-    while (sv_physical_time->getValue() < end_time)
+    while (!time_stepper.isEndTime())
     {
-        Real integration_time = 0.0;
-        while (integration_time < Output_Time)
+        Real dt = time_stepper.incrementPhysicalTime(get_time_step_size);
+        diffusion_relaxation_rk2.exec(dt);
+        left_boundary_condition.exec();
+        other_boundary_condition.exec();
+        iteration_steps++;
+
+        if (iteration_steps % 10 == 0)
         {
-            Real relaxation_time = 0.0;
-            while (relaxation_time < Observe_time)
-            {
-                if (ite % 1 == 0)
-                {
-                    std::cout << "N=" << ite << " Time: " << sv_physical_time->getValue() << "	dt: " << dt << "\n";
-                }
-
-                diffusion_relaxation_rk2.exec(dt);
-                left_boundary_condition.exec();
-                other_boundary_condition.exec();
-                ite++;
-                dt = get_time_step_size.exec();
-                relaxation_time += dt;
-                integration_time += dt;
-                sv_physical_time->incrementValue(dt);
-
-                if (ite % 100 == 0)
-                {
-                    write_solid_temperature.writeToFile(ite);
-                    write_solid_average_temperature_part.writeToFile(ite);
-                    write_states.writeToFile();
-                }
-            }
+            std::cout << "N=" << iteration_steps << " Time: " << time_stepper.getPhysicalTime()
+                      << "	dt: " << time_stepper.getGlobalTimeStepSize() << "\n";
         }
 
-        TickCount t2 = TickCount::now();
-        TickCount t3 = TickCount::now();
-        interval += t3 - t2;
+        if (iteration_steps % 100 == 0)
+        {
+            write_solid_temperature.writeToFile(iteration_steps);
+            write_solid_average_temperature_part.writeToFile(iteration_steps);
+        }
+
+        if (state_recording())
+        {
+            write_states.writeToFile();
+        }
     }
-    TickCount t4 = TickCount::now();
-    TimeInterval tt;
-    tt = t4 - t1 - interval;
-    std::cout << "Total wall time for computation: " << tt.seconds() << " seconds." << std::endl;
     //----------------------------------------------------------------------
     //	@ensemble_average_method.
     //	The first argument is the threshold of mean value convergence.

--- a/tests/tests_sycl/2d_examples/test_2d_dambreak_sycl/dambreak_sycl.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_dambreak_sycl/dambreak_sycl.cpp
@@ -124,10 +124,10 @@ int main(int ac, char *av[])
     body_state_recorder.addToWrite<Vecd>(wall_boundary, "NormalDirection");
     body_state_recorder.addToWrite<Real>(water_block, "Density");
     auto &restart_io = main_methods.addIODynamics<RestartIOCK>(sph_system);
-    auto &record_water_mechanical_energy = main_methods.addRegressionTest<
-        RegressionTestDynamicTimeWarping, ReducedQuantityRecording, TotalMechanicalEnergyCK>(water_block, gravity);
-    auto &fluid_observer_pressure = main_methods.addRegressionTest<
-        RegressionTestDynamicTimeWarping, ObservedQuantityRecording, Real>("Pressure", fluid_observer_contact);
+    auto &record_water_mechanical_energy = main_methods.addReduceRegression<
+        RegressionTestDynamicTimeWarping, TotalMechanicalEnergyCK>(water_block, gravity);
+    auto &fluid_observer_pressure = main_methods.addObserveRegression<
+        RegressionTestDynamicTimeWarping, Real>("Pressure", fluid_observer_contact);
     //----------------------------------------------------------------------
     //	Define time stepper with end and start time.
     //----------------------------------------------------------------------

--- a/tests/tests_sycl/2d_examples/test_2d_diffusion_NeumannBC_sycl/diffusion_NeumannBC.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_diffusion_NeumannBC_sycl/diffusion_NeumannBC.cpp
@@ -163,13 +163,13 @@ int main(int ac, char *av[])
     UpdateRelation<MainExecutionPolicy, Contact<>> observer_contact_relation(temperature_observer_contact);
 
     StateDynamics<execution::ParallelPolicy, NormalFromBodyShapeCK> wall_boundary_normal_direction(wall_Neumann);
-    StateDynamics<MainExecutionPolicy, VariableAssignment<SPHBody, ConstantValue<Real>>>
+    StateDynamics<MainExecutionPolicy, VariableAssignment<ConstantValue<Real>, SPHBody>>
         diffusion_initial_condition(diffusion_body, diffusion_species_name, initial_temperature);
-    StateDynamics<MainExecutionPolicy, VariableAssignment<BodyRegionByParticle, ConstantValue<Real>>>
+    StateDynamics<MainExecutionPolicy, VariableAssignment<ConstantValue<Real>, BodyRegionByParticle>>
         left_initial_condition(wall_Dirichlet_left_region, diffusion_species_name, left_temperature);
-    StateDynamics<MainExecutionPolicy, VariableAssignment<BodyRegionByParticle, ConstantValue<Real>>>
+    StateDynamics<MainExecutionPolicy, VariableAssignment<ConstantValue<Real>, BodyRegionByParticle>>
         right_initial_condition(wall_Dirichlet_right_region, diffusion_species_name, right_temperature);
-    StateDynamics<MainExecutionPolicy, VariableAssignment<SPHBody, ConstantValue<Real>>>
+    StateDynamics<MainExecutionPolicy, VariableAssignment<ConstantValue<Real>, SPHBody>>
         wall_Neumann_initial_condition(wall_Neumann, diffusion_species_name + "Flux", heat_flux);
 
     IsotropicDiffusion isotropic_diffusion(diffusion_species_name, diffusion_coeff);

--- a/tests/tests_sycl/unit_test_src/shared/particle_dynamics/general_dynamics/unit_test_gradient_sycl/2d_gradient.cpp
+++ b/tests/tests_sycl/unit_test_src/shared/particle_dynamics/general_dynamics/unit_test_gradient_sycl/2d_gradient.cpp
@@ -171,9 +171,9 @@ int main(int ac, char *av[])
     InteractionDynamicsCK<MainExecutionPolicy, HessianCorrectionMatrix<Inner<WithUpdate>, Contact<>>>
         hessian_correction_matrix(DynamicsArgs(water_block_inner, 0.0), water_wall_contact);
 
-    StateDynamics<MainExecutionPolicy, VariableAssignment<SPHBody, SpatialDistribution<ParabolicProfile>>>
+    StateDynamics<MainExecutionPolicy, VariableAssignment<SpatialDistribution<ParabolicProfile>, SPHBody>>
         water_block_initial_condition(water_block, "Phi");
-    StateDynamics<MainExecutionPolicy, VariableAssignment<SPHBody, SpatialDistribution<ParabolicProfile>>>
+    StateDynamics<MainExecutionPolicy, VariableAssignment<SpatialDistribution<ParabolicProfile>, SPHBody>>
         wall_initial_condition(wall, "Phi");
     InteractionDynamicsCK<MainExecutionPolicy, LinearGradient<Inner<Real>, Contact<Real>>>
         variable_linear_gradient(

--- a/tests/unit_tests_src/shared/particle_dynamics/general_dynamics/unit_test_gradient_ck/2d_gradient.cpp
+++ b/tests/unit_tests_src/shared/particle_dynamics/general_dynamics/unit_test_gradient_ck/2d_gradient.cpp
@@ -70,7 +70,7 @@ class ParabolicProfile : public ReturnFunction<Real>
 
   public:
     ParabolicProfile() : first_coefficient_(first_coefficient),
-        second_coefficient_(second_coefficient) {};
+                         second_coefficient_(second_coefficient) {};
 
     Real operator()(const Vec2d &position)
     {
@@ -172,9 +172,9 @@ int main(int ac, char *av[])
     InteractionDynamicsCK<MainExecutionPolicy, HessianCorrectionMatrix<Inner<WithUpdate>, Contact<>>>
         hessian_correction_matrix(DynamicsArgs(water_block_inner, 0.0), water_wall_contact);
 
-    StateDynamics<MainExecutionPolicy, VariableAssignment<SPHBody, SpatialDistribution<ParabolicProfile>>>
+    StateDynamics<MainExecutionPolicy, VariableAssignment<SpatialDistribution<ParabolicProfile>, SPHBody>>
         water_block_initial_condition(water_block, "Phi");
-    StateDynamics<MainExecutionPolicy, VariableAssignment<SPHBody, SpatialDistribution<ParabolicProfile>>>
+    StateDynamics<MainExecutionPolicy, VariableAssignment<SpatialDistribution<ParabolicProfile>, SPHBody>>
         wall_initial_condition(wall, "Phi");
     InteractionDynamicsCK<MainExecutionPolicy, LinearGradient<Inner<Real>, Contact<Real>>>
         variable_linear_gradient(


### PR DESCRIPTION
This pull request introduces several updates to improve the structure and functionality of particle dynamics in SPH (Smoothed Particle Hydrodynamics) simulations. Key changes include refactoring template parameter order for consistency, adding new methods to enhance flexibility in defining dynamics, and simplifying simulation setup in test cases. The updates aim to streamline code readability, improve maintainability, and enhance simulation capabilities.

### Refactoring Template Parameter Order:
* Updated the order of template parameters in `VariableAssignment` and `ConstantConstraintCK` classes to prioritize the `AssignmentFunctionType` or `DataType` over `DynamicsIdentifier` for consistency across the codebase. (`src/shared/shared_ck/particle_dynamics/general_dynamics/general_assignment.h` - [[1]](diffhunk://#diff-66bbe592db2864e78756ce48d1b8008bf48dd93a151b9453ebc8df3bdb46b5c7L36-R36) `src/shared/shared_ck/particle_dynamics/general_dynamics/general_constraint_ck.h` - [[2]](diffhunk://#diff-0d5431e2ce9b7a5729b28c6acea5989062f810574b58990864db59026178ebf5L37-R37)

### Enhancements to `ParticleMethodContainer`:
* Added new methods such as `addStateDynamics`, `add2ndRungeKuttaSequence`, and `addReduceRegression` to support more flexible and modular definitions of dynamics and regression tests. (`src/shared/shared_ck/particle_dynamics/particle_method_container.h` - [[1]](diffhunk://#diff-e01bd7970daee29a0a395d1b3b4be8cc465552c6cd839ab3e8799bc8c90c8a37R96-R104) [[2]](diffhunk://#diff-e01bd7970daee29a0a395d1b3b4be8cc465552c6cd839ab3e8799bc8c90c8a37R130-R170) [[3]](diffhunk://#diff-e01bd7970daee29a0a395d1b3b4be8cc465552c6cd839ab3e8799bc8c90c8a37L108-R119)
* Refactored existing methods like `addInteractionDynamics` to improve parameter handling and readability. (`src/shared/shared_ck/particle_dynamics/particle_method_container.h` - [src/shared/shared_ck/particle_dynamics/particle_method_container.hL108-R119](diffhunk://#diff-e01bd7970daee29a0a395d1b3b4be8cc465552c6cd839ab3e8799bc8c90c8a37L108-R119))

### Simplification of Test Case Setup:
* Replaced manual initialization of dynamics and regression tests with streamlined method calls using `ParticleMethodContainer` in multiple test files, including `test_0d_regression_test_ck`, `test_2d_dambreak_ck`, and `test_2d_diffusion_NeumannBC_ck`. (`tests/2d_examples/2d_examples_ck/test_0d_regression_test_ck/regression_test.cpp` - [[1]](diffhunk://#diff-2b3889a7619639bdca3dacee19be82730054c6c5ee354d4d03204ae07b7f18e7L159-R199) [[2]](diffhunk://#diff-2b3889a7619639bdca3dacee19be82730054c6c5ee354d4d03204ae07b7f18e7L203-L263); `tests/2d_examples/2d_examples_ck/test_2d_dambreak_ck/dambreak_ck.cpp` - [[3]](diffhunk://#diff-875bc2a9d578ebd35729d2f937f17906e2aaede91b3fbaf677f5e694069975f5L127-R130); `tests/2d_examples/2d_examples_ck/test_2d_diffusion_NeumannBC_ck/diffusion_NeumannBC.cpp` - [[4]](diffhunk://#diff-08b33bf4007b7208513197254a3a0ef5ee3f5ef19467b215194449fd004415fcL166-R172)

### Introduction of SPHSolver:
* Introduced `SPHSolver` in test cases to encapsulate particle method containers and execution policies, simplifying the setup and execution of SPH simulations. (`tests/2d_examples/2d_examples_ck/test_0d_regression_test_ck/regression_test.cpp` - [[1]](diffhunk://#diff-2b3889a7619639bdca3dacee19be82730054c6c5ee354d4d03204ae07b7f18e7L145-R154) `tests/tests_sycl/2d_examples/test_0d_regression_test_sycl/regression_test.cpp` - [[2]](diffhunk://#diff-51b8c56769c3a56473e73715b14b1f1a4f0a49004862e342efad5a499e406215L145-R154)

### Addition of Body Parts in Test Cases:
* Added definitions for body parts (e.g., `left_boundary`, `inner_domain`) in regression test setups to enhance simulation capabilities and provide more detailed control over domain boundaries. (`tests/2d_examples/2d_examples_ck/test_0d_regression_test_ck/regression_test.cpp` - [[1]](diffhunk://#diff-2b3889a7619639bdca3dacee19be82730054c6c5ee354d4d03204ae07b7f18e7R137-R142) `tests/tests_sycl/2d_examples/test_0d_regression_test_sycl/regression_test.cpp` - [[2]](diffhunk://#diff-51b8c56769c3a56473e73715b14b1f1a4f0a49004862e342efad5a499e406215R137-R142)