### PR TITLE
Revise Log Generator

### DIFF
--- a/src/shared/io_system/io_environment.cpp
+++ b/src/shared/io_system/io_environment.cpp
@@ -22,7 +22,15 @@ IOEnvironment::IOEnvironment(SPHSystem &sph_system)
     }
     else
     {
-        fs::remove_all(output_folder_);
+        std::string backup_name = output_folder_ + "_backup";
+        fs::path output_dir = output_folder_;
+        fs::path backup_path = output_dir.parent_path() / backup_name;
+        if (fs::exists(backup_path))
+        {
+            fs::remove_all(backup_path);
+        }
+        fs::rename(output_dir, backup_path);
+        std::cout << "Moved existing output to: " << backup_path << std::endl;
         fs::create_directory(output_folder_);
     }
 

--- a/src/shared/io_system/io_log.cpp
+++ b/src/shared/io_system/io_log.cpp
@@ -2,7 +2,7 @@
 
 #include "io_environment.h"
 
-#include <spdlog/sinks/basic_file_sink.h>
+#include "spdlog/sinks/rotating_file_sink.h"
 
 namespace SPH
 {
@@ -15,7 +15,10 @@ void init(IOEnvironment &io_environment)
 {
     if (!logger) // Create a logger with a file sink
     {
-        logger = spdlog::basic_logger_mt("sphinxsys_logger", "sphinxsys.log");
+        // Create a file rotating logger with 5 MB size max and 3 rotated files
+        auto max_size = 1048576 * 5;
+        auto max_files = 3;
+        logger = spdlog::rotating_logger_mt("sphinxsys_logger", "sphinxsys.log", max_size, max_files);
         logger->flush_on(spdlog::level::info);                          // Flush logs on info level
         spdlog::set_default_logger(logger);                             // Set the default logger to the created logger
         spdlog::set_pattern("[%Y-%m-%d %H:%M:%S] [%l] [thread %t] %v"); // Set the log format

--- a/src/shared/shared_ck/particle_dynamics/configuration_dynamics/update_body_relation.hpp
+++ b/src/shared/shared_ck/particle_dynamics/configuration_dynamics/update_body_relation.hpp
@@ -100,9 +100,14 @@ void UpdateRelation<ExecutionPolicy, Inner<Parameters...>>::exec(Real dt)
 
     if (current_neighbor_index_size > dv_neighbor_index->getDataSize())
     {
+        UnsignedInt old_size = dv_neighbor_index->getDataSize();
         dv_neighbor_index->reallocateData(ex_policy_, current_neighbor_index_size);
         this->inner_relation_.resetComputingKernelUpdated();
         kernel_implementation_.overwriteComputingKernel();
+
+        this->logger_->info(
+            "UpdateRelation: increase neighbor index size from {} to {} at {} .",
+            old_size, dv_neighbor_index->getDataSize(), this->sph_body_.getName());
     }
 
     particle_for(ex_policy_,
@@ -197,8 +202,9 @@ void UpdateRelation<ExecutionPolicy, Contact<Parameters...>>::exec(Real dt)
                      [=](size_t i)
                      { computing_kernel->incrementNeighborSize(i); });
 
-        this->logger_->debug("UpdateCellLinkedList: incrementNeighborSize done at {} for Relation {}.",
-                             this->sph_body_.getName(), type_name<Contact<Parameters...>>());
+        this->logger_->debug("UpdateRelation: incrementNeighborSize done at {} for Relation {} to {}.",
+                             this->sph_body_.getName(), type_name<Contact<Parameters...>>(),
+                             contact_relation_.getContactIdentifier(k).getName());
 
         auto *dv_neighbor_index = this->contact_relation_.getNeighborIndex(k);
         auto *dv_particle_offset = this->contact_relation_.getParticleOffset(k);
@@ -211,9 +217,14 @@ void UpdateRelation<ExecutionPolicy, Contact<Parameters...>>::exec(Real dt)
 
         if (current_neighbor_index_size > dv_neighbor_index->getDataSize())
         {
+            UnsignedInt old_size = dv_neighbor_index->getDataSize();
             dv_neighbor_index->reallocateData(ex_policy_, current_neighbor_index_size);
             this->contact_relation_.resetComputingKernelUpdated(k);
             contact_kernel_implementation_[k]->overwriteComputingKernel(k);
+
+            this->logger_->info(
+                "UpdateRelation: increase neighbor index size from {} to {} at .",
+                old_size, dv_neighbor_index->getDataSize(), this->sph_body_.getName());
         }
 
         particle_for(ex_policy_,
@@ -222,8 +233,9 @@ void UpdateRelation<ExecutionPolicy, Contact<Parameters...>>::exec(Real dt)
                      { computing_kernel->updateNeighborList(i); });
 
         this->logger_->debug(
-            "UpdateCellLinkedList: updateNeighborList done at {} for Relation {}.",
-            this->sph_body_.getName(), type_name<Contact<Parameters...>>());
+            "UpdateRelation: updateNeighborList done at {} for Relation {} to {}.",
+            this->sph_body_.getName(), type_name<Contact<Parameters...>>(),
+            contact_relation_.getContactIdentifier(k).getName());
     }
 }
 //=================================================================================================//

--- a/src/shared/sphinxsys_system/sph_system.cpp
+++ b/src/shared/sphinxsys_system/sph_system.cpp
@@ -21,6 +21,18 @@ SPHSystem::SPHSystem(BoundingBox system_domain_bounds, Real resolution_ref, size
     registerSystemVariable<Real>("PhysicalTime", 0.0);
 }
 //=================================================================================================//
+void SPHSystem::setLogLevel(size_t log_level)
+{
+    if (log_level < 0 || log_level > 6)
+    {
+        std::cerr << "Log level must be between 0 and 6.\n";
+        exit(1);
+    }
+
+    log_level_ = log_level;
+    spdlog::set_level(static_cast<spdlog::level::level_enum>(log_level_));
+}
+//=================================================================================================//
 IOEnvironment &SPHSystem::getIOEnvironment()
 {
     if (io_environment_ == nullptr)

--- a/src/shared/sphinxsys_system/sph_system.h
+++ b/src/shared/sphinxsys_system/sph_system.h
@@ -71,6 +71,7 @@ class SPHSystem
     bool StateRecording() { return state_recording_; };
     void setStateRecording(bool state_recording) { state_recording_ = state_recording; };
     void setRestartStep(size_t restart_step) { restart_step_ = restart_step; };
+    void setLogLevel(size_t log_level);
     size_t RestartStep() { return restart_step_; };
     /** Initialize cell linked list for the SPH system. */
     void initializeSystemCellLinkedLists();


### PR DESCRIPTION
This pull request introduces several updates to logging, file management, and system configuration within the SPH system. Key changes include enhancing the logging system with rotating log files, improving output directory handling by implementing a backup mechanism, and adding a method to configure log levels. Additionally, logging messages in particle dynamics were improved for better clarity.

### Logging Enhancements:
* Replaced the basic file logger with a rotating file logger in `io_log.cpp`, allowing up to 5 MB per file and 3 rotated files for better log management. (`[[1]](diffhunk://#diff-a6e22fdeb0d614f25256e4b9a2f525b4f9f49c917bf2977879a9b311f85a1234L5-R5)`, `[[2]](diffhunk://#diff-a6e22fdeb0d614f25256e4b9a2f525b4f9f49c917bf2977879a9b311f85a1234L18-R21)`)
* Added a new method `setLogLevel` in `SPHSystem` to configure logging verbosity levels, with validation to ensure the level is between 0 and 6. (`[[1]](diffhunk://#diff-79de432f29aa9fba528130763843cc5741f40343bada480df8e007b787815533R24-R35)`, `[[2]](diffhunk://#diff-bf5842e948f30501e533fc7284884ef933f1dab28038c934ef786388c48eaaefR74)`)

### File Management Improvements:
* Updated `IOEnvironment` to back up the existing output directory before creating a new one, preventing accidental data loss. If a backup already exists, it will be removed before creating a new backup. (`[src/shared/io_system/io_environment.cppL25-R33](diffhunk://#diff-1f88932675c4ad1ea64f426b8eb40e71c0abcf72d54b4b1dc5ddcceef14f2db9L25-R33)`)

### Particle Dynamics Logging Updates:
* Enhanced logging in `UpdateRelation` methods to include more detailed information, such as the size changes in neighbor indices and specific contact identifiers, improving traceability. (`[[1]](diffhunk://#diff-7ee8774e3c6fb91d4235dbabf9be9112149fd215f6812df43ce5bf5273052bc6R103-R110)`, `[[2]](diffhunk://#diff-7ee8774e3c6fb91d4235dbabf9be9112149fd215f6812df43ce5bf5273052bc6L200-R207)`, `[[3]](diffhunk://#diff-7ee8774e3c6fb91d4235dbabf9be9112149fd215f6812df43ce5bf5273052bc6R220-R227)`, `[[4]](diffhunk://#diff-7ee8774e3c6fb91d4235dbabf9be9112149fd215f6812df43ce5bf5273052bc6L225-R238)`)