### PR TITLE
eulerian flow around cylinder ok

### DIFF
--- a/src/shared/geometries/level_set.cpp
+++ b/src/shared/geometries/level_set.cpp
@@ -13,7 +13,8 @@ MultilevelLevelSet::MultilevelLevelSet(
 {
     Real reference_data_spacing = coarse_data->DataSpacing() * 0.5;
     Real global_h_ratio = sph_adaptation.ReferenceSpacing() / reference_data_spacing;
-    host_kernel_ = sph_adaptation.getKernel();
+    kernel_ = makeUnique<SingularVariable<KernelTabulatedCK>>(
+        "levelset_kernel", KernelTabulatedCK(*sph_adaptation.getKernel()));
     global_h_ratio_vec_.push_back(global_h_ratio);
 
     initializeLevel(reference_data_spacing, tentative_bounds, coarse_data);
@@ -26,7 +27,8 @@ MultilevelLevelSet::MultilevelLevelSet(
 {
     Real global_h_ratio = sph_adaptation.ReferenceSpacing() / reference_data_spacing;
     global_h_ratio_vec_.push_back(global_h_ratio);
-    host_kernel_ = sph_adaptation.getKernel();
+    kernel_ = makeUnique<SingularVariable<KernelTabulatedCK>>(
+        "levelset_kernel", KernelTabulatedCK(*sph_adaptation.getKernel()));
 
     initializeLevel(reference_data_spacing, tentative_bounds);
     for (size_t level = 1; level < total_levels_; ++level)

--- a/src/shared/geometries/level_set.h
+++ b/src/shared/geometries/level_set.h
@@ -64,8 +64,8 @@ class MultilevelLevelSet : public BaseMeshField
     template <class ExecutionPolicy>
     void finishInitialization(const ExecutionPolicy &ex_policy)
     {
-        initializeMeshVariables(ex_policy, host_kernel_);
-        configOperationExecutionPolicy(ex_policy, host_kernel_);
+        initializeMeshVariables(ex_policy, kernel_->Data());
+        configOperationExecutionPolicy(ex_policy, kernel_->Data());
     }
     void finishInitialization(const ParallelDevicePolicy &par_device);
     void cleanInterface(Real small_shift_factor);
@@ -152,8 +152,7 @@ class MultilevelLevelSet : public BaseMeshField
 
     UniquePtr<BaseExecDynamics> correct_topology_keeper_;
     UniquePtr<BaseExecDynamics> clean_interface_keeper_;
-    Kernel *host_kernel_;
-    UniquePtr<SingularVariable<KernelTabulatedCK>> device_kernel_;
+    UniquePtr<SingularVariable<KernelTabulatedCK>> kernel_;
     std::function<void()> sync_mesh_variable_data_;
 
     template <class ExecutionPolicy, class KernelType>

--- a/src/src_sycl/shared/mesh_dynamics/level_set_sycl.hpp
+++ b/src/src_sycl/shared/mesh_dynamics/level_set_sycl.hpp
@@ -1,20 +1,18 @@
 #ifndef LEVEL_SET_SYCL_HPP
 #define LEVEL_SET_SYCL_HPP
 
-#include "mesh_iterators_sycl.hpp"
 #include "implementation_sycl.h"
-#include "sphinxsys_variable_sycl.hpp"
-#include "sphinxsys_constant_sycl.hpp"
 #include "level_set.h"
+#include "mesh_iterators_sycl.hpp"
+#include "sphinxsys_constant_sycl.hpp"
+#include "sphinxsys_variable_sycl.hpp"
 namespace SPH
 {
 //=================================================================================================//
 void MultilevelLevelSet::finishInitialization(const ParallelDevicePolicy &par_device)
 {
-    device_kernel_ = makeUnique<SingularVariable<KernelTabulatedCK>>(
-        "levelset_kernel", KernelTabulatedCK(*host_kernel_));
-    initializeMeshVariables(par_device, device_kernel_->DelegatedData(par_device));
-    configOperationExecutionPolicy(par_device, device_kernel_->DelegatedData(par_device));
+    initializeMeshVariables(par_device, kernel_->DelegatedData(par_device));
+    configOperationExecutionPolicy(par_device, kernel_->DelegatedData(par_device));
 }
 //=================================================================================================//
 } // namespace SPH


### PR DESCRIPTION
This pull request refactors the `MultilevelLevelSet` class to simplify kernel management by consolidating `host_kernel_` and `device_kernel_` into a single `kernel_` member. Additionally, it updates include directives in `level_set_sycl.hpp` for better organization. Below are the key changes grouped by theme:

### Refactoring kernel management in `MultilevelLevelSet`:

* Replaced `host_kernel_` and `device_kernel_` members with a unified `kernel_` member of type `UniquePtr<SingularVariable<KernelTabulatedCK>>`. This simplifies kernel handling and removes redundancy. (`src/shared/geometries/level_set.h`, [src/shared/geometries/level_set.hL155-R155](diffhunk://#diff-1004bbbeee8efdea7578748841d134891882f969bf5a673ec8172dbffc8be15cL155-R155))
* Updated the initialization of `kernel_` in the `MultilevelLevelSet` constructor to use `makeUnique` with a `KernelTabulatedCK` instance. (`src/shared/geometries/level_set.cpp`, [[1]](diffhunk://#diff-5241dd2410cd9e6ce6281faf040145d13b69a06d8efd6a1cd54e15218b66a014L16-R17) [[2]](diffhunk://#diff-5241dd2410cd9e6ce6281faf040145d13b69a06d8efd6a1cd54e15218b66a014L29-R31)
* Modified `finishInitialization` methods to use `kernel_->Data()` instead of `host_kernel_` or `device_kernel_`. (`src/shared/geometries/level_set.h`, [[1]](diffhunk://#diff-1004bbbeee8efdea7578748841d134891882f969bf5a673ec8172dbffc8be15cL67-R68); `src/src_sycl/shared/mesh_dynamics/level_set_sycl.hpp`, [[2]](diffhunk://#diff-2d4ee6b7d1a1c345bf196ddf00df3b3fdf2f9bbf106edf1bd0db0dc847cc8e23L4-R15)

### Include directive reorganization:

* Reorganized include directives in `level_set_sycl.hpp` for consistency and clarity by reordering and removing redundant includes. (`src/src_sycl/shared/mesh_dynamics/level_set_sycl.hpp`, [src/src_sycl/shared/mesh_dynamics/level_set_sycl.hppL4-R15](diffhunk://#diff-2d4ee6b7d1a1c345bf196ddf00df3b3fdf2f9bbf106edf1bd0db0dc847cc8e23L4-R15))