### PR TITLE
all compiled, check sycl

### DIFF
--- a/src/shared/shared_ck/particle_dynamics/continum_dynamics/continuum_integration_1st_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/continum_dynamics/continuum_integration_1st_ck.h
@@ -136,7 +136,7 @@ class PlasticAcousticStep1stHalf<Contact<Wall, RiemannSolverType, KernelCorrecti
         Vecd *force_, *force_prior_;
         Mat3d *stress_tensor_3D_;
 
-        Real *wall_Vol_;
+        Real *contact_Vol_;
         Vecd *wall_acc_ave_;
     };
 

--- a/src/shared/shared_ck/particle_dynamics/continum_dynamics/continuum_integration_1st_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/continum_dynamics/continuum_integration_1st_ck.hpp
@@ -130,7 +130,7 @@ PlasticAcousticStep1stHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType
       force_(encloser.dv_force_->DelegatedData(ex_policy)),
       force_prior_(encloser.dv_force_prior_->DelegatedData(ex_policy)),
       stress_tensor_3D_(encloser.dv_stress_tensor_3D_->DelegatedData(ex_policy)),
-      wall_Vol_(encloser.dv_wall_Vol_[contact_index]->DelegatedData(ex_policy)),
+      contact_Vol_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)),
       wall_acc_ave_(encloser.dv_wall_acc_ave_[contact_index]->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
@@ -146,7 +146,7 @@ void PlasticAcousticStep1stHalf<Contact<Wall, RiemannSolverType, KernelCorrectio
     {
         UnsignedInt index_j = this->neighbor_index_[n];
         Vecd e_ij = this->e_ij(index_i, index_j);
-        Real dW_ijV_j = this->dW_ij(index_i, index_j) * wall_Vol_[index_j];
+        Real dW_ijV_j = this->dW_ij(index_i, index_j) * contact_Vol_[index_j];
         Real r_ij = this->vec_r_ij(index_i, index_j).norm();
         Real face_wall_external_acceleration = (force_prior_[index_i] / mass_[index_i] - wall_acc_ave_[index_j]).dot(-e_ij);
         Real p_in_wall = p_[index_i] + rho_[index_i] * r_ij * SMAX(Real(0), face_wall_external_acceleration);

--- a/src/shared/shared_ck/particle_dynamics/continum_dynamics/continuum_integration_2nd_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/continum_dynamics/continuum_integration_2nd_ck.h
@@ -117,7 +117,7 @@ class PlasticAcousticStep2ndHalf<Contact<Wall, RiemannSolverType, KernelCorrecti
         RiemannSolverType riemann_solver_;
         Real *Vol_, *rho_, *drho_dt_;
         Vecd *vel_, *force_;
-        Real *wall_Vol_;
+        Real *contact_Vol_;
         Vecd *wall_vel_ave_, *wall_n_;
         Matd *velocity_gradient_;
     };

--- a/src/shared/shared_ck/particle_dynamics/continum_dynamics/continuum_integration_2nd_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/continum_dynamics/continuum_integration_2nd_ck.hpp
@@ -116,7 +116,7 @@ PlasticAcousticStep2ndHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType
       drho_dt_(encloser.dv_drho_dt_->DelegatedData(ex_policy)),
       vel_(encloser.dv_vel_->DelegatedData(ex_policy)),
       force_(encloser.dv_force_->DelegatedData(ex_policy)),
-      wall_Vol_(encloser.dv_wall_Vol_[contact_index]->DelegatedData(ex_policy)),
+      contact_Vol_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)),
       wall_vel_ave_(encloser.dv_wall_vel_ave_[contact_index]->DelegatedData(ex_policy)),
       wall_n_(encloser.dv_wall_n_[contact_index]->DelegatedData(ex_policy)),
       velocity_gradient_(encloser.dv_velocity_gradient_->DelegatedData(ex_policy)) {}
@@ -133,7 +133,7 @@ void PlasticAcousticStep2ndHalf<Contact<Wall, RiemannSolverType, KernelCorrectio
     {
         UnsignedInt index_j = this->neighbor_index_[n];
         Vecd e_ij = this->e_ij(index_i, index_j);
-        Real dW_ijV_j = this->dW_ij(index_i, index_j) * wall_Vol_[index_j];
+        Real dW_ijV_j = this->dW_ij(index_i, index_j) * contact_Vol_[index_j];
         Vecd vel_in_wall = 2.0 * wall_vel_ave_[index_j] - vel_[index_i];
         density_change_rate += (vel_i - vel_in_wall).dot(e_ij) * dW_ijV_j;
         Real u_jump = 2.0 * (vel_i - wall_vel_ave_[index_j]).dot(wall_n_[index_j]);

--- a/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.h
@@ -159,7 +159,6 @@ class DiffusionRelaxationCK<Contact<InteractionOnly, BoundaryType<DiffusionType>
 
   protected:
     KernelCorrectionType kernel_correction_method_;
-    StdVec<DiscreteVariable<Real> *> dv_contact_Vol_;
     StdVec<DiscreteVariableArray<Real> *> contact_dv_transfer_array_;
     StdVec<BoundaryType<DiffusionType> *> contact_boundary_method_;
 };

--- a/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.h
@@ -123,7 +123,6 @@ class DiffusionRelaxationCK<Inner<InteractionOnly, DiffusionType, KernelCorrecti
   protected:
     KernelCorrectionType kernel_correction_method_;
     ConstantArray<DiffusionType, InterParticleDiffusionCoeff> ca_inter_particle_diffusion_coeff_;
-    DiscreteVariable<Real> *dv_Vol_;
     Real smoothing_length_sq_;
 };
 

--- a/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.hpp
@@ -102,7 +102,6 @@ DiffusionRelaxationCK<Inner<InteractionOnly, DiffusionType, KernelCorrectionType
     : BaseInteraction(std::forward<Args>(args)...),
       kernel_correction_method_(this->particles_),
       ca_inter_particle_diffusion_coeff_(this->diffusions_),
-      dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure")),
       smoothing_length_sq_(pow(this->sph_adaptation_->ReferenceSmoothingLength(), 2)) {}
 //=================================================================================================//
 template <class DiffusionType, class KernelCorrectionType, class... Parameters>

--- a/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.hpp
@@ -146,8 +146,6 @@ DiffusionRelaxationCK<Contact<InteractionOnly, BoundaryType<DiffusionType>, Kern
 {
     for (UnsignedInt k = 0; k != this->contact_particles_.size(); ++k)
     {
-        dv_contact_Vol_.push_back(
-            this->contact_particles_[k]->template getVariableByName<Real>("VolumetricMeasure"));
         contact_dv_transfer_array_.push_back(
             contact_transfer_array_ptrs_keeper_.createPtr<DiscreteVariableArray<Real>>(
                 this->particles_->template registerStateVariables<Real>(

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.h
@@ -139,7 +139,7 @@ class AcousticStep1stHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType,
         RiemannSolverType riemann_solver_;
         Real *Vol_, *rho_, *mass_, *p_, *drho_dt_;
         Vecd *vel_, *force_, *force_prior_;
-        Real *wall_Vol_;
+        Real *contact_Vol_;
         Vecd *wall_acc_ave_;
     };
 
@@ -182,7 +182,7 @@ class AcousticStep1stHalf<Contact<RiemannSolverType, KernelCorrectionType, Param
     KernelCorrectionType kernel_correction_;
     StdVec<KernelCorrectionType> contact_kernel_corrections_;
     StdVec<RiemannSolverType> riemann_solvers_;
-    StdVec<DiscreteVariable<Real> *> dv_contact_Vol_, dv_contact_p_;
+    StdVec<DiscreteVariable<Real> *> dv_contact_p_;
 };
 
 using AcousticStep1stHalfWithWallRiemannCK =

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.h
@@ -50,7 +50,7 @@ class AcousticStep : public BaseInteractionType
     virtual ~AcousticStep() {};
 
   protected:
-    DiscreteVariable<Real> *dv_Vol_, *dv_rho_, *dv_mass_, *dv_p_, *dv_drho_dt_;
+    DiscreteVariable<Real> *dv_rho_, *dv_mass_, *dv_p_, *dv_drho_dt_;
     DiscreteVariable<Vecd> *dv_vel_, *dv_dpos_, *dv_force_, *dv_force_prior_;
 };
 

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.hpp
@@ -141,7 +141,7 @@ AcousticStep1stHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType, Param
       drho_dt_(encloser.dv_drho_dt_->DelegatedData(ex_policy)),
       force_(encloser.dv_force_->DelegatedData(ex_policy)),
       force_prior_(encloser.dv_force_prior_->DelegatedData(ex_policy)),
-      wall_Vol_(encloser.dv_wall_Vol_[contact_index]->DelegatedData(ex_policy)),
+      contact_Vol_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)),
       wall_acc_ave_(encloser.dv_wall_acc_ave_[contact_index]->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
@@ -153,7 +153,7 @@ void AcousticStep1stHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType, 
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
     {
         UnsignedInt index_j = this->neighbor_index_[n];
-        Real dW_ijV_j = this->dW_ij(index_i, index_j) * wall_Vol_[index_j];
+        Real dW_ijV_j = this->dW_ij(index_i, index_j) * contact_Vol_[index_j];
         Vecd e_ij = this->e_ij(index_i, index_j);
         Real r_ij = this->vec_r_ij(index_i, index_j).norm();
 
@@ -179,8 +179,6 @@ AcousticStep1stHalf<Contact<RiemannSolverType, KernelCorrectionType, Parameters.
         TargetFluidType &target_fluid =
             DynamicCast<TargetFluidType>(this, this->contact_bodies_[k]->getBaseMaterial());
         riemann_solvers_.push_back(RiemannSolverType(source_fluid, target_fluid));
-        dv_contact_Vol_.push_back(
-            this->contact_particles_[k]->template getVariableByName<Real>("VolumetricMeasure"));
         dv_contact_p_.push_back(
             this->contact_particles_[k]->template getVariableByName<Real>("Pressure"));
     }

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.hpp
@@ -12,7 +12,6 @@ template <class BaseInteractionType>
 template <class DynamicsIdentifier>
 AcousticStep<BaseInteractionType>::AcousticStep(DynamicsIdentifier &identifier)
     : BaseInteractionType(identifier),
-      dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure")),
       dv_rho_(this->particles_->template getVariableByName<Real>("Density")),
       dv_mass_(this->particles_->template getVariableByName<Real>("Mass")),
       dv_p_(this->particles_->template registerStateVariable<Real>("Pressure")),

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_2nd_half.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_2nd_half.h
@@ -124,7 +124,7 @@ class AcousticStep2ndHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType,
         RiemannSolverType riemann_solver_;
         Real *Vol_, *rho_, *drho_dt_;
         Vecd *vel_, *force_;
-        Real *wall_Vol_;
+        Real *contact_Vol_;
         Vecd *wall_vel_ave_, *wall_n_;
     };
 
@@ -169,7 +169,6 @@ class AcousticStep2ndHalf<Contact<RiemannSolverType, KernelCorrectionType, Param
   protected:
     KernelCorrectionType kernel_correction_;
     StdVec<RiemannSolverType> riemann_solvers_;
-    StdVec<DiscreteVariable<Real> *> dv_contact_Vol_;
     StdVec<DiscreteVariable<Vecd> *> dv_contact_vel_;
 };
 

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_2nd_half.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_2nd_half.hpp
@@ -102,7 +102,7 @@ AcousticStep2ndHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType, Param
       drho_dt_(encloser.dv_drho_dt_->DelegatedData(ex_policy)),
       vel_(encloser.dv_vel_->DelegatedData(ex_policy)),
       force_(encloser.dv_force_->DelegatedData(ex_policy)),
-      wall_Vol_(encloser.dv_wall_Vol_[contact_index]->DelegatedData(ex_policy)),
+      contact_Vol_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)),
       wall_vel_ave_(encloser.dv_wall_vel_ave_[contact_index]->DelegatedData(ex_policy)),
       wall_n_(encloser.dv_wall_n_[contact_index]->DelegatedData(ex_policy)) {}
 //=================================================================================================//
@@ -115,7 +115,7 @@ void AcousticStep2ndHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType, 
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
     {
         UnsignedInt index_j = this->neighbor_index_[n];
-        Real dW_ijV_j = this->dW_ij(index_i, index_j) * wall_Vol_[index_j];
+        Real dW_ijV_j = this->dW_ij(index_i, index_j) * contact_Vol_[index_j];
         Vecd corrected_e_ij = correction_(index_i) * this->e_ij(index_i, index_j);
 
         Vecd face_to_fluid_n = SGN(corrected_e_ij.dot(wall_n_[index_j])) * wall_n_[index_j];
@@ -140,8 +140,6 @@ AcousticStep2ndHalf<Contact<RiemannSolverType, KernelCorrectionType, Parameters.
         TargetFluidType &target_fluid =
             DynamicCast<TargetFluidType>(this, this->contact_bodies_[k]->getBaseMaterial());
         riemann_solvers_.push_back(RiemannSolverType(source_fluid, target_fluid));
-        dv_contact_Vol_.push_back(
-            this->contact_particles_[k]->template getVariableByName<Real>("VolumetricMeasure"));
         dv_contact_vel_.push_back(
             this->contact_particles_[k]->template getVariableByName<Vecd>("Velocity"));
     }

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.h
@@ -114,7 +114,7 @@ class DensityRegularization<Base, RelationType<Parameters...>>
     };
 
   protected:
-    DiscreteVariable<Real> *dv_rho_, *dv_mass_, *dv_rho_sum_, *dv_Vol_;
+    DiscreteVariable<Real> *dv_rho_, *dv_mass_, *dv_rho_sum_;
     Real rho0_, inv_sigma0_;
 };
 

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.hpp
@@ -18,7 +18,6 @@ DensityRegularization<Base, RelationType<Parameters...>>::
       dv_rho_(this->particles_->template getVariableByName<Real>("Density")),
       dv_mass_(this->particles_->template getVariableByName<Real>("Mass")),
       dv_rho_sum_(this->particles_->template registerStateVariable<Real>("DensitySummation")),
-      dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure")),
       rho0_(this->sph_body_.getBaseMaterial().ReferenceDensity()),
       inv_sigma0_(1.0 / this->sph_adaptation_->LatticeNumberDensity()) {}
 //=================================================================================================//

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.h
@@ -19,7 +19,6 @@ class TransportVelocityCorrectionCKBase : public BaseInteractionType
     virtual ~TransportVelocityCorrectionCKBase() {}
 
   protected:
-    DiscreteVariable<Real> *dv_Vol_;                   ///< "VolumetricMeasure"
     DiscreteVariable<Vecd> *dv_dpos_;                  ///< "Position"
     DiscreteVariable<Vecd> *dv_zero_gradient_residue_; ///< "ZeroGradientResidue"
 };

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.h
@@ -103,12 +103,11 @@ class TransportVelocityCorrectionCK<Contact<Wall, KernelCorrectionType, Paramete
       protected:
         CorrectionKernel correction_;
         Vecd *zero_gradient_residue_;
-        Real *contact_wall_Vol_;
+        Real *contact_contact_Vol_;
     };
 
   protected:
     KernelCorrectionType kernel_correction_;
-    StdVec<DiscreteVariable<Real> *> dv_contact_wall_Vol_;
 };
 //--------------------------------------------------------------------------------------
 // Alias Definitions for Specific Configurations

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.hpp
@@ -101,14 +101,7 @@ template <class KernelCorrectionType, typename... Parameters>
 TransportVelocityCorrectionCK<Contact<Wall, KernelCorrectionType, Parameters...>>::
     TransportVelocityCorrectionCK(Contact<Parameters...> &contact_relation)
     : BaseInteraction(contact_relation), Interaction<Wall>(contact_relation),
-      kernel_correction_(this->particles_)
-{
-    for (size_t k = 0; k != this->contact_particles_.size(); ++k)
-    {
-        dv_contact_wall_Vol_.push_back(
-            this->contact_particles_[k]->template getVariableByName<Real>("VolumetricMeasure"));
-    }
-}
+      kernel_correction_(this->particles_){}
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
 template <class ExecutionPolicy, class EncloserType>
@@ -117,7 +110,7 @@ TransportVelocityCorrectionCK<Contact<Wall, KernelCorrectionType, Parameters...>
     : BaseInteraction::InteractKernel(ex_policy, encloser, contact_index),
       correction_(ex_policy, encloser.kernel_correction_),
       zero_gradient_residue_(encloser.dv_zero_gradient_residue_->DelegatedData(ex_policy)),
-      contact_wall_Vol_(encloser.dv_contact_wall_Vol_[contact_index]->DelegatedData(ex_policy)) {}
+      contact_contact_Vol_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
 void TransportVelocityCorrectionCK<Contact<Wall, KernelCorrectionType, Parameters...>>::
@@ -127,7 +120,7 @@ void TransportVelocityCorrectionCK<Contact<Wall, KernelCorrectionType, Parameter
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
     {
         UnsignedInt index_j = this->neighbor_index_[n];
-        const Real dW_ijV_j = this->dW_ij(index_i, index_j) * contact_wall_Vol_[index_j];
+        const Real dW_ijV_j = this->dW_ij(index_i, index_j) * contact_contact_Vol_[index_j];
         const Vecd e_ij = this->e_ij(index_i, index_j);
 
         // acceleration for transport velocity

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.hpp
@@ -13,7 +13,6 @@ template <class DynamicsIdentifier>
 TransportVelocityCorrectionCKBase<BaseInteractionType>::
     TransportVelocityCorrectionCKBase(DynamicsIdentifier &identifier)
     : BaseInteractionType(identifier),
-      dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure")),
       dv_dpos_(this->particles_->template getVariableByName<Vecd>("Displacement")),
       dv_zero_gradient_residue_(
           this->particles_->template registerStateVariable<Vecd>("ZeroGradientResidue")) {}

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.h
@@ -120,12 +120,12 @@ class ViscousForceCK<Contact<Wall, ViscosityType, KernelCorrectionType, Paramete
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, size_t contact_index)
             : BaseViscousForceType::InteractKernel(ex_policy, encloser, contact_index),
-              wall_Vol_(encloser.dv_wall_Vol_[contact_index]->DelegatedData(ex_policy)),
+              contact_Vol_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)),
               wall_vel_ave_(encloser.dv_wall_vel_ave_[contact_index]->DelegatedData(ex_policy)){};
         void interact(size_t index_i, Real dt = 0.0);
 
       protected:
-        Real *wall_Vol_;
+        Real *contact_Vol_;
         Vecd *wall_vel_ave_;
     };
 

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.h
@@ -76,7 +76,6 @@ class ViscousForceCK<Base, ViscosityType, KernelCorrectionType, RelationType<Par
 
     ViscosityType &viscosity_model_;
     KernelCorrectionType kernel_correction_;
-    DiscreteVariable<Real> *dv_Vol_;
     DiscreteVariable<Vecd> *dv_vel_, *dv_viscous_force_;
     Real smoothing_length_sq_;
 };

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.hpp
@@ -69,7 +69,7 @@ void ViscousForceCK<Contact<Wall, ViscosityType, KernelCorrectionType, Parameter
 
         force += 2.0 * vec_r_ij.dot(this->correction_(index_i) * e_ij) *
                  this->viscosity_(index_i) * vel_derivative *
-                 this->dW_ij(index_i, index_j) * this->wall_Vol_[index_j];
+                 this->dW_ij(index_i, index_j) * this->contact_Vol_[index_j];
     }
     this->viscous_force_[index_i] += force * this->Vol_[index_i];
 }

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.hpp
@@ -16,7 +16,6 @@ ViscousForceCK<Base, ViscosityType, KernelCorrectionType, RelationType<Parameter
       ForcePriorCK(this->particles_, "ViscousForce"),
       viscosity_model_(DynamicCast<ViscosityType>(this, this->particles_->getBaseMaterial())),
       kernel_correction_(this->particles_),
-      dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure")),
       dv_vel_(this->particles_->template getVariableByName<Vecd>("Velocity")),
       dv_viscous_force_(this->dv_current_force_),
       smoothing_length_sq_(pow(this->sph_body_.getSPHAdaptation().ReferenceSmoothingLength(), 2)) {}

--- a/src/shared/shared_ck/particle_dynamics/fluid_structure_interaction/force_on_structure.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_structure_interaction/force_on_structure.h
@@ -66,12 +66,10 @@ class ForceFromFluid : public Interaction<Contact<Parameters...>>, public ForceP
 
   protected:
     Solid &solid_;
-    DiscreteVariable<Real> *dv_Vol_;
     DiscreteVariable<Vecd> *dv_force_from_fluid_, *dv_vel_ave_;
 
     StdVec<KernelCorrectionType> contact_kernel_correction_;
-    StdVec<DiscreteVariable<Real> *> contact_Vol_;
-    StdVec<DiscreteVariable<Vecd> *> contact_vel_;
+    StdVec<DiscreteVariable<Vecd> *> dv_contact_vel_;
 };
 
 template <typename...>

--- a/src/shared/shared_ck/particle_dynamics/fluid_structure_interaction/force_on_structure.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_structure_interaction/force_on_structure.hpp
@@ -14,15 +14,13 @@ ForceFromFluid<KernelCorrectionType, Parameters...>::
     ForceFromFluid(ContactRelationType &contact_relation, const std::string &force_name)
     : Interaction<Contact<Parameters...>>(contact_relation), ForcePriorCK(this->particles_, force_name),
       solid_(DynamicCast<Solid>(this, this->sph_body_.getBaseMaterial())),
-      dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure")),
       dv_force_from_fluid_(this->dv_current_force_),
       dv_vel_ave_(solid_.AverageVelocityVariable(this->particles_))
 {
     for (size_t k = 0; k != this->contact_particles_.size(); ++k)
     {
         contact_kernel_correction_.push_back(KernelCorrectionType(this->contact_particles_[k]));
-        contact_Vol_.push_back(this->contact_particles_[k]->template getVariableByName<Real>("VolumetricMeasure"));
-        contact_vel_.push_back(this->contact_particles_[k]->template getVariableByName<Vecd>("Velocity"));
+        dv_contact_vel_.push_back(this->contact_particles_[k]->template getVariableByName<Vecd>("Velocity"));
     }
 }
 //=================================================================================================//
@@ -35,8 +33,8 @@ ForceFromFluid<KernelCorrectionType, Parameters...>::InteractKernel::
       force_from_fluid_(encloser.dv_force_from_fluid_->DelegatedData(ex_policy)),
       vel_ave_(encloser.dv_vel_ave_->DelegatedData(ex_policy)),
       contact_correction_(ex_policy, encloser.contact_kernel_correction_[contact_index]),
-      contact_Vol_(encloser.contact_Vol_[contact_index]->DelegatedData(ex_policy)),
-      contact_vel_(encloser.contact_vel_[contact_index]->DelegatedData(ex_policy)) {}
+      contact_Vol_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)),
+      contact_vel_(encloser.dv_contact_vel_[contact_index]->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <typename ViscousForceType, typename... Parameters>
 template <class ContactRelationType>

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.h
@@ -157,7 +157,6 @@ class LinearGradient<Contact<DataType, Parameters...>>
     };
 
   protected:
-    StdVec<DiscreteVariable<Real> *> dv_contact_Vol_;
     StdVec<DiscreteVariable<DataType> *> dv_contact_variable_;
 };
 
@@ -236,7 +235,6 @@ class Hessian<Contact<DataType, Parameters...>>
     };
 
   protected:
-    StdVec<DiscreteVariable<Real> *> dv_contact_Vol_;
     StdVec<DiscreteVariable<DataType> *> dv_contact_variable_;
 };
 
@@ -288,7 +286,6 @@ class SecondOrderGradient<Contact<DataType, Parameters...>>
     };
 
   protected:
-    StdVec<DiscreteVariable<Real> *> dv_contact_Vol_;
     StdVec<DiscreteVariable<DataType> *> dv_contact_variable_;
 };
 } // namespace SPH

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.h
@@ -103,7 +103,6 @@ class Gradient<Base, DataType, RelationType<Parameters...>>
 
   protected:
     std::string variable_name_;
-    DiscreteVariable<Real> *dv_Vol_;
     DiscreteVariable<DataType> *dv_variable_;
     DiscreteVariable<Grad<DataType>> *dv_gradient_;
     DiscreteVariable<Matd> *dv_B_;

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.hpp
@@ -11,7 +11,6 @@ template <class DynamicsIdentifier>
 Gradient<Base, DataType, RelationType<Parameters...>>::
     Gradient(DynamicsIdentifier &identifier, std::string &variable_name)
     : BaseDynamicsType(identifier), variable_name_(variable_name),
-      dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure")),
       dv_variable_(this->particles_->template getVariableByName<DataType>(variable_name)),
       dv_gradient_(this->particles_->template registerStateVariable<Grad<DataType>>(
           variable_name + "Gradient", ZeroData<Grad<DataType>>::value)),

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.hpp
@@ -50,8 +50,6 @@ LinearGradient<Contact<DataType, Parameters...>>::LinearGradient(Args &&...args)
 {
     for (UnsignedInt k = 0; k != this->contact_particles_.size(); ++k)
     {
-        dv_contact_Vol_.push_back(
-            this->contact_particles_[k]->template getVariableByName<Real>("VolumetricMeasure"));
         dv_contact_variable_.push_back(
             this->contact_particles_[k]->template getVariableByName<DataType>(this->variable_name_));
     }
@@ -123,8 +121,6 @@ Hessian<Contact<DataType, Parameters...>>::Hessian(Args &&...args)
 {
     for (UnsignedInt k = 0; k != this->contact_particles_.size(); ++k)
     {
-        dv_contact_Vol_.push_back(
-            this->contact_particles_[k]->template getVariableByName<Real>("VolumetricMeasure"));
         dv_contact_variable_.push_back(
             this->contact_particles_[k]->template getVariableByName<DataType>(this->variable_name_));
     }
@@ -182,8 +178,6 @@ SecondOrderGradient<Contact<DataType, Parameters...>>::SecondOrderGradient(Args 
 {
     for (UnsignedInt k = 0; k != this->contact_particles_.size(); ++k)
     {
-        dv_contact_Vol_.push_back(
-            this->contact_particles_[k]->template getVariableByName<Real>("VolumetricMeasure"));
         dv_contact_variable_.push_back(
             this->contact_particles_[k]->template getVariableByName<DataType>(this->variable_name_));
     }

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.h
@@ -117,8 +117,6 @@ class DisplacementMatrixGradient<Contact<Parameters...>>
         Real *contact_Vol_;
     };
 
-  protected:
-    StdVec<DiscreteVariable<Real> *> dv_contact_Vol_;
 };
 
 template <typename... Parameters>
@@ -183,9 +181,6 @@ class HessianCorrectionMatrix<Contact<Parameters...>>
       protected:
         Real *contact_Vol_;
     };
-
-  protected:
-    StdVec<DiscreteVariable<Real> *> dv_contact_Vol_;
 };
 using HessianCorrectionMatrixComplex = HessianCorrectionMatrix<Inner<WithUpdate>, Contact<>>;
 } // namespace SPH

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.h
@@ -64,7 +64,6 @@ class HessianCorrectionMatrix<Base, RelationType<Parameters...>>
     };
 
   protected:
-    DiscreteVariable<Real> *dv_Vol_;
     DiscreteVariable<Matd> *dv_B_;
     DiscreteVariable<VecMatGrad> *dv_displacement_matrix_grad_;
     DiscreteVariable<MatTend> *dv_M_;

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.hpp
@@ -11,7 +11,6 @@ template <class DynamicsIdentifier>
 HessianCorrectionMatrix<Base, RelationType<Parameters...>>::
     HessianCorrectionMatrix(DynamicsIdentifier &identifier)
     : Interaction<RelationType<Parameters...>>(identifier),
-      dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure")),
       dv_B_(this->particles_->template registerStateVariable<Matd>(
           "LinearCorrectionMatrix", IdentityMatrix<Matd>::value)),
       dv_displacement_matrix_grad_(this->particles_->template registerStateVariable<VecMatGrad>(

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.hpp
@@ -50,14 +50,7 @@ void DisplacementMatrixGradient<Inner<Parameters...>>::
 template <typename... Parameters>
 DisplacementMatrixGradient<Contact<Parameters...>>::
     DisplacementMatrixGradient(Contact<Parameters...> &contact_relation)
-    : BaseDynamicsType(contact_relation)
-{
-    for (UnsignedInt k = 0; k != this->contact_particles_.size(); ++k)
-    {
-        dv_contact_Vol_.push_back(
-            this->contact_particles_[k]->template getVariableByName<Real>("VolumetricMeasure"));
-    }
-}
+    : BaseDynamicsType(contact_relation){}
 //=================================================================================================//
 template <typename... Parameters>
 void DisplacementMatrixGradient<Contact<Parameters...>>::
@@ -112,14 +105,7 @@ void HessianCorrectionMatrix<Inner<WithUpdate, Parameters...>>::
 template <typename... Parameters>
 HessianCorrectionMatrix<Contact<Parameters...>>::
     HessianCorrectionMatrix(Contact<Parameters...> &contact_relation)
-    : BaseDynamicsType(contact_relation)
-{
-    for (UnsignedInt k = 0; k != this->contact_particles_.size(); ++k)
-    {
-        dv_contact_Vol_.push_back(
-            this->contact_particles_[k]->template getVariableByName<Real>("VolumetricMeasure"));
-    }
-}
+    : BaseDynamicsType(contact_relation){}
 //=================================================================================================//
 template <typename... Parameters>
 void HessianCorrectionMatrix<Contact<Parameters...>>::

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.h
@@ -57,7 +57,6 @@ class Interpolation<Contact<Base, DataType, Parameters...>> : public Interaction
 
   protected:
     DiscreteVariable<DataType> *dv_interpolated_quantities_;
-    StdVec<DiscreteVariable<Real> *> dv_contact_Vol_;
     StdVec<DiscreteVariable<DataType> *> dv_contact_data_;
 };
 

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.hpp
@@ -18,7 +18,6 @@ Interpolation<Contact<Base, DataType, Parameters...>>::Interpolation(
         exit(1);
     }
     // must be single contact body
-    dv_contact_Vol_.push_back(this->contact_particles_[0]->template getVariableByName<Real>("VolumetricMeasure"));
     dv_contact_data_.push_back(this->contact_particles_[0]->template getVariableByName<DataType>(variable_name));
 }
 //=================================================================================================//

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.h
@@ -63,7 +63,6 @@ class LinearCorrectionMatrix<Base, RelationType<Parameters...>>
     };
 
   protected:
-    DiscreteVariable<Real> *dv_Vol_;
     DiscreteVariable<Matd> *dv_B_;
 };
 

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.h
@@ -129,9 +129,6 @@ class LinearCorrectionMatrix<Contact<Parameters...>>
       protected:
         Real *contact_Vol_k_;
     };
-
-  protected:
-    StdVec<DiscreteVariable<Real> *> dv_contact_Vol_;
 };
 
 using LinearCorrectionMatrixComplex = LinearCorrectionMatrix<Inner<WithUpdate>, Contact<>>;

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.hpp
@@ -70,13 +70,7 @@ void LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>>::
 template <typename... Parameters>
 LinearCorrectionMatrix<Contact<Parameters...>>::
     LinearCorrectionMatrix(Contact<Parameters...> &contact_relation)
-    : LinearCorrectionMatrix<Base, Contact<Parameters...>>(contact_relation)
-{
-    for (size_t k = 0; k != this->contact_particles_.size(); ++k)
-    {
-        dv_contact_Vol_.push_back(this->contact_particles_[k]->template getVariableByName<Real>("VolumetricMeasure"));
-    }
-}
+    : LinearCorrectionMatrix<Base, Contact<Parameters...>>(contact_relation){}
 //=================================================================================================//
 template <typename... Parameters>
 template <class ExecutionPolicy>

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.hpp
@@ -11,7 +11,6 @@ template <class DynamicsIdentifier>
 LinearCorrectionMatrix<Base, RelationType<Parameters...>>::
     LinearCorrectionMatrix(DynamicsIdentifier &identifier)
     : Interaction<RelationType<Parameters...>>(identifier),
-      dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure")),
       dv_B_(this->particles_->template registerStateVariable<Matd>(
           "LinearCorrectionMatrix", IdentityMatrix<Matd>::value)) {}
 //=================================================================================================//

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/surface_indication/surface_indication_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/surface_indication/surface_indication_ck.h
@@ -162,9 +162,6 @@ class FreeSurfaceIndicationCK<Contact<Parameters...>>
       protected:
         Real *contact_Vol_;
     };
-
-  protected:
-    StdVec<DiscreteVariable<Real> *> dv_contact_Vol_;
 };
 
 //------------------------------------------------------------------------------------------//

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/surface_indication/surface_indication_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/surface_indication/surface_indication_ck.h
@@ -64,7 +64,6 @@ class FreeSurfaceIndicationCK<Base, RelationType<Parameters...>>
   protected:
     DiscreteVariable<int> *dv_indicator_;
     DiscreteVariable<Real> *dv_pos_div_;
-    DiscreteVariable<Real> *dv_Vol_;
     Real dv_threshold_by_dimensions_;
     Real dv_smoothing_length_;
 };

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/surface_indication/surface_indication_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/surface_indication/surface_indication_ck.hpp
@@ -128,14 +128,7 @@ void FreeSurfaceIndicationCK<Inner<WithUpdate, Parameters...>>::UpdateKernel::
 template <typename... Parameters>
 FreeSurfaceIndicationCK<Contact<Parameters...>>::
     FreeSurfaceIndicationCK(Contact<Parameters...> &contact_relation)
-    : FreeSurfaceIndicationCK<Base, Contact<Parameters...>>(contact_relation)
-{
-    for (size_t k = 0; k != this->contact_particles_.size(); ++k)
-    {
-        dv_contact_Vol_.push_back(
-            this->contact_particles_[k]->template getVariableByName<Real>("VolumetricMeasure"));
-    }
-}
+    : FreeSurfaceIndicationCK<Base, Contact<Parameters...>>(contact_relation){}
 //=================================================================================================//
 template <typename... Parameters>
 template <class ExecutionPolicy>

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/surface_indication/surface_indication_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/surface_indication/surface_indication_ck.hpp
@@ -16,7 +16,6 @@ FreeSurfaceIndicationCK<Base, RelationType<Parameters...>>::
     : Interaction<RelationType<Parameters...>>(base_relation),
       dv_indicator_(this->particles_->template registerStateVariable<int>("Indicator")),
       dv_pos_div_(this->particles_->template registerStateVariable<Real>("PositionDivergence")),
-      dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure")),
       dv_threshold_by_dimensions_(0.75 * Dimensions),
       dv_smoothing_length_(this->sph_body_.getSPHAdaptation().ReferenceSmoothingLength()) {}
 //=================================================================================================//

--- a/src/shared/shared_ck/particle_dynamics/interaction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/interaction_ck.h
@@ -105,6 +105,7 @@ class Interaction<Contact<Parameters...>>
     StdVec<SPHBody *> contact_bodies_;
     StdVec<BaseParticles *> contact_particles_;
     StdVec<SPHAdaptation *> contact_adaptations_;
+    DiscreteVariable<Real> *dv_Vol_;
     StdVec<DiscreteVariable<Real> *> dv_contact_Vol_;
 };
 

--- a/src/shared/shared_ck/particle_dynamics/interaction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/interaction_ck.h
@@ -21,10 +21,10 @@
  *                                                                           *
  * ------------------------------------------------------------------------- */
 /**
- * @file    interaction_ck.h
- * @brief 	This is for the base classes of local particle dynamics, which describe the
- * 			dynamics of a particle and it neighbors.
- * @author	Chi Zhang, Chenxi Zhao and Xiangyu Hu
+ * @file interaction_ck.h
+ * @brief This is for the base classes of particle interaction with its neighbors,
+ * which describe the basic patterns of particle methods.
+ * @author Xiangyu Hu
  */
 
 #ifndef INTERACTION_CK_H
@@ -71,6 +71,7 @@ class Interaction<Inner<Parameters...>>
 
   protected:
     InnerRelationType &inner_relation_;
+    DiscreteVariable<Real> *dv_Vol_;
 };
 
 template <typename... Parameters>
@@ -104,6 +105,7 @@ class Interaction<Contact<Parameters...>>
     StdVec<SPHBody *> contact_bodies_;
     StdVec<BaseParticles *> contact_particles_;
     StdVec<SPHAdaptation *> contact_adaptations_;
+    StdVec<DiscreteVariable<Real> *> dv_contact_Vol_;
 };
 
 template <>
@@ -116,7 +118,6 @@ class Interaction<Wall>
 
   protected:
     StdVec<DiscreteVariable<Vecd> *> dv_wall_vel_ave_, dv_wall_acc_ave_, dv_wall_n_;
-    StdVec<DiscreteVariable<Real> *> dv_wall_Vol_;
 };
 } // namespace SPH
 #endif // INTERACTION_CK_H

--- a/src/shared/shared_ck/particle_dynamics/interaction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/interaction_ck.hpp
@@ -40,7 +40,8 @@ Interaction<Contact<Parameters...>>::
       contact_relation_(contact_relation),
       contact_bodies_(contact_relation.getContactBodies()),
       contact_particles_(contact_relation.getContactParticles()),
-      contact_adaptations_(contact_relation.getContactAdaptations())
+      contact_adaptations_(contact_relation.getContactAdaptations()),
+      dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure"))
 {
     for (auto &particles : contact_particles_)
     {

--- a/src/shared/shared_ck/particle_dynamics/interaction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/interaction_ck.hpp
@@ -10,7 +10,8 @@ template <typename... Parameters>
 Interaction<Inner<Parameters...>>::
     Interaction(InnerRelationType &inner_relation)
     : BaseLocalDynamicsType(inner_relation.getDynamicsIdentifier()),
-      inner_relation_(inner_relation) {}
+      inner_relation_(inner_relation),
+      dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure")) {}
 //=================================================================================================//
 template <typename... Parameters>
 void Interaction<Inner<Parameters...>>::
@@ -39,7 +40,14 @@ Interaction<Contact<Parameters...>>::
       contact_relation_(contact_relation),
       contact_bodies_(contact_relation.getContactBodies()),
       contact_particles_(contact_relation.getContactParticles()),
-      contact_adaptations_(contact_relation.getContactAdaptations()) {}
+      contact_adaptations_(contact_relation.getContactAdaptations())
+{
+    for (auto &particles : contact_particles_)
+    {
+        dv_contact_Vol_.push_back(
+            particles->template getVariableByName<Real>("VolumetricMeasure"));
+    }
+}
 //=================================================================================================//
 template <typename... Parameters>
 void Interaction<Contact<Parameters...>>::
@@ -72,7 +80,6 @@ Interaction<Wall>::Interaction(WallContactRelationType &wall_contact_relation)
         dv_wall_vel_ave_.push_back(solid_material.AverageVelocityVariable(contact_particles[k]));
         dv_wall_acc_ave_.push_back(solid_material.AverageAccelerationVariable(contact_particles[k]));
         dv_wall_n_.push_back(contact_particles[k]->template getVariableByName<Vecd>("NormalDirection"));
-        dv_wall_Vol_.push_back(contact_particles[k]->template getVariableByName<Real>("VolumetricMeasure"));
     }
 }
 //=================================================================================================//

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_residue_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_residue_ck.h
@@ -105,7 +105,6 @@ class RelaxationResidueCK<Contact<Boundary, KernelCorrectionType, Parameters...>
 
   protected:
     KernelCorrectionType kernel_correction_;
-    StdVec<DiscreteVariable<Real> *> dv_contact_Vol_;
 };
 } // namespace SPH
 #endif // RELAXATION_RESIDUE_CK_H

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_residue_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_residue_ck.h
@@ -42,7 +42,6 @@ class RelaxationResidueBase : public BaseInteractionType
     virtual ~RelaxationResidueBase() {}
 
   protected:
-    DiscreteVariable<Real> *dv_Vol_;
     DiscreteVariable<Vecd> *dv_pos_;
     DiscreteVariable<Vecd> *dv_residue_;
 };

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_residue_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_residue_ck.hpp
@@ -47,14 +47,7 @@ void RelaxationResidueCK<Inner<KernelCorrectionType, Parameters...>>::InteractKe
 template <class KernelCorrectionType, typename... Parameters>
 RelaxationResidueCK<Contact<Boundary, KernelCorrectionType, Parameters...>>::
     RelaxationResidueCK(Contact<Parameters...> &contact_relation)
-    : BaseInteraction(contact_relation), kernel_correction_(this->particles_)
-{
-    for (size_t k = 0; k != this->contact_particles_.size(); ++k)
-    {
-        dv_contact_Vol_.push_back(
-            this->contact_particles_[k]->template getVariableByName<Real>("VolumetricMeasure"));
-    }
-}
+    : BaseInteraction(contact_relation), kernel_correction_(this->particles_){}
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
 template <class ExecutionPolicy, class EncloserType>

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_residue_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_residue_ck.hpp
@@ -10,7 +10,6 @@ template <class BaseInteractionType>
 template <class DynamicsIdentifier>
 RelaxationResidueBase<BaseInteractionType>::RelaxationResidueBase(DynamicsIdentifier &identifier)
     : BaseInteractionType(identifier),
-      dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure")),
       dv_pos_(this->particles_->template getVariableByName<Vecd>("Position")),
       dv_residue_(this->particles_->template registerStateVariable<Vecd>("ZeroGradientResidue")) {}
 //=================================================================================================//


### PR DESCRIPTION
This pull request standardizes the naming and usage of contact volume variables across several fluid and continuum dynamics classes. The main change is replacing the use of `wall_Vol_` and similar variables with `contact_Vol_` (or similarly named variables), and removing redundant storage of contact volume pointers in various classes. This improves code consistency, clarity, and maintainability, especially for contact interactions between particles and walls.

**Standardization and Refactoring of Contact Volume Variables:**

* Replaced all instances of `wall_Vol_` (and similar variables like `contact_wall_Vol_`) with `contact_Vol_` (or `contact_contact_Vol_`) in the constructors, member variables, and interaction kernels of classes such as `PlasticAcousticStep1stHalf`, `PlasticAcousticStep2ndHalf`, `AcousticStep1stHalf`, `AcousticStep2ndHalf`, `ViscousForceCK`, and `TransportVelocityCorrectionCK`. This includes all usages in both header (`.h`) and implementation (`.hpp`) files. [[1]](diffhunk://#diff-fcd8cb14e4a5c4a4130e53bc0f8c0ad019a0e33faabdb7c82f44400eee1d2796L139-R139) [[2]](diffhunk://#diff-f43d8ebed4a0b2c9091efbc13b11aff86e9587ea0eaf6075d71a32f72522034dL133-R133) [[3]](diffhunk://#diff-f43d8ebed4a0b2c9091efbc13b11aff86e9587ea0eaf6075d71a32f72522034dL149-R149) [[4]](diffhunk://#diff-f672e6d281e7739ba589eab7e20427180dfbe0a5a3582d53118a10cf08608b61L120-R120) [[5]](diffhunk://#diff-36547f6442d0c11a3e19d5f94937cdceac4929435b353bd98ea572330db747f4L119-R119) [[6]](diffhunk://#diff-36547f6442d0c11a3e19d5f94937cdceac4929435b353bd98ea572330db747f4L136-R136) [[7]](diffhunk://#diff-dc5e8b1b5adf3af50bdc3f32e8d0501405cd176bf50fe2db14fa812e8cc7d221L142-R142) [[8]](diffhunk://#diff-b03a2803d7bd272a902e26875759f82f575df65cdb79deeb3783c1627518bdc3L144-R144) [[9]](diffhunk://#diff-b03a2803d7bd272a902e26875759f82f575df65cdb79deeb3783c1627518bdc3L156-R156) [[10]](diffhunk://#diff-34288914d15f431868e538649d46454c5de06a12bd2c6ca9d7b260442dfd6eebL127-R127) [[11]](diffhunk://#diff-c697bcffe8489f8c1fa5f26af1629e92125e42a74d736cf30e9d60000fe63ecdL105-R105) [[12]](diffhunk://#diff-c697bcffe8489f8c1fa5f26af1629e92125e42a74d736cf30e9d60000fe63ecdL118-R118) [[13]](diffhunk://#diff-ba7c26d6c42e7b42438d500a9e3870728c7d74a4e54eb225a831f4eae3c8af07L123-R128) [[14]](diffhunk://#diff-2700a8d53949c455ca8ff54d5af9c99c87b4f37ece119b094992a3a091ceb42fL72-R72) [[15]](diffhunk://#diff-ef55017961967def7b42c6a8dfc91ddc07d081e97fc83d0919a75c03bb401549L106-L111) [[16]](diffhunk://#diff-3428a5cabc10529f32c69861cca9ed12e61ed0e562d15e510ff02b3ebad073bfL120-R113) [[17]](diffhunk://#diff-3428a5cabc10529f32c69861cca9ed12e61ed0e562d15e510ff02b3ebad073bfL130-R123)

* Updated all calculations involving the volume of contact particles to use the new `contact_Vol_` variable, ensuring consistency in mathematical operations across all affected classes. [[1]](diffhunk://#diff-f43d8ebed4a0b2c9091efbc13b11aff86e9587ea0eaf6075d71a32f72522034dL149-R149) [[2]](diffhunk://#diff-36547f6442d0c11a3e19d5f94937cdceac4929435b353bd98ea572330db747f4L136-R136) [[3]](diffhunk://#diff-b03a2803d7bd272a902e26875759f82f575df65cdb79deeb3783c1627518bdc3L156-R156) [[4]](diffhunk://#diff-c697bcffe8489f8c1fa5f26af1629e92125e42a74d736cf30e9d60000fe63ecdL118-R118) [[5]](diffhunk://#diff-2700a8d53949c455ca8ff54d5af9c99c87b4f37ece119b094992a3a091ceb42fL72-R72) [[6]](diffhunk://#diff-3428a5cabc10529f32c69861cca9ed12e61ed0e562d15e510ff02b3ebad073bfL130-R123)

**Removal of Redundant or Unused Variables:**

* Removed redundant storage of `dv_contact_Vol_` and similar vectors from several classes, such as `AcousticStep1stHalf`, `AcousticStep2ndHalf`, `DiffusionRelaxationCK`, `LinearGradient`, `Hessian`, and `SecondOrderGradient`, as these are now handled more centrally and consistently. [[1]](diffhunk://#diff-dc5e8b1b5adf3af50bdc3f32e8d0501405cd176bf50fe2db14fa812e8cc7d221L185-R185) [[2]](diffhunk://#diff-34288914d15f431868e538649d46454c5de06a12bd2c6ca9d7b260442dfd6eebL172) [[3]](diffhunk://#diff-a4b262bf02d6d07d62e3656c70201511a56118a2acd8948e40d536c12c8040f8L162) [[4]](diffhunk://#diff-c4e5d5c54e139113e9631a3329bb4bbe5961e1854728e40db82f0bb3843df074L160) [[5]](diffhunk://#diff-c4e5d5c54e139113e9631a3329bb4bbe5961e1854728e40db82f0bb3843df074L239) [[6]](diffhunk://#diff-c4e5d5c54e139113e9631a3329bb4bbe5961e1854728e40db82f0bb3843df074L291)

* Removed unnecessary initialization of contact volume pointers in constructors, simplifying the setup of contact relations in affected classes. [[1]](diffhunk://#diff-b03a2803d7bd272a902e26875759f82f575df65cdb79deeb3783c1627518bdc3L182-L183) [[2]](diffhunk://#diff-c697bcffe8489f8c1fa5f26af1629e92125e42a74d736cf30e9d60000fe63ecdL143-L144) [[3]](diffhunk://#diff-6cb488e70e2deacf4d79c3e64804ce38058ec7744239a2e08689eb6a118a3d78L149-L150) [[4]](diffhunk://#diff-7a38c355c13a57a7c0dee6a968cec10709d3ce9e4588d2e9b48cda34348879b0L53-L54) [[5]](diffhunk://#diff-3428a5cabc10529f32c69861cca9ed12e61ed0e562d15e510ff02b3ebad073bfL104-R104)

These changes collectively enhance code readability, reduce duplication, and clarify the distinction between wall and contact volumes in particle interactions.