### PR TITLE
Xiangyu/revise tvf

### DIFF
--- a/src/shared/shared_ck/body_relation/neighbor_method.h
+++ b/src/shared/shared_ck/body_relation/neighbor_method.h
@@ -159,6 +159,14 @@ class SmoothingLength<SingleValued> : public SmoothingLength<Base>
         };
     };
 
+    class SmoothingRatio
+    {
+      public:
+        SmoothingRatio(SmoothingLength<SingleValued> &smoothing_length) {};
+
+        Real operator()(UnsignedInt index_i) const { return 1.0; };
+    };
+
   protected:
     Real inv_h_;
 };


### PR DESCRIPTION
This pull request refactors the `TransportVelocityCorrectionCK` class hierarchy to simplify its template structure and improve maintainability. The key changes include replacing `ResolutionType` with `SmoothingRatio` for adaptive resolution, removing unused template parameters, and streamlining alias definitions. Additionally, a new `SmoothingRatio` class is introduced to encapsulate smoothing length ratio calculations.

### Refactoring of `TransportVelocityCorrectionCK`:

* Simplified the template structure of `TransportVelocityCorrectionCK` by removing the `ResolutionType` parameter and replacing it with the newly introduced `SmoothingRatio` class for adaptive resolution. (`[[1]](diffhunk://#diff-ef55017961967def7b42c6a8dfc91ddc07d081e97fc83d0919a75c03bb401549L76-R69)`, `[[2]](diffhunk://#diff-ef55017961967def7b42c6a8dfc91ddc07d081e97fc83d0919a75c03bb401549L89-L108)`, `[[3]](diffhunk://#diff-3428a5cabc10529f32c69861cca9ed12e61ed0e562d15e510ff02b3ebad073bfL21-R29)`)
* Updated the `InteractKernel` and `UpdateKernel` implementations to use `SmoothingRatio` instead of `ResolutionType`. (`[[1]](diffhunk://#diff-3428a5cabc10529f32c69861cca9ed12e61ed0e562d15e510ff02b3ebad073bfL47-R55)`, `[[2]](diffhunk://#diff-3428a5cabc10529f32c69861cca9ed12e61ed0e562d15e510ff02b3ebad073bfL77-R88)`)
* Consolidated partial specializations for `Inner` and `Contact` configurations by removing redundant template parameters and simplifying the class definitions. (`[[1]](diffhunk://#diff-ef55017961967def7b42c6a8dfc91ddc07d081e97fc83d0919a75c03bb401549L31-L50)`, `[[2]](diffhunk://#diff-ef55017961967def7b42c6a8dfc91ddc07d081e97fc83d0919a75c03bb401549L126-L156)`, `[[3]](diffhunk://#diff-3428a5cabc10529f32c69861cca9ed12e61ed0e562d15e510ff02b3ebad073bfL124-R123)`)

### Introduction of `SmoothingRatio`:

* Added a new `SmoothingRatio` class to encapsulate smoothing length ratio calculations, improving modularity and reducing complexity in the `TransportVelocityCorrectionCK` class. (`[src/shared/shared_ck/body_relation/neighbor_method.hR162-R169](diffhunk://#diff-3c0ba5fca0fab3305e9ae03aad34db79de155457e2e171df3aa259a4b4b65c07R162-R169)`)

### Cleanup and Streamlining:

* Removed outdated comments and redundant alias definitions for specific configurations, such as `TransportVelocityCorrectionInnerNoCorrectionBulkParticlesCK`. (`[src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.hL126-L156](diffhunk://#diff-ef55017961967def7b42c6a8dfc91ddc07d081e97fc83d0919a75c03bb401549L126-L156)`)
* Reorganized and reformatted the implementation files (`transport_velocity_correction_ck.hpp`) to improve readability and consistency. (`[[1]](diffhunk://#diff-3428a5cabc10529f32c69861cca9ed12e61ed0e562d15e510ff02b3ebad073bfR3-R10)`, `[[2]](diffhunk://#diff-3428a5cabc10529f32c69861cca9ed12e61ed0e562d15e510ff02b3ebad073bfL172)`)