### PR TITLE
move total body part to base particles

### DIFF
--- a/src/shared/bodies/base_body.cpp
+++ b/src/shared/bodies/base_body.cpp
@@ -9,7 +9,7 @@ namespace SPH
 //=================================================================================================//
 SPHBody::SPHBody(SPHSystem &sph_system, Shape &shape, const std::string &name)
     : sph_system_(sph_system), body_name_(name), newly_updated_(true),
-      base_particles_(nullptr), is_bound_set_(false), initial_shape_(&shape), total_body_parts_(0),
+      base_particles_(nullptr), is_bound_set_(false), initial_shape_(&shape),
       sph_adaptation_(sph_adaptation_ptr_keeper_.createPtr<SPHAdaptation>(sph_system.ReferenceResolution())),
       base_material_(base_material_ptr_keeper_.createPtr<BaseMaterial>())
 {
@@ -35,12 +35,6 @@ BoundingBox SPHBody::getSPHSystemBounds()
 {
     return sph_system_.getSystemDomainBounds();
 }
-//=================================================================================================//
-int SPHBody::getNewBodyPartID()
-{
-    total_body_parts_++;
-    return total_body_parts_;
-};
 //=================================================================================================//
 SPHSystem &SPHBody::getSPHSystem()
 {

--- a/src/shared/bodies/base_body.h
+++ b/src/shared/bodies/base_body.h
@@ -52,7 +52,6 @@ namespace SPH
 {
 class SPHRelation;
 class BodySurface;
-class BodyPartByParticle;
 
 /**
  * @class SPHBody
@@ -72,16 +71,14 @@ class SPHBody
   protected:
     SPHSystem &sph_system_;
     std::string body_name_;
-    bool newly_updated_;                                  /**< whether this body is in a newly updated state */
-    BaseParticles *base_particles_;                       /**< Base particles for dynamic cast DataDelegate  */
-    bool is_bound_set_;                                   /**< whether the bounding box is set */
-    BoundingBox bound_;                                   /**< bounding box of the body */
-    Shape *initial_shape_;                                /**< initial volumetric geometry enclosing the body */
-    int total_body_parts_;                                /**< total number of body parts */
-    StdVec<BodyPartByParticle *> body_parts_by_particle_; /**< all body parts by particle */
-    SPHAdaptation *sph_adaptation_;                       /**< numerical adaptation policy */
-    BaseMaterial *base_material_;                         /**< base material for dynamic cast in DataDelegate */
-    StdVec<SPHRelation *> body_relations_;                /**< all contact relations centered from this body **/
+    bool newly_updated_;                   /**< whether this body is in a newly updated state */
+    BaseParticles *base_particles_;        /**< Base particles for dynamic cast DataDelegate  */
+    bool is_bound_set_;                    /**< whether the bounding box is set */
+    BoundingBox bound_;                    /**< bounding box of the body */
+    Shape *initial_shape_;                 /**< initial volumetric geometry enclosing the body */
+    SPHAdaptation *sph_adaptation_;        /**< numerical adaptation policy */
+    BaseMaterial *base_material_;          /**< base material for dynamic cast in DataDelegate */
+    StdVec<SPHRelation *> body_relations_; /**< all contact relations centered from this body **/
 
   public:
     typedef SPHBody BaseIdentifier;
@@ -110,10 +107,6 @@ class SPHBody
     void setSPHBodyBounds(const BoundingBox &bound);
     BoundingBox getSPHBodyBounds();
     BoundingBox getSPHSystemBounds();
-    int getNewBodyPartID();
-    int getTotalBodyParts() { return total_body_parts_; };
-    void addBodyPartByParticle(BodyPartByParticle *body_part) { body_parts_by_particle_.push_back(body_part); };
-    StdVec<BodyPartByParticle *> getBodyPartsByParticle() { return body_parts_by_particle_; };
 
     class SourceParticleMask
     {
@@ -140,8 +133,7 @@ class SPHBody
     //----------------------------------------------------------------------
     //		Object factory template functions
     //----------------------------------------------------------------------
-    virtual void
-    defineAdaptationRatios(Real h_spacing_ratio, Real new_system_refinement_ratio = 1.0);
+    virtual void defineAdaptationRatios(Real h_spacing_ratio, Real new_system_refinement_ratio = 1.0);
 
     template <class AdaptationType, typename... Args>
     void defineAdaptation(Args &&...args)

--- a/src/shared/bodies/base_body_part.cpp
+++ b/src/shared/bodies/base_body_part.cpp
@@ -6,10 +6,11 @@ namespace SPH
 {
 //=================================================================================================//
 BodyPart::BodyPart(SPHBody &sph_body)
-    : sph_body_(sph_body), part_id_(sph_body.getNewBodyPartID()),
+    : sph_body_(sph_body), base_particles_(sph_body.getBaseParticles()),
+      part_id_(base_particles_.getNewBodyPartID()),
       part_name_(sph_body.getName() + "Part" + std::to_string(part_id_)),
       sph_adaptation_(sph_body.getSPHAdaptation()),
-      base_particles_(sph_body.getBaseParticles()), sv_range_size_(nullptr),
+      sv_range_size_(nullptr),
       dv_body_part_id_(base_particles_.registerStateVariableOnly<int>(part_name_ + "ID")),
       pos_(base_particles_.getVariableDataByName<Vecd>("Position")) {}
 //=================================================================================================//
@@ -28,7 +29,7 @@ BodyPartByParticle::BodyPartByParticle(SPHBody &sph_body)
     : BodyPart(sph_body), body_part_bounds_(Vecd::Zero(), Vecd::Zero()),
       body_part_bounds_set_(false)
 {
-    sph_body.addBodyPartByParticle(this);
+    base_particles_.addBodyPartByParticle(this);
     base_particles_.addEvolvingVariable<int>(dv_body_part_id_);
 }
 //=================================================================================================//

--- a/src/shared/bodies/base_body_part.h
+++ b/src/shared/bodies/base_body_part.h
@@ -81,11 +81,11 @@ class BodyPart
 
   protected:
     SPHBody &sph_body_;
+    BaseParticles &base_particles_;
     int part_id_;
     std::string part_name_;
     std::optional<std::string> alias_;
     SPHAdaptation &sph_adaptation_;
-    BaseParticles &base_particles_;
     SingularVariable<UnsignedInt> *sv_range_size_;
     DiscreteVariable<int> *dv_body_part_id_;
     Vecd *pos_;

--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -16,7 +16,8 @@ BaseParticles::BaseParticles(SPHBody &sph_body, BaseMaterial *base_material)
       sph_body_(sph_body), body_name_(sph_body.getName()),
       base_material_(*base_material),
       restart_xml_parser_("xml_restart", "particles"),
-      reload_xml_parser_("xml_particle_reload", "particles")
+      reload_xml_parser_("xml_particle_reload", "particles"),
+      total_body_parts_(0)
 {
     sph_body.assignBaseParticles(this);
     sv_total_real_particles_ = registerSingularVariable<UnsignedInt>("TotalRealParticles");
@@ -122,6 +123,12 @@ UnsignedInt BaseParticles::createRealParticleFrom(UnsignedInt index)
     incrementTotalRealParticles();
     return new_original_id;
 }
+//=================================================================================================//
+int BaseParticles::getNewBodyPartID()
+{
+    total_body_parts_++;
+    return total_body_parts_;
+};
 //=================================================================================================//
 void BaseParticles::resizeXmlDocForParticles(XmlParser &xml_parser)
 {

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -49,6 +49,7 @@ class SPHBody;
 class SPHAdaptation;
 class BaseMaterial;
 class BodySurface;
+class BodyPartByParticle;
 
 /**
  * @class BaseParticles
@@ -244,6 +245,15 @@ class BaseParticles
     ParticleVariables all_discrete_variables_;
     SingularVariables all_singular_variables_;
     ParticleVariables variables_to_write_;
+
+  protected:
+    int total_body_parts_;                                /**< total number of body parts indicated particle groups*/
+    StdVec<BodyPartByParticle *> body_parts_by_particle_; /**< all body parts by particle */
+
+  public:
+    int getNewBodyPartID();
+    void addBodyPartByParticle(BodyPartByParticle *body_part) { body_parts_by_particle_.push_back(body_part); };
+    StdVec<BodyPartByParticle *> getBodyPartsByParticle() { return body_parts_by_particle_; };
 
   protected:
     //----------------------------------------------------------------------

--- a/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.hpp
@@ -64,7 +64,7 @@ ParticleSortCK<ExecutionPolicy>::ParticleSortCK(RealBody &real_body)
 {
     particles_->addEvolvingVariable<UnsignedInt>("OriginalID");
 
-    body_parts_by_particle_ = real_body.getBodyPartsByParticle();
+    body_parts_by_particle_ = particles_->getBodyPartsByParticle();
     for (size_t i = 0; i != body_parts_by_particle_.size(); ++i)
     {
         DiscreteVariable<UnsignedInt> *dv_particle_list =


### PR DESCRIPTION
This pull request refactors the handling of body parts in the SPH simulation framework by moving responsibility for managing body parts from the `SPHBody` class to the `BaseParticles` class. This change simplifies the responsibilities of `SPHBody` and consolidates particle-related logic within `BaseParticles`. Below are the most important changes grouped by theme:

### Refactoring of Body Part Management:
* Removed `total_body_parts_` and `body_parts_by_particle_` from the `SPHBody` class, along with related methods such as `getNewBodyPartID`, `getTotalBodyParts`, and `addBodyPartByParticle`. (`src/shared/bodies/base_body.h`: [[1]](diffhunk://#diff-e35dfdb89c0ce4bead5d4b0b08f38f1ba3cdc322be51572845e73a570e358eeeL80-L81) [[2]](diffhunk://#diff-e35dfdb89c0ce4bead5d4b0b08f38f1ba3cdc322be51572845e73a570e358eeeL113-L116); `src/shared/bodies/base_body.cpp`: [[3]](diffhunk://#diff-aef936194c31d0a7903c589e47bd565ff0ef4527f569110cbccebc9574c45c94L39-L44)
* Added `total_body_parts_` and `body_parts_by_particle_` to the `BaseParticles` class, along with new methods to manage body parts (`getNewBodyPartID`, `addBodyPartByParticle`, and `getBodyPartsByParticle`). (`src/shared/particles/base_particles.h`: [[1]](diffhunk://#diff-429fe4c2d7d343634cb6b8f381e45b91cecbd79fa65b86c343c0b0318c70606eR249-R257); `src/shared/particles/base_particles.cpp`: [[2]](diffhunk://#diff-d7dc99d92f4fd7062b15aacdd54fc73984fe85ae9b0408fc5caead8de70bfa93R127-R132)

### Updates to Body Part Initialization:
* Updated the `BodyPart` and `BodyPartByParticle` constructors to use `BaseParticles` for managing body parts instead of `SPHBody`. (`src/shared/bodies/base_body_part.cpp`: [[1]](diffhunk://#diff-f1c10084a4ad0b18bcc8b6ec8a5b36cc53aae0e943a7580524e9729e5ce9ccecL9-R13) [[2]](diffhunk://#diff-f1c10084a4ad0b18bcc8b6ec8a5b36cc53aae0e943a7580524e9729e5ce9ccecL31-R32)

### Code Cleanup and Simplification:
* Removed the unused `BodyPartByParticle` forward declaration from `SPHBody`'s header file. (`src/shared/bodies/base_body.h`: [src/shared/bodies/base_body.hL55](diffhunk://#diff-e35dfdb89c0ce4bead5d4b0b08f38f1ba3cdc322be51572845e73a570e358eeeL55))
* Reformatted the `defineAdaptationRatios` method in `SPHBody` for consistency. (`src/shared/bodies/base_body.h`: [src/shared/bodies/base_body.hL143-R136](diffhunk://#diff-e35dfdb89c0ce4bead5d4b0b08f38f1ba3cdc322be51572845e73a570e358eeeL143-R136))

### Adjustments to Particle Sorting:
* Updated `ParticleSortCK` to retrieve body parts from `BaseParticles` instead of `SPHBody`. (`src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.hpp`: [src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.hppL67-R67](diffhunk://#diff-8e17328079f4b1f3e610c9b0a00d9b5a09c94de941b27773c276ed0174ee420dL67-R67))

### Initialization of `BaseParticles`:
* Added initialization of `total_body_parts_` in the `BaseParticles` constructor to support the new body part management logic. (`src/shared/particles/base_particles.cpp`: [src/shared/particles/base_particles.cppL19-R20](diffhunk://#diff-d7dc99d92f4fd7062b15aacdd54fc73984fe85ae9b0408fc5caead8de70bfa93L19-R20))

These changes improve the modularity and maintainability of the code by centralizing particle-related operations in the `BaseParticles` class, reducing the responsibilities of `SPHBody`.