### PR TITLE
Use zero gradient residue

### DIFF
--- a/modules/opencascade/opencascade/relax_dynamics_surface.h
+++ b/modules/opencascade/opencascade/relax_dynamics_surface.h
@@ -63,7 +63,7 @@ class RelaxationStepInnerFirstHalf : public BaseDynamics<void>
   protected:
     RealBody *real_body_;
     BaseInnerRelation &inner_relation_;
-    InteractionDynamics<RelaxationResidue<Inner<>>> relaxation_acceleration_inner_;
+    InteractionDynamics<RelaxationResidual<Inner<>>> relaxation_acceleration_inner_;
 };
 
 class RelaxationStepInnerSecondHalf : public BaseDynamics<void>

--- a/src/shared/particle_dynamics/fluid_dynamics/transport_velocity_correction.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/transport_velocity_correction.h
@@ -55,7 +55,7 @@ class TransportVelocityCorrection<Base, DataDelegationType, KernelCorrectionType
     virtual ~TransportVelocityCorrection() {};
 
   protected:
-    Vecd *zero_gradient_residue_;
+    Vecd *zero_gradient_residual_;
     KernelCorrectionType kernel_correction_;
     ParticleScope within_scope_;
 };

--- a/src/shared/particle_dynamics/fluid_dynamics/transport_velocity_correction.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/transport_velocity_correction.hpp
@@ -12,7 +12,7 @@ template <class BaseRelationType>
 TransportVelocityCorrection<Base, DataDelegationType, KernelCorrectionType, ParticleScope>::
     TransportVelocityCorrection(BaseRelationType &base_relation)
     : LocalDynamics(base_relation.getSPHBody()), DataDelegationType(base_relation),
-      zero_gradient_residue_(this->particles_->template registerStateVariableData<Vecd>("ZeroGradientResidue")),
+      zero_gradient_residual_(this->particles_->template registerStateVariableData<Vecd>("ZeroGradientResidual")),
       kernel_correction_(this->particles_), within_scope_(this->particles_)
 {
     static_assert(std::is_base_of<WithinScope, ParticleScope>::value,
@@ -48,7 +48,7 @@ void TransportVelocityCorrection<Inner<ResolutionType, LimiterType>, CommonContr
             inconsistency -= (this->kernel_correction_(index_i) + this->kernel_correction_(index_j, index_i)) *
                              inner_neighborhood.dW_ij_[n] * this->Vol_[index_j] * inner_neighborhood.e_ij_[n];
         }
-        this->zero_gradient_residue_[index_i] = inconsistency;
+        this->zero_gradient_residual_[index_i] = inconsistency;
     }
 }
 //=================================================================================================//
@@ -59,9 +59,9 @@ void TransportVelocityCorrection<Inner<ResolutionType, LimiterType>, CommonContr
     if (this->within_scope_(index_i))
     {
         Real inv_h_ratio = 1.0 / h_ratio_(index_i);
-        Real squared_norm = this->zero_gradient_residue_[index_i].squaredNorm();
+        Real squared_norm = this->zero_gradient_residual_[index_i].squaredNorm();
         pos_[index_i] += correction_scaling_ * limiter_(squared_norm) *
-                         this->zero_gradient_residue_[index_i] * inv_h_ratio * inv_h_ratio;
+                         this->zero_gradient_residual_[index_i] * inv_h_ratio * inv_h_ratio;
     }
 }
 //=================================================================================================//
@@ -95,7 +95,7 @@ void TransportVelocityCorrection<Contact<Boundary>, CommonControlTypes...>::
                                  wall_Vol_k[index_j] * contact_neighborhood.e_ij_[n];
             }
         }
-        this->zero_gradient_residue_[index_i] += inconsistency;
+        this->zero_gradient_residual_[index_i] += inconsistency;
     }
 }
 //=================================================================================================//
@@ -132,7 +132,7 @@ void TransportVelocityCorrection<Contact<>, KernelCorrectionType, CommonControlT
                                  contact_neighborhood.dW_ij_[n] * Vol_k[index_j] * contact_neighborhood.e_ij_[n];
             }
         }
-        this->zero_gradient_residue_[index_i] += inconsistency;
+        this->zero_gradient_residual_[index_i] += inconsistency;
     }
 }
 //=================================================================================================//

--- a/src/shared/particle_dynamics/relax_dynamics/relax_stepping.h
+++ b/src/shared/particle_dynamics/relax_dynamics/relax_stepping.h
@@ -61,32 +61,32 @@ struct ErrorAndParameters
 };
 
 template <typename... InteractionTypes>
-class RelaxationResidue;
+class RelaxationResidual;
 
 template <class DataDelegationType>
-class RelaxationResidue<Base, DataDelegationType>
+class RelaxationResidual<Base, DataDelegationType>
     : public LocalDynamics, public DataDelegationType
 {
   public:
     template <class BaseRelationType>
-    explicit RelaxationResidue(BaseRelationType &base_relation);
-    virtual ~RelaxationResidue() {};
+    explicit RelaxationResidual(BaseRelationType &base_relation);
+    virtual ~RelaxationResidual() {};
 
   protected:
     SPHAdaptation *sph_adaptation_;
     Kernel *kernel_;
     Real *Vol_, *kinetic_energy_;
-    Vecd *pos_, *residue_;
+    Vecd *pos_, *residual_;
 };
 
 template <>
-class RelaxationResidue<Inner<>>
-    : public RelaxationResidue<Base, DataDelegateInner>
+class RelaxationResidual<Inner<>>
+    : public RelaxationResidual<Base, DataDelegateInner>
 {
   public:
-    explicit RelaxationResidue(BaseInnerRelation &inner_relation);
-    RelaxationResidue(BaseInnerRelation &inner_relation, const std::string &sub_shape_name);
-    virtual ~RelaxationResidue() {};
+    explicit RelaxationResidual(BaseInnerRelation &inner_relation);
+    RelaxationResidual(BaseInnerRelation &inner_relation, const std::string &sub_shape_name);
+    virtual ~RelaxationResidual() {};
     Shape &getRelaxShape() { return relax_shape_; };
     void interaction(size_t index_i, Real dt = 0.0);
 
@@ -95,15 +95,15 @@ class RelaxationResidue<Inner<>>
 };
 
 template <>
-class RelaxationResidue<Inner<LevelSetCorrection>> : public RelaxationResidue<Inner<>>
+class RelaxationResidual<Inner<LevelSetCorrection>> : public RelaxationResidual<Inner<>>
 {
   public:
     template <typename... Args>
-    RelaxationResidue(Args &&...args);
+    RelaxationResidual(Args &&...args);
     template <typename BodyRelationType, typename FirstArg>
-    explicit RelaxationResidue(DynamicsArgs<BodyRelationType, FirstArg> parameters)
-        : RelaxationResidue(parameters.identifier_, std::get<0>(parameters.others_)){};
-    virtual ~RelaxationResidue() {};
+    explicit RelaxationResidual(DynamicsArgs<BodyRelationType, FirstArg> parameters)
+        : RelaxationResidual(parameters.identifier_, std::get<0>(parameters.others_)){};
+    virtual ~RelaxationResidual() {};
     void interaction(size_t index_i, Real dt = 0.0);
 
   protected:
@@ -112,15 +112,15 @@ class RelaxationResidue<Inner<LevelSetCorrection>> : public RelaxationResidue<In
 };
 
 template <>
-class RelaxationResidue<Inner<Implicit>> : public RelaxationResidue<Inner<>>
+class RelaxationResidual<Inner<Implicit>> : public RelaxationResidual<Inner<>>
 {
   public:
     template <typename... Args>
-    RelaxationResidue(Args &&...args);
+    RelaxationResidual(Args &&...args);
     template <typename BodyRelationType, typename FirstArg>
-    explicit RelaxationResidue(DynamicsArgs<BodyRelationType, FirstArg> parameters)
-        : RelaxationResidue(parameters.identifier_, std::get<0>(parameters.others_)){};
-    virtual ~RelaxationResidue() {};
+    explicit RelaxationResidual(DynamicsArgs<BodyRelationType, FirstArg> parameters)
+        : RelaxationResidual(parameters.identifier_, std::get<0>(parameters.others_)){};
+    virtual ~RelaxationResidual() {};
     void interaction(size_t index_i, Real dt = 0.0);
 
   protected:
@@ -129,15 +129,15 @@ class RelaxationResidue<Inner<Implicit>> : public RelaxationResidue<Inner<>>
 };
 
 template <>
-class RelaxationResidue<Inner<LevelSetCorrection, Implicit>> : public RelaxationResidue<Inner<Implicit>>
+class RelaxationResidual<Inner<LevelSetCorrection, Implicit>> : public RelaxationResidual<Inner<Implicit>>
 {
   public:
     template <typename... Args>
-    RelaxationResidue(Args &&...args);
+    RelaxationResidual(Args &&...args);
     template <typename BodyRelationType, typename FirstArg>
-    explicit RelaxationResidue(DynamicsArgs<BodyRelationType, FirstArg> parameters)
-        : RelaxationResidue(parameters.identifier_, std::get<0>(parameters.others_)){};
-    virtual ~RelaxationResidue() {};
+    explicit RelaxationResidual(DynamicsArgs<BodyRelationType, FirstArg> parameters)
+        : RelaxationResidual(parameters.identifier_, std::get<0>(parameters.others_)){};
+    virtual ~RelaxationResidual() {};
     void interaction(size_t index_i, Real dt = 0.0);
 
   protected:
@@ -147,19 +147,19 @@ class RelaxationResidue<Inner<LevelSetCorrection, Implicit>> : public Relaxation
 };
 
 template <>
-class RelaxationResidue<Contact<>>
-    : public RelaxationResidue<Base, DataDelegateContact>
+class RelaxationResidual<Contact<>>
+    : public RelaxationResidual<Base, DataDelegateContact>
 {
   public:
-    explicit RelaxationResidue(BaseContactRelation &contact_relation)
-        : RelaxationResidue<Base, DataDelegateContact>(contact_relation)
+    explicit RelaxationResidual(BaseContactRelation &contact_relation)
+        : RelaxationResidual<Base, DataDelegateContact>(contact_relation)
     {
         for (size_t k = 0; k < this->contact_configuration_.size(); ++k)
         {
             contact_Vol_.push_back(this->contact_particles_[k]->template registerStateVariableData<Real>("VolumetricMeasure"));
         }
     };
-    virtual ~RelaxationResidue() {};
+    virtual ~RelaxationResidual() {};
     void interaction(size_t index_i, Real dt = 0.0);
 
   protected:
@@ -179,7 +179,7 @@ class RelaxationScaling : public LocalDynamicsReduce<ReduceMax>
     virtual Real outputResult(Real reduced_value);
 
   protected:
-    Vecd *residue_;
+    Vecd *residual_;
     Real h_ref_;
 };
 
@@ -191,7 +191,7 @@ class PositionRelaxation : public LocalDynamics
 {
   protected:
     SPHAdaptation *sph_adaptation_;
-    Vecd *pos_, *residue_;
+    Vecd *pos_, *residual_;
 
   public:
     explicit PositionRelaxation(SPHBody &sph_body);
@@ -215,7 +215,7 @@ class UpdateSmoothingLengthRatioByShape : public LocalDynamics
     void update(size_t index_i, Real dt = 0.0);
 };
 
-template <class RelaxationResidueType>
+template <class RelaxationResidualType>
 class RelaxationStep : public BaseDynamics<void>
 {
   public:
@@ -228,14 +228,14 @@ class RelaxationStep : public BaseDynamics<void>
   protected:
     RealBody &real_body_;
     StdVec<SPHRelation *> &body_relations_;
-    InteractionDynamics<RelaxationResidueType> relaxation_residue_;
+    InteractionDynamics<RelaxationResidualType> relaxation_residual_;
     ReduceDynamics<RelaxationScaling> relaxation_scaling_;
     SimpleDynamics<PositionRelaxation> position_relaxation_;
     NearShapeSurface near_shape_surface_;
     SimpleDynamics<ShapeSurfaceBounding> surface_bounding_;
 };
 
-template <class RelaxationResidueType>
+template <class RelaxationResidualType>
 class RelaxationStepImplicit : public BaseDynamics<void>
 {
   public:
@@ -248,19 +248,19 @@ class RelaxationStepImplicit : public BaseDynamics<void>
   protected:
     RealBody &real_body_;
     StdVec<SPHRelation *> &body_relations_;
-    InteractionSplit<RelaxationResidueType> relaxation_residue_;
+    InteractionSplit<RelaxationResidualType> relaxation_residual_;
     ReduceDynamics<RelaxationScaling> relaxation_scaling_;
     SimpleDynamics<PositionRelaxation> position_relaxation_;
     NearShapeSurface near_shape_surface_;
     SimpleDynamics<ShapeSurfaceBounding> surface_bounding_;
 };
 
-using RelaxationStepInner = RelaxationStep<RelaxationResidue<Inner<>>>;
-using RelaxationStepLevelSetCorrectionInner = RelaxationStep<RelaxationResidue<Inner<LevelSetCorrection>>>;
-using RelaxationStepComplex = RelaxationStep<ComplexInteraction<RelaxationResidue<Inner<>, Contact<>>>>;
-using RelaxationStepLevelSetCorrectionComplex = RelaxationStep<ComplexInteraction<RelaxationResidue<Inner<LevelSetCorrection>, Contact<>>>>;
-using RelaxationStepInnerImplicit = RelaxationStepImplicit<RelaxationResidue<Inner<Implicit>>>;
-using RelaxationStepLevelSetCorrectionInnerImplicit = RelaxationStepImplicit<RelaxationResidue<Inner<LevelSetCorrection, Implicit>>>;
+using RelaxationStepInner = RelaxationStep<RelaxationResidual<Inner<>>>;
+using RelaxationStepLevelSetCorrectionInner = RelaxationStep<RelaxationResidual<Inner<LevelSetCorrection>>>;
+using RelaxationStepComplex = RelaxationStep<ComplexInteraction<RelaxationResidual<Inner<>, Contact<>>>>;
+using RelaxationStepLevelSetCorrectionComplex = RelaxationStep<ComplexInteraction<RelaxationResidual<Inner<LevelSetCorrection>, Contact<>>>>;
+using RelaxationStepInnerImplicit = RelaxationStepImplicit<RelaxationResidual<Inner<Implicit>>>;
+using RelaxationStepLevelSetCorrectionInnerImplicit = RelaxationStepImplicit<RelaxationResidual<Inner<LevelSetCorrection, Implicit>>>;
 } // namespace relax_dynamics
 } // namespace SPH
 #endif // RELAX_STEPPING_H

--- a/src/shared/particle_dynamics/relax_dynamics/relax_stepping.hpp
+++ b/src/shared/particle_dynamics/relax_dynamics/relax_stepping.hpp
@@ -10,76 +10,76 @@ namespace relax_dynamics
 //=================================================================================================//
 template <class DataDelegationType>
 template <class BaseRelationType>
-RelaxationResidue<Base, DataDelegationType>::RelaxationResidue(BaseRelationType &base_relation)
+RelaxationResidual<Base, DataDelegationType>::RelaxationResidual(BaseRelationType &base_relation)
     : LocalDynamics(base_relation.getSPHBody()), DataDelegationType(base_relation),
       sph_adaptation_(&this->sph_body_.getSPHAdaptation()),
       kernel_(base_relation.getSPHBody().getSPHAdaptation().getKernel()),
       Vol_(this->particles_->template getVariableDataByName<Real>("VolumetricMeasure")),
       kinetic_energy_(this->particles_->template registerStateVariableData<Real>("ParticleKineticEnergy")),
       pos_(this->particles_->template getVariableDataByName<Vecd>("Position")),
-      residue_(this->particles_->template registerStateVariableData<Vecd>("ZeroOrderResidue")) {}
+      residual_(this->particles_->template registerStateVariableData<Vecd>("ZeroOrderResidual")) {}
 //=================================================================================================//
 template <typename... Args>
-RelaxationResidue<Inner<LevelSetCorrection>>::RelaxationResidue(Args &&...args)
-    : RelaxationResidue<Inner<>>(std::forward<Args>(args)...),
+RelaxationResidual<Inner<LevelSetCorrection>>::RelaxationResidual(Args &&...args)
+    : RelaxationResidual<Inner<>>(std::forward<Args>(args)...),
       pos_(particles_->getVariableDataByName<Vecd>("Position")),
       level_set_shape_(DynamicCast<LevelSetShape>(this, this->getRelaxShape())){};
 //=================================================================================================//
 template <typename... Args>
-RelaxationResidue<Inner<Implicit>>::RelaxationResidue(Args &&...args)
-    : RelaxationResidue<Inner<>>(std::forward<Args>(args)...){};
+RelaxationResidual<Inner<Implicit>>::RelaxationResidual(Args &&...args)
+    : RelaxationResidual<Inner<>>(std::forward<Args>(args)...){};
 //=================================================================================================//
 template <typename... Args>
-RelaxationResidue<Inner<LevelSetCorrection, Implicit>>::RelaxationResidue(Args &&...args)
-    : RelaxationResidue<Inner<Implicit>>(std::forward<Args>(args)...),
+RelaxationResidual<Inner<LevelSetCorrection, Implicit>>::RelaxationResidual(Args &&...args)
+    : RelaxationResidual<Inner<Implicit>>(std::forward<Args>(args)...),
       pos_(particles_->getVariableDataByName<Vecd>("Position")),
       level_set_shape_(DynamicCast<LevelSetShape>(this, this->getRelaxShape())){};
 //=================================================================================================//
-template <class RelaxationResidueType>
+template <class RelaxationResidualType>
 template <typename FirstArg, typename... OtherArgs>
-RelaxationStep<RelaxationResidueType>::
+RelaxationStep<RelaxationResidualType>::
     RelaxationStep(FirstArg &&first_arg, OtherArgs &&...other_args)
     : BaseDynamics<void>(),
       real_body_(DynamicCast<RealBody>(this, first_arg.getSPHBody())),
       body_relations_(real_body_.getBodyRelations()),
-      relaxation_residue_(first_arg, std::forward<OtherArgs>(other_args)...),
+      relaxation_residual_(first_arg, std::forward<OtherArgs>(other_args)...),
       relaxation_scaling_(real_body_), position_relaxation_(real_body_),
-      near_shape_surface_(real_body_, DynamicCast<LevelSetShape>(this, relaxation_residue_.getRelaxShape())),
+      near_shape_surface_(real_body_, DynamicCast<LevelSetShape>(this, relaxation_residual_.getRelaxShape())),
       surface_bounding_(near_shape_surface_) {}
 //=================================================================================================//
-template <class RelaxationResidueType>
-void RelaxationStep<RelaxationResidueType>::exec(Real dt)
+template <class RelaxationResidualType>
+void RelaxationStep<RelaxationResidualType>::exec(Real dt)
 {
     real_body_.updateCellLinkedList();
     for (size_t k = 0; k != body_relations_.size(); ++k)
     {
         body_relations_[k]->updateConfiguration();
     }
-    relaxation_residue_.exec();
+    relaxation_residual_.exec();
     Real scaling = relaxation_scaling_.exec();
     position_relaxation_.exec(scaling);
     surface_bounding_.exec();
 }
 //=================================================================================================//
-template <class RelaxationResidueType>
+template <class RelaxationResidualType>
 template <typename FirstArg, typename... OtherArgs>
-RelaxationStepImplicit<RelaxationResidueType>::
+RelaxationStepImplicit<RelaxationResidualType>::
     RelaxationStepImplicit(FirstArg &&first_arg, OtherArgs &&...other_args)
     : BaseDynamics<void>(),
       real_body_(DynamicCast<RealBody>(this, first_arg.getSPHBody())),
       body_relations_(real_body_.getBodyRelations()),
-      relaxation_residue_(first_arg, std::forward<OtherArgs>(other_args)...),
+      relaxation_residual_(first_arg, std::forward<OtherArgs>(other_args)...),
       relaxation_scaling_(real_body_), position_relaxation_(real_body_),
-      near_shape_surface_(real_body_, DynamicCast<LevelSetShape>(this, relaxation_residue_.getRelaxShape())),
+      near_shape_surface_(real_body_, DynamicCast<LevelSetShape>(this, relaxation_residual_.getRelaxShape())),
       surface_bounding_(near_shape_surface_)
 {
 }
 //=================================================================================================//
-template <class RelaxationResidueType>
-void RelaxationStepImplicit<RelaxationResidueType>::exec(Real dt)
+template <class RelaxationResidualType>
+void RelaxationStepImplicit<RelaxationResidualType>::exec(Real dt)
 {
     Real scaling = SMIN(Real(sqrt(relaxation_scaling_.exec())), Real(0.01));
-    relaxation_residue_.exec(scaling);
+    relaxation_residual_.exec(scaling);
     real_body_.updateCellLinkedList();
     for (size_t k = 0; k != body_relations_.size(); ++k)
     {

--- a/src/shared/particle_dynamics/relax_dynamics/relax_thick_shell.cpp
+++ b/src/shared/particle_dynamics/relax_dynamics/relax_thick_shell.cpp
@@ -172,7 +172,7 @@ ShellRelaxationStep::ShellRelaxationStep(BaseInnerRelation &inner_relation)
     : BaseDynamics<void>(),
       real_body_(DynamicCast<RealBody>(this, inner_relation.getSPHBody())),
       inner_relation_(inner_relation), near_shape_surface_(real_body_),
-      relaxation_residue_(inner_relation),
+      relaxation_residual_(inner_relation),
       relaxation_scaling_(real_body_), position_relaxation_(real_body_),
       mid_surface_bounding_(near_shape_surface_) {}
 //=================================================================================================//
@@ -180,7 +180,7 @@ void ShellRelaxationStep::exec(Real ite_p)
 {
     real_body_.updateCellLinkedList();
     inner_relation_.updateConfiguration();
-    relaxation_residue_.exec();
+    relaxation_residual_.exec();
     Real scaling = relaxation_scaling_.exec();
     position_relaxation_.exec(scaling);
     mid_surface_bounding_.exec();

--- a/src/shared/particle_dynamics/relax_dynamics/relax_thick_shell.h
+++ b/src/shared/particle_dynamics/relax_dynamics/relax_thick_shell.h
@@ -166,7 +166,7 @@ class ShellRelaxationStep : public BaseDynamics<void>
     RealBody &real_body_;
     BaseInnerRelation &inner_relation_;
     NearShapeSurface near_shape_surface_;
-    InteractionDynamics<RelaxationResidue<Inner<>>> relaxation_residue_;
+    InteractionDynamics<RelaxationResidual<Inner<>>> relaxation_residual_;
     ReduceDynamics<RelaxationScaling> relaxation_scaling_;
     SimpleDynamics<PositionRelaxation> position_relaxation_;
     SimpleDynamics<ShellMidSurfaceBounding> mid_surface_bounding_;

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.h
@@ -220,7 +220,7 @@ class PressureVelocityCondition : public BaseLocalDynamics<AlignedBoxByCell>,
         CorrectionKernel correction_kernel_;
         ConditionType condition_;
         Real *physical_time_;
-        Vecd *zero_gradient_residue_;
+        Vecd *zero_gradient_residual_;
         int axis_;
         Transform *transform_;
     };
@@ -230,7 +230,7 @@ class PressureVelocityCondition : public BaseLocalDynamics<AlignedBoxByCell>,
     KernelCorrectionType kernel_correction_method_;
     ConditionType condition_;
     SingularVariable<Real> *sv_physical_time_;
-    DiscreteVariable<Vecd> *dv_zero_gradient_residue_;
+    DiscreteVariable<Vecd> *dv_zero_gradient_residual_;
 };
 
 template <typename ExecutionPolicy, class KernelCorrectionType, class ConditionType>

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.hpp
@@ -124,7 +124,7 @@ PressureVelocityCondition<KernelCorrectionType, ConditionType>::
       kernel_correction_method_(this->particles_),
       condition_(std::forward<Args>(args)...),
       sv_physical_time_(this->sph_system_.template getSystemVariableByName<Real>("PhysicalTime")),
-      dv_zero_gradient_residue_(this->particles_->template getVariableByName<Vecd>("ZeroGradientResidue")) {}
+      dv_zero_gradient_residual_(this->particles_->template getVariableByName<Vecd>("ZeroGradientResidual")) {}
 //=================================================================================================//
 template <class KernelCorrectionType, typename ConditionType>
 template <class ExecutionPolicy, class EncloserType>
@@ -135,7 +135,7 @@ PressureVelocityCondition<KernelCorrectionType, ConditionType>::UpdateKernel::
       correction_kernel_(ex_policy, encloser.kernel_correction_method_),
       condition_(encloser.condition_),
       physical_time_(encloser.sv_physical_time_->DelegatedData(ex_policy)),
-      zero_gradient_residue_(encloser.dv_zero_gradient_residue_->DelegatedData(ex_policy)),
+      zero_gradient_residual_(encloser.dv_zero_gradient_residual_->DelegatedData(ex_policy)),
       axis_(aligned_box_->AlignmentAxis()), transform_(&aligned_box_->getTransform()) {}
 //=================================================================================================//
 template <class KernelCorrectionType, typename ConditionType>
@@ -144,9 +144,9 @@ void PressureVelocityCondition<KernelCorrectionType, ConditionType>::
 {
     if (aligned_box_->checkContain(pos_[index_i]))
     {
-        Vecd corrected_residue = correction_kernel_(index_i) * zero_gradient_residue_[index_i];
+        Vecd corrected_residual = correction_kernel_(index_i) * zero_gradient_residual_[index_i];
         vel_[index_i] -= dt * condition_.getPressure(p_[index_i], *physical_time_) /
-                         rho_[index_i] * corrected_residue;
+                         rho_[index_i] * corrected_residual;
 
         Vecd frame_velocity = Vecd::Zero();
         frame_velocity[axis_] = transform_->xformBaseVecToFrame(vel_[index_i])[axis_];

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.h
@@ -39,7 +39,7 @@ class TransportVelocityCorrectionCK<
         SmoothingRatio h_ratio_;
         LimiterType limiter_;
         Vecd *dpos_;
-        Vecd *zero_gradient_residue_;
+        Vecd *zero_gradient_residual_;
         ParticleScopeTypeKernel within_scope_;
     };
 

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.h
@@ -5,55 +5,27 @@
 #include "interaction_ck.hpp"
 #include "kernel_correction_ck.hpp"
 #include "particle_functors_ck.h"
+#include "zero_gradient_residual.hpp"
 
 namespace SPH
 {
 namespace fluid_dynamics
 {
-template <class BaseInteractionType>
-class TransportVelocityCorrectionCKBase : public BaseInteractionType
-{
-  public:
-    template <class DynamicsIdentifier>
-    explicit TransportVelocityCorrectionCKBase(DynamicsIdentifier &identifier);
-    virtual ~TransportVelocityCorrectionCKBase() {}
-
-  protected:
-    DiscreteVariable<Vecd> *dv_dpos_;                  ///< "Position"
-    DiscreteVariable<Vecd> *dv_zero_gradient_residue_; ///< "ZeroGradientResidue"
-};
-
 template <typename...>
 class TransportVelocityCorrectionCK;
 
 template <class KernelCorrectionType, class LimiterType, class ParticleScopeType, typename... Parameters>
 class TransportVelocityCorrectionCK<
     Inner<WithUpdate, KernelCorrectionType, LimiterType, ParticleScopeType, Parameters...>>
-    : public TransportVelocityCorrectionCKBase<Interaction<Inner<Parameters...>>>
+    : public ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>
 {
-    using BaseInteraction = TransportVelocityCorrectionCKBase<Interaction<Inner<Parameters...>>>;
-    using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
+    using BaseInteraction = ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>;
     using ParticleScopeTypeKernel = typename ParticleScopeTypeCK<ParticleScopeType>::ComputingKernel;
     using SmoothingRatio = typename Inner<Parameters...>::NeighborMethodType::SmoothingRatio;
 
   public:
     explicit TransportVelocityCorrectionCK(Inner<Parameters...> &inner_relation, Real coefficient = 0.2);
     virtual ~TransportVelocityCorrectionCK() {}
-
-    class InteractKernel : public BaseInteraction::InteractKernel
-    {
-      public:
-        template <class ExecutionPolicy, class EncloserType>
-        InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
-
-      protected:
-        CorrectionKernel correction_;
-        Real *Vol_;
-        Vecd *dpos_;
-        Vecd *zero_gradient_residue_;
-        ParticleScopeTypeKernel within_scope_;
-    };
 
     class UpdateKernel
     {
@@ -63,7 +35,6 @@ class TransportVelocityCorrectionCK<
         void update(size_t index_i, Real dt = 0.0);
 
       protected:
-        CorrectionKernel correction_;
         Real correction_scaling_;
         SmoothingRatio h_ratio_;
         LimiterType limiter_;
@@ -73,53 +44,37 @@ class TransportVelocityCorrectionCK<
     };
 
   protected:
-    KernelCorrectionType kernel_correction_;
     Real h_ref_;              ///< e.g. reference smoothing length
     Real correction_scaling_; ///< typically coefficient * h_ref^2
     SmoothingRatio h_ratio_;  ///< e.g. for adaptive resolution
     LimiterType limiter_;     ///< e.g. a limiter on the final correction step
     ParticleScopeTypeCK<ParticleScopeType> within_scope_method_;
+    DiscreteVariable<Vecd> *dv_dpos_;
 };
 
 template <class KernelCorrectionType, typename... Parameters>
-class TransportVelocityCorrectionCK<Contact<Wall, KernelCorrectionType, Parameters...>>
-    : public TransportVelocityCorrectionCKBase<Interaction<Contact<Parameters...>>>, public Interaction<Wall>
+class TransportVelocityCorrectionCK<Contact<Boundary, KernelCorrectionType, Parameters...>>
+    : public ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...>>
 {
-    using BaseInteraction = TransportVelocityCorrectionCKBase<Interaction<Contact<Parameters...>>>;
-    using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
+    using BaseInteraction = ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...>>;
 
-  public:
-    explicit TransportVelocityCorrectionCK(Contact<Parameters...> &contact_relation);
-    virtual ~TransportVelocityCorrectionCK() {}
-
-    class InteractKernel : public BaseInteraction::InteractKernel
-    {
       public:
-        template <class ExecutionPolicy, class EncloserType>
-        InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt contact_index);
-        void interact(size_t index_i, Real dt = 0.0);
-
-      protected:
-        CorrectionKernel correction_;
-        Vecd *zero_gradient_residue_;
-        Real *contact_contact_Vol_;
-    };
-
-  protected:
-    KernelCorrectionType kernel_correction_;
+        explicit TransportVelocityCorrectionCK(Contact<Parameters...> & contact_relation)
+            : BaseInteraction(contact_relation){}
+        virtual ~TransportVelocityCorrectionCK() {}
 };
 //--------------------------------------------------------------------------------------
 // Alias Definitions for Specific Configurations
 //--------------------------------------------------------------------------------------
-using TransportVelocityCorrectionWallNoCorrectionBulkParticlesCK =
+using TransportVelocityCorrectionComplexBulkParticlesCK =
     TransportVelocityCorrectionCK<
         Inner<WithUpdate, NoKernelCorrectionCK, NoLimiter, BulkParticles>,
-        Contact<Wall, NoKernelCorrectionCK>>;
+        Contact<Boundary, NoKernelCorrectionCK>>;
 
 using TransportVelocityLimitedCorrectionCorrectedComplexBulkParticlesCK =
     TransportVelocityCorrectionCK<
         Inner<WithUpdate, LinearCorrectionCK, TruncatedLinear, BulkParticles>,
-        Contact<Wall, LinearCorrectionCK>>;
+        Contact<Boundary, LinearCorrectionCK>>;
 } // namespace fluid_dynamics
 } // namespace SPH
 #endif // TRANSPORT_VELOCITY_CORRECTION_CK_H

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.hpp
@@ -8,30 +8,19 @@ namespace SPH
 namespace fluid_dynamics
 {
 //=================================================================================================//
-template <class BaseInteractionType>
-template <class DynamicsIdentifier>
-TransportVelocityCorrectionCKBase<BaseInteractionType>::
-    TransportVelocityCorrectionCKBase(DynamicsIdentifier &identifier)
-    : BaseInteractionType(identifier),
-      dv_dpos_(this->particles_->template getVariableByName<Vecd>("Displacement")),
-      dv_zero_gradient_residue_(
-          this->particles_->template registerStateVariable<Vecd>("ZeroGradientResidue")) {}
-//=================================================================================================//
 template <class KernelCorrectionType, class LimiterType, class ParticleScopeType, typename... Parameters>
 TransportVelocityCorrectionCK<
     Inner<WithUpdate, KernelCorrectionType, LimiterType, ParticleScopeType, Parameters...>>::
     TransportVelocityCorrectionCK(Inner<Parameters...> &inner_relation, Real coefficient)
-    : TransportVelocityCorrectionCKBase<Interaction<Inner<Parameters...>>>(inner_relation),
-      kernel_correction_(this->particles_),
+    : BaseInteraction(inner_relation),
       h_ref_(this->sph_body_.getSPHAdaptation().ReferenceSmoothingLength()),
       correction_scaling_(coefficient * h_ref_ * h_ref_),
       h_ratio_(inner_relation.getNeighborMethod()), limiter_(h_ref_ * h_ref_),
-      within_scope_method_(this->particles_)
+      within_scope_method_(this->particles_),
+      dv_dpos_(this->particles_->template getVariableByName<Vecd>("Displacement"))
 {
     static_assert(std::is_base_of<WithinScope, ParticleScopeType>::value,
                   "WithinScope is not the base of ParticleScope!");
-    static_assert(std::is_base_of<KernelCorrection, KernelCorrectionType>::value,
-                  "KernelCorrectionType must derive from KernelCorrection!");
     static_assert(std::is_base_of<Limiter, LimiterType>::value,
                   "Limiter is not the base of LimiterType!");
 }
@@ -40,42 +29,8 @@ template <class KernelCorrectionType, class LimiterType, class ParticleScopeType
 template <class ExecutionPolicy, class EncloserType>
 TransportVelocityCorrectionCK<
     Inner<WithUpdate, KernelCorrectionType, LimiterType, ParticleScopeType, Parameters...>>::
-    InteractKernel::InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
-    : BaseInteraction::InteractKernel(ex_policy, encloser),
-      correction_(ex_policy, encloser.kernel_correction_),
-      Vol_(encloser.dv_Vol_->DelegatedData(ex_policy)),
-      dpos_(encloser.dv_dpos_->DelegatedData(ex_policy)),
-      zero_gradient_residue_(encloser.dv_zero_gradient_residue_->DelegatedData(ex_policy)),
-      within_scope_(ex_policy, encloser.within_scope_method_, *this) {}
-//=================================================================================================//
-template <class KernelCorrectionType, class LimiterType, class ParticleScopeType, typename... Parameters>
-void TransportVelocityCorrectionCK<
-    Inner<WithUpdate, KernelCorrectionType, LimiterType, ParticleScopeType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
-{
-    {
-        Vecd inconsistency = Vecd::Zero();
-        for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
-        {
-            UnsignedInt index_j = this->neighbor_index_[n];
-            const Real dW_ijV_j = this->dW_ij(index_i, index_j) * Vol_[index_j];
-            const Vecd e_ij = this->e_ij(index_i, index_j);
-
-            // acceleration for transport velocity
-            inconsistency -=
-                (this->correction_(index_i) + this->correction_(index_j)) * dW_ijV_j * e_ij;
-        }
-        this->zero_gradient_residue_[index_i] = inconsistency;
-    }
-}
-//=================================================================================================//
-template <class KernelCorrectionType, class LimiterType, class ParticleScopeType, typename... Parameters>
-template <class ExecutionPolicy, class EncloserType>
-TransportVelocityCorrectionCK<
-    Inner<WithUpdate, KernelCorrectionType, LimiterType, ParticleScopeType, Parameters...>>::
     UpdateKernel::UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
-    : correction_(ex_policy, encloser.kernel_correction_),
-      correction_scaling_(encloser.correction_scaling_),
+    : correction_scaling_(encloser.correction_scaling_),
       h_ratio_(encloser.h_ratio_), limiter_(encloser.limiter_),
       dpos_(encloser.dv_dpos_->DelegatedData(ex_policy)),
       zero_gradient_residue_(encloser.dv_zero_gradient_residue_->DelegatedData(ex_policy)),
@@ -94,39 +49,6 @@ void TransportVelocityCorrectionCK<
         dpos_[index_i] += correction_scaling_ * limiter_(squared_norm) *
                           this->zero_gradient_residue_[index_i] * inv_h_ratio * inv_h_ratio;
     }
-}
-//=================================================================================================//
-template <class KernelCorrectionType, typename... Parameters>
-TransportVelocityCorrectionCK<Contact<Wall, KernelCorrectionType, Parameters...>>::
-    TransportVelocityCorrectionCK(Contact<Parameters...> &contact_relation)
-    : BaseInteraction(contact_relation), Interaction<Wall>(contact_relation),
-      kernel_correction_(this->particles_){}
-//=================================================================================================//
-template <class KernelCorrectionType, typename... Parameters>
-template <class ExecutionPolicy, class EncloserType>
-TransportVelocityCorrectionCK<Contact<Wall, KernelCorrectionType, Parameters...>>::InteractKernel::
-    InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt contact_index)
-    : BaseInteraction::InteractKernel(ex_policy, encloser, contact_index),
-      correction_(ex_policy, encloser.kernel_correction_),
-      zero_gradient_residue_(encloser.dv_zero_gradient_residue_->DelegatedData(ex_policy)),
-      contact_contact_Vol_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)) {}
-//=================================================================================================//
-template <class KernelCorrectionType, typename... Parameters>
-void TransportVelocityCorrectionCK<Contact<Wall, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
-{
-    Vecd inconsistency = Vecd::Zero();
-    for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
-    {
-        UnsignedInt index_j = this->neighbor_index_[n];
-        const Real dW_ijV_j = this->dW_ij(index_i, index_j) * contact_contact_Vol_[index_j];
-        const Vecd e_ij = this->e_ij(index_i, index_j);
-
-        // acceleration for transport velocity
-        inconsistency -= 2.0 * this->correction_(index_i) *
-                         dW_ijV_j * e_ij;
-    }
-    this->zero_gradient_residue_[index_i] += inconsistency;
 }
 } // end namespace fluid_dynamics
 } // end namespace SPH

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.hpp
@@ -33,7 +33,7 @@ TransportVelocityCorrectionCK<
     : correction_scaling_(encloser.correction_scaling_),
       h_ratio_(encloser.h_ratio_), limiter_(encloser.limiter_),
       dpos_(encloser.dv_dpos_->DelegatedData(ex_policy)),
-      zero_gradient_residue_(encloser.dv_zero_gradient_residue_->DelegatedData(ex_policy)),
+      zero_gradient_residual_(encloser.dv_zero_gradient_residual_->DelegatedData(ex_policy)),
       within_scope_(ex_policy, encloser.within_scope_method_, *this) {}
 //=================================================================================================//
 template <class KernelCorrectionType, class LimiterType, class ParticleScopeType, typename... Parameters>
@@ -44,10 +44,10 @@ void TransportVelocityCorrectionCK<
     if (this->within_scope_(index_i))
     {
         Real inv_h_ratio = 1.0 / h_ratio_(index_i);
-        Vecd residue = this->zero_gradient_residue_[index_i];
-        Real squared_norm = residue.squaredNorm();
+        Vecd residual = this->zero_gradient_residual_[index_i];
+        Real squared_norm = residual.squaredNorm();
         dpos_[index_i] += correction_scaling_ * limiter_(squared_norm) *
-                          this->zero_gradient_residue_[index_i] * inv_h_ratio * inv_h_ratio;
+                          this->zero_gradient_residual_[index_i] * inv_h_ratio * inv_h_ratio;
     }
 }
 } // end namespace fluid_dynamics

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/zero_gradient_residual.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/zero_gradient_residual.h
@@ -42,7 +42,7 @@ class ZeroGradientResidualBase : public BaseInteractionType
     virtual ~ZeroGradientResidualBase() {}
 
   protected:
-    DiscreteVariable<Vecd> *dv_zero_gradient_residue_; ///< "ZeroGradientResidue"
+    DiscreteVariable<Vecd> *dv_zero_gradient_residual_; ///< "ZeroGradientResidual"
 };
 
 template <typename...>
@@ -68,7 +68,7 @@ class ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>
 
       protected:
         CorrectionKernel correction_;
-        Vecd *zero_gradient_residue_;
+        Vecd *zero_gradient_residual_;
         Real *Vol_;
     };
 
@@ -96,7 +96,7 @@ class ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...
 
       protected:
         CorrectionKernel correction_;
-        Vecd *zero_gradient_residue_;
+        Vecd *zero_gradient_residual_;
         Real *contact_Vol_;
     };
 

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/zero_gradient_residual.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/zero_gradient_residual.h
@@ -1,0 +1,107 @@
+/* ------------------------------------------------------------------------- *
+ *                                SPHinXsys                                  *
+ * ------------------------------------------------------------------------- *
+ * SPHinXsys (pronunciation: s'finksis) is an acronym from Smoothed Particle *
+ * Hydrodynamics for industrial compleX systems. It provides C++ APIs for    *
+ * physical accurate simulation and aims to model coupled industrial dynamic *
+ * systems including fluid, solid, multi-body dynamics and beyond with SPH   *
+ * (smoothed particle hydrodynamics), a meshless computational method using  *
+ * particle discretization.                                                  *
+ *                                                                           *
+ * SPHinXsys is partially funded by German Research Foundation               *
+ * (Deutsche Forschungsgemeinschaft) DFG HU1527/6-1, HU1527/10-1,            *
+ *  HU1527/12-1 and HU1527/12-4.                                             *
+ *                                                                           *
+ * Portions copyright (c) 2017-2025 Technical University of Munich and       *
+ * the authors' affiliations.                                                *
+ *                                                                           *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may   *
+ * not use this file except in compliance with the License. You may obtain a *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.        *
+ *                                                                           *
+ * ------------------------------------------------------------------------- */
+/**
+ * @file zero_gradient_residual.h
+ * @brief The error residual for computing the gradient of unit.
+ * @author	Xiangyu Hu
+ */
+
+#ifndef ZERO_GRADIENT_RESIDUAL_H
+#define ZERO_GRADIENT_RESIDUAL_H
+
+#include "base_general_dynamics.h"
+
+namespace SPH
+{
+template <class BaseInteractionType>
+class ZeroGradientResidualBase : public BaseInteractionType
+{
+  public:
+    template <class DynamicsIdentifier>
+    explicit ZeroGradientResidualBase(DynamicsIdentifier &identifier);
+    virtual ~ZeroGradientResidualBase() {}
+
+  protected:
+    DiscreteVariable<Vecd> *dv_zero_gradient_residue_; ///< "ZeroGradientResidue"
+};
+
+template <typename...>
+class ZeroGradientResidual;
+
+template <class KernelCorrectionType, typename... Parameters>
+class ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>
+    : public ZeroGradientResidualBase<Interaction<Inner<Parameters...>>>
+{
+    using BaseInteraction = ZeroGradientResidualBase<Interaction<Inner<Parameters...>>>;
+    using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
+
+  public:
+    explicit ZeroGradientResidual(Inner<Parameters...> &inner_relation);
+    virtual ~ZeroGradientResidual() {}
+
+    class InteractKernel : public BaseInteraction::InteractKernel
+    {
+      public:
+        template <class ExecutionPolicy, class EncloserType>
+        InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
+        void interact(size_t index_i, Real dt = 0.0);
+
+      protected:
+        CorrectionKernel correction_;
+        Vecd *zero_gradient_residue_;
+        Real *Vol_;
+    };
+
+  protected:
+    KernelCorrectionType kernel_correction_;
+};
+
+template <class KernelCorrectionType, typename... Parameters>
+class ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...>>
+    : public ZeroGradientResidualBase<Interaction<Contact<Parameters...>>>
+{
+    using BaseInteraction = ZeroGradientResidualBase<Interaction<Contact<Parameters...>>>;
+    using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
+
+  public:
+    explicit ZeroGradientResidual(Contact<Parameters...> &contact_relation);
+    virtual ~ZeroGradientResidual() {}
+
+    class InteractKernel : public BaseInteraction::InteractKernel
+    {
+      public:
+        template <class ExecutionPolicy, class EncloserType>
+        InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt contact_index);
+        void interact(size_t index_i, Real dt = 0.0);
+
+      protected:
+        CorrectionKernel correction_;
+        Vecd *zero_gradient_residue_;
+        Real *contact_Vol_;
+    };
+
+  protected:
+    KernelCorrectionType kernel_correction_;
+};
+} // namespace SPH
+#endif // ZERO_GRADIENT_RESIDUAL_H

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/zero_gradient_residual.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/zero_gradient_residual.hpp
@@ -1,0 +1,85 @@
+#ifndef ZERO_GRADIENT_RESIDUAL_HPP
+#define ZERO_GRADIENT_RESIDUAL_HPP
+
+#include "zero_gradient_residual.h"
+
+namespace SPH
+{
+//=================================================================================================//
+template <class BaseInteractionType>
+template <class DynamicsIdentifier>
+ZeroGradientResidualBase<BaseInteractionType>::ZeroGradientResidualBase(DynamicsIdentifier &identifier)
+    : BaseInteractionType(identifier),
+      dv_zero_gradient_residue_(
+          this->particles_->template registerStateVariable<Vecd>("ZeroGradientResidue")) {}
+//=================================================================================================//
+template <class KernelCorrectionType, typename... Parameters>
+ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>::ZeroGradientResidual(
+    Inner<Parameters...> &inner_relation)
+    : ZeroGradientResidualBase<Interaction<Inner<Parameters...>>>(inner_relation),
+      kernel_correction_(this->particles_)
+{
+    static_assert(std::is_base_of<KernelCorrection, KernelCorrectionType>::value,
+                  "KernelCorrectionType must derive from KernelCorrection!");
+}
+//=================================================================================================//
+template <class KernelCorrectionType, typename... Parameters>
+template <class ExecutionPolicy, class EncloserType>
+ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>::InteractKernel::
+    InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
+    : BaseInteraction::InteractKernel(ex_policy, encloser),
+      correction_(ex_policy, encloser.kernel_correction_),
+      zero_gradient_residue_(encloser.dv_zero_gradient_residue_->DelegatedData(ex_policy)),
+      Vol_(encloser.dv_Vol_->DelegatedData(ex_policy)) {}
+//=================================================================================================//
+template <class KernelCorrectionType, typename... Parameters>
+void ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>::
+    InteractKernel::interact(size_t index_i, Real dt)
+{
+    Vecd inconsistency = Vecd::Zero();
+    for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
+    {
+        UnsignedInt index_j = this->neighbor_index_[n];
+        const Real dW_ijV_j = this->dW_ij(index_i, index_j) * Vol_[index_j];
+        const Vecd e_ij = this->e_ij(index_i, index_j);
+        inconsistency -= (correction_(index_i) + correction_(index_j)) * dW_ijV_j * e_ij;
+    }
+    zero_gradient_residue_[index_i] = inconsistency;
+}
+//=================================================================================================//
+template <class KernelCorrectionType, typename... Parameters>
+ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...>>::
+    ZeroGradientResidual(Contact<Parameters...> &contact_relation)
+    : ZeroGradientResidualBase<Interaction<Contact<Parameters...>>>(contact_relation),
+      kernel_correction_(this->particles_)
+{
+    static_assert(std::is_base_of<KernelCorrection, KernelCorrectionType>::value,
+                  "KernelCorrectionType must derive from KernelCorrection!");
+}
+//=================================================================================================//
+template <class KernelCorrectionType, typename... Parameters>
+template <class ExecutionPolicy, class EncloserType>
+ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...>>::InteractKernel::
+    InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt contact_index)
+    : BaseInteraction::InteractKernel(ex_policy, encloser, contact_index),
+      correction_(ex_policy, encloser.kernel_correction_),
+      zero_gradient_residue_(encloser.dv_zero_gradient_residue_->DelegatedData(ex_policy)),
+      contact_Vol_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)) {}
+//=================================================================================================//
+template <class KernelCorrectionType, typename... Parameters>
+void ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...>>::
+    InteractKernel::interact(size_t index_i, Real dt)
+{
+    Vecd inconsistency = Vecd::Zero();
+    for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
+    {
+        UnsignedInt index_j = this->neighbor_index_[n];
+        const Real dW_ijV_j = this->dW_ij(index_i, index_j) * contact_Vol_[index_j];
+        const Vecd e_ij = this->e_ij(index_i, index_j);
+        inconsistency -= 2.0 * correction_(index_i) * dW_ijV_j * e_ij;
+    }
+    zero_gradient_residue_[index_i] += inconsistency;
+}
+//=================================================================================================//
+} // namespace SPH
+#endif // ZERO_GRADIENT_RESIDUAL_HPP

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/zero_gradient_residual.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/zero_gradient_residual.hpp
@@ -10,8 +10,8 @@ template <class BaseInteractionType>
 template <class DynamicsIdentifier>
 ZeroGradientResidualBase<BaseInteractionType>::ZeroGradientResidualBase(DynamicsIdentifier &identifier)
     : BaseInteractionType(identifier),
-      dv_zero_gradient_residue_(
-          this->particles_->template registerStateVariable<Vecd>("ZeroGradientResidue")) {}
+      dv_zero_gradient_residual_(
+          this->particles_->template registerStateVariable<Vecd>("ZeroGradientResidual")) {}
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
 ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>::ZeroGradientResidual(
@@ -29,7 +29,7 @@ ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>::InteractKernel
     InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
     : BaseInteraction::InteractKernel(ex_policy, encloser),
       correction_(ex_policy, encloser.kernel_correction_),
-      zero_gradient_residue_(encloser.dv_zero_gradient_residue_->DelegatedData(ex_policy)),
+      zero_gradient_residual_(encloser.dv_zero_gradient_residual_->DelegatedData(ex_policy)),
       Vol_(encloser.dv_Vol_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
@@ -44,7 +44,7 @@ void ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>::
         const Vecd e_ij = this->e_ij(index_i, index_j);
         inconsistency -= (correction_(index_i) + correction_(index_j)) * dW_ijV_j * e_ij;
     }
-    zero_gradient_residue_[index_i] = inconsistency;
+    zero_gradient_residual_[index_i] = inconsistency;
 }
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
@@ -63,7 +63,7 @@ ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...>>::In
     InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt contact_index)
     : BaseInteraction::InteractKernel(ex_policy, encloser, contact_index),
       correction_(ex_policy, encloser.kernel_correction_),
-      zero_gradient_residue_(encloser.dv_zero_gradient_residue_->DelegatedData(ex_policy)),
+      zero_gradient_residual_(encloser.dv_zero_gradient_residual_->DelegatedData(ex_policy)),
       contact_Vol_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
@@ -78,7 +78,7 @@ void ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...>
         const Vecd e_ij = this->e_ij(index_i, index_j);
         inconsistency -= 2.0 * correction_(index_i) * dW_ijV_j * e_ij;
     }
-    zero_gradient_residue_[index_i] += inconsistency;
+    zero_gradient_residual_[index_i] += inconsistency;
 }
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/all_relax_dynamics_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/all_relax_dynamics_ck.h
@@ -31,7 +31,7 @@
 #define ALL_RELAX_DYNAMICS_CK_H
 
 #include "level_set_correction.hpp"
-#include "relaxation_residue_ck.hpp"
+#include "relaxation_residual_ck.hpp"
 #include "relaxation_stepping_ck.h"
 
 #endif // ALL_RELAX_DYNAMICS_CK_H

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/level_set_correction.cpp
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/level_set_correction.cpp
@@ -12,7 +12,7 @@ LevelsetBounding::LevelsetBounding(NearShapeSurface &body_part)
 LevelsetKernelGradientIntegral::LevelsetKernelGradientIntegral(SPHBody &sph_body, LevelSetShape &level_set_shape)
     : LocalDynamics(sph_body),
       dv_pos_(particles_->getVariableByName<Vecd>("Position")),
-      dv_residue_(particles_->registerStateVariable<Vecd>("ZeroGradientResidue")),
+      dv_residual_(particles_->registerStateVariable<Vecd>("ZeroGradientResidual")),
       level_set_(level_set_shape.getLevelSet()) {}
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/level_set_correction.h
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/level_set_correction.h
@@ -84,17 +84,17 @@ class LevelsetKernelGradientIntegral : public LocalDynamics
 
         void update(size_t index_i, Real dt = 0.0)
         {
-            residue_[index_i] -= 2.0 * kernel_gradient_integral_(pos_[index_i]);
+            residual_[index_i] -= 2.0 * kernel_gradient_integral_(pos_[index_i]);
         };
 
       protected:
-        Vecd *pos_, *residue_;
+        Vecd *pos_, *residual_;
         ProbeKernelGradientIntegral kernel_gradient_integral_;
     };
 
   protected:
     DiscreteVariable<Vecd> *dv_pos_;
-    DiscreteVariable<Vecd> *dv_residue_;
+    DiscreteVariable<Vecd> *dv_residual_;
     MultilevelLevelSet &level_set_;
 };
 

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/level_set_correction.hpp
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/level_set_correction.hpp
@@ -20,7 +20,7 @@ template <class ExecutionPolicy, class EncloserType>
 LevelsetKernelGradientIntegral::UpdateKernel::
     UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
     : pos_(encloser.dv_pos_->DelegatedData(ex_policy)),
-      residue_(encloser.dv_residue_->DelegatedData(ex_policy)),
+      residual_(encloser.dv_residual_->DelegatedData(ex_policy)),
       kernel_gradient_integral_(encloser.level_set_.getProbeKernelGradientIntegral(ex_policy)) {}
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_residual_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_residual_ck.h
@@ -21,7 +21,7 @@
  *                                                                           *
  * ------------------------------------------------------------------------- */
 /**
- * @file relaxation_residue_ck.h
+ * @file relaxation_residual_ck.h
  * @brief TBD.
  * @author Xiangyu Hu
  */
@@ -34,31 +34,31 @@
 namespace SPH
 {
 template <class BaseInteractionType>
-class RelaxationResidueBase : public BaseInteractionType
+class RelaxationResidualBase : public BaseInteractionType
 {
   public:
     template <class DynamicsIdentifier>
-    explicit RelaxationResidueBase(DynamicsIdentifier &identifier);
-    virtual ~RelaxationResidueBase() {}
+    explicit RelaxationResidualBase(DynamicsIdentifier &identifier);
+    virtual ~RelaxationResidualBase() {}
 
   protected:
     DiscreteVariable<Vecd> *dv_pos_;
-    DiscreteVariable<Vecd> *dv_residue_;
+    DiscreteVariable<Vecd> *dv_residual_;
 };
 
 template <typename...>
-class RelaxationResidueCK;
+class RelaxationResidualCK;
 
 template <class KernelCorrectionType, typename... Parameters>
-class RelaxationResidueCK<Inner<KernelCorrectionType, Parameters...>>
-    : public RelaxationResidueBase<Interaction<Inner<Parameters...>>>
+class RelaxationResidualCK<Inner<KernelCorrectionType, Parameters...>>
+    : public RelaxationResidualBase<Interaction<Inner<Parameters...>>>
 {
-    using BaseInteraction = RelaxationResidueBase<Interaction<Inner<Parameters...>>>;
+    using BaseInteraction = RelaxationResidualBase<Interaction<Inner<Parameters...>>>;
     using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
 
   public:
-    explicit RelaxationResidueCK(Inner<Parameters...> &inner_relation);
-    virtual ~RelaxationResidueCK() {}
+    explicit RelaxationResidualCK(Inner<Parameters...> &inner_relation);
+    virtual ~RelaxationResidualCK() {}
 
     class InteractKernel : public BaseInteraction::InteractKernel
     {
@@ -70,7 +70,7 @@ class RelaxationResidueCK<Inner<KernelCorrectionType, Parameters...>>
       protected:
         CorrectionKernel correction_;
         Real *Vol_;
-        Vecd *residue_;
+        Vecd *residual_;
     };
 
   protected:
@@ -78,15 +78,15 @@ class RelaxationResidueCK<Inner<KernelCorrectionType, Parameters...>>
 };
 
 template <class KernelCorrectionType, typename... Parameters>
-class RelaxationResidueCK<Contact<Boundary, KernelCorrectionType, Parameters...>>
-    : public RelaxationResidueBase<Interaction<Contact<Parameters...>>>
+class RelaxationResidualCK<Contact<Boundary, KernelCorrectionType, Parameters...>>
+    : public RelaxationResidualBase<Interaction<Contact<Parameters...>>>
 {
-    using BaseInteraction = RelaxationResidueBase<Interaction<Contact<Parameters...>>>;
+    using BaseInteraction = RelaxationResidualBase<Interaction<Contact<Parameters...>>>;
     using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
 
   public:
-    explicit RelaxationResidueCK(Contact<Parameters...> &contact_relation);
-    virtual ~RelaxationResidueCK() {}
+    explicit RelaxationResidualCK(Contact<Parameters...> &contact_relation);
+    virtual ~RelaxationResidualCK() {}
 
     class InteractKernel : public BaseInteraction::InteractKernel
     {
@@ -99,7 +99,7 @@ class RelaxationResidueCK<Contact<Boundary, KernelCorrectionType, Parameters...>
       protected:
         CorrectionKernel correction_;
         Real *contact_Vol_;
-        Vecd *residue_;
+        Vecd *residual_;
     };
 
   protected:

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_residual_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_residual_ck.hpp
@@ -1,76 +1,76 @@
 #ifndef RELAXATION_RESIDUE_CK_HPP
 #define RELAXATION_RESIDUE_CK_HPP
 
-#include "relaxation_residue_ck.h"
+#include "relaxation_residual_ck.h"
 
 namespace SPH
 {
 //=================================================================================================//
 template <class BaseInteractionType>
 template <class DynamicsIdentifier>
-RelaxationResidueBase<BaseInteractionType>::RelaxationResidueBase(DynamicsIdentifier &identifier)
+RelaxationResidualBase<BaseInteractionType>::RelaxationResidualBase(DynamicsIdentifier &identifier)
     : BaseInteractionType(identifier),
       dv_pos_(this->particles_->template getVariableByName<Vecd>("Position")),
-      dv_residue_(this->particles_->template registerStateVariable<Vecd>("ZeroGradientResidue")) {}
+      dv_residual_(this->particles_->template registerStateVariable<Vecd>("ZeroGradientResidual")) {}
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
-RelaxationResidueCK<Inner<KernelCorrectionType, Parameters...>>::
-    RelaxationResidueCK(Inner<Parameters...> &inner_relation)
+RelaxationResidualCK<Inner<KernelCorrectionType, Parameters...>>::
+    RelaxationResidualCK(Inner<Parameters...> &inner_relation)
     : BaseInteraction(inner_relation), kernel_correction_(this->particles_) {}
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
 template <class ExecutionPolicy, class EncloserType>
-RelaxationResidueCK<Inner<KernelCorrectionType, Parameters...>>::InteractKernel::
+RelaxationResidualCK<Inner<KernelCorrectionType, Parameters...>>::InteractKernel::
     InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
     : BaseInteraction::InteractKernel(ex_policy, encloser),
       correction_(ex_policy, encloser.kernel_correction_),
       Vol_(encloser.dv_Vol_->DelegatedData(ex_policy)),
-      residue_(encloser.dv_residue_->DelegatedData(ex_policy)) {}
+      residual_(encloser.dv_residual_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
-void RelaxationResidueCK<Inner<KernelCorrectionType, Parameters...>>::InteractKernel::
+void RelaxationResidualCK<Inner<KernelCorrectionType, Parameters...>>::InteractKernel::
     interact(size_t index_i, Real dt)
 {
-    Vecd residue = Vecd::Zero();
+    Vecd residual = Vecd::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
     {
         UnsignedInt index_j = this->neighbor_index_[n];
         const Real dW_ijV_j = this->dW_ij(index_i, index_j) * Vol_[index_j];
         const Vecd e_ij = this->e_ij(index_i, index_j);
 
-        residue -= (this->correction_(index_i) + this->correction_(index_j)) * dW_ijV_j * e_ij;
+        residual -= (this->correction_(index_i) + this->correction_(index_j)) * dW_ijV_j * e_ij;
     }
-    residue_[index_i] = residue;
+    residual_[index_i] = residual;
 }
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
-RelaxationResidueCK<Contact<Boundary, KernelCorrectionType, Parameters...>>::
-    RelaxationResidueCK(Contact<Parameters...> &contact_relation)
+RelaxationResidualCK<Contact<Boundary, KernelCorrectionType, Parameters...>>::
+    RelaxationResidualCK(Contact<Parameters...> &contact_relation)
     : BaseInteraction(contact_relation), kernel_correction_(this->particles_){}
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
 template <class ExecutionPolicy, class EncloserType>
-RelaxationResidueCK<Contact<Boundary, KernelCorrectionType, Parameters...>>::InteractKernel::
+RelaxationResidualCK<Contact<Boundary, KernelCorrectionType, Parameters...>>::InteractKernel::
     InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt contact_index)
     : BaseInteraction::InteractKernel(ex_policy, encloser, contact_index),
       correction_(ex_policy, encloser.kernel_correction_),
       contact_Vol_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)),
-      residue_(encloser.dv_residue_->DelegatedData(ex_policy)) {}
+      residual_(encloser.dv_residual_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
-void RelaxationResidueCK<Contact<Boundary, KernelCorrectionType, Parameters...>>::InteractKernel::
+void RelaxationResidualCK<Contact<Boundary, KernelCorrectionType, Parameters...>>::InteractKernel::
     interact(size_t index_i, Real dt)
 {
-    Vecd residue = Vecd::Zero();
+    Vecd residual = Vecd::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
     {
         UnsignedInt index_j = this->neighbor_index_[n];
         const Real dW_ijV_j = this->dW_ij(index_i, index_j) * contact_Vol_[index_j];
         const Vecd e_ij = this->e_ij(index_i, index_j);
 
-        residue -= 2.0 * this->correction_(index_i) * dW_ijV_j * e_ij;
+        residual -= 2.0 * this->correction_(index_i) * dW_ijV_j * e_ij;
     }
-    residue_[index_i] += residue;
+    residual_[index_i] += residual;
 }
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_stepping_ck.cpp
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_stepping_ck.cpp
@@ -5,7 +5,7 @@ namespace SPH
 //=================================================================================================//
 RelaxationScalingCK::RelaxationScalingCK(SPHBody &sph_body)
     : LocalDynamicsReduce<ReduceMax>(sph_body),
-      dv_residue_(particles_->getVariableByName<Vecd>("ZeroGradientResidue")),
+      dv_residual_(particles_->getVariableByName<Vecd>("ZeroGradientResidual")),
       h_ref_(sph_body.getSPHAdaptation().ReferenceSmoothingLength()) {}
 //=================================================================================================//
 RelaxationScalingCK::FinishDynamics::FinishDynamics(RelaxationScalingCK &encloser)
@@ -19,6 +19,6 @@ Real RelaxationScalingCK::FinishDynamics::Result(Real reduced_value)
 PositionRelaxationCK::PositionRelaxationCK(SPHBody &sph_body)
     : LocalDynamics(sph_body),
       pos_(particles_->getVariableByName<Vecd>("Position")),
-      residue_(particles_->getVariableByName<Vecd>("ZeroGradientResidue")) {}
+      residual_(particles_->getVariableByName<Vecd>("ZeroGradientResidual")) {}
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_stepping_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_stepping_ck.h
@@ -54,21 +54,21 @@ class RelaxationScalingCK : public LocalDynamicsReduce<ReduceMax>
       public:
         template <class ExecutionPolicy>
         ReduceKernel(const ExecutionPolicy &ex_policy, RelaxationScalingCK &encloser)
-            : residue_(encloser.dv_residue_->DelegatedData(ex_policy)),
+            : residual_(encloser.dv_residual_->DelegatedData(ex_policy)),
               h_ref_(encloser.h_ref_){};
 
         Real reduce(size_t index_i, Real dt)
         {
-            return residue_[index_i].norm();
+            return residual_[index_i].norm();
         };
 
       protected:
-        Vecd *residue_;
+        Vecd *residual_;
         Real h_ref_;
     };
 
   protected:
-    DiscreteVariable<Vecd> *dv_residue_;
+    DiscreteVariable<Vecd> *dv_residual_;
     Real h_ref_;
 };
 
@@ -84,19 +84,19 @@ class PositionRelaxationCK : public LocalDynamics
         template <class ExecutionPolicy>
         UpdateKernel(const ExecutionPolicy &ex_policy, PositionRelaxationCK &encloser)
             : pos_(encloser.pos_->DelegatedData(ex_policy)),
-              residue_(encloser.residue_->DelegatedData(ex_policy)){};
+              residual_(encloser.residual_->DelegatedData(ex_policy)){};
 
         void update(size_t index_i, Real dt_square)
         {
-            pos_[index_i] += residue_[index_i] * dt_square * 0.5;
+            pos_[index_i] += residual_[index_i] * dt_square * 0.5;
         };
 
       protected:
-        Vecd *pos_, *residue_;
+        Vecd *pos_, *residual_;
     };
 
   protected:
-    DiscreteVariable<Vecd> *pos_, *residue_;
+    DiscreteVariable<Vecd> *pos_, *residual_;
 };
 
 } // namespace SPH

--- a/tests/2d_examples/2d_examples_ck/test_2d_eulerian_flow_around_cylinder_ck/2d_eulerian_flow_around_cylinder.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_eulerian_flow_around_cylinder_ck/2d_eulerian_flow_around_cylinder.cpp
@@ -101,15 +101,15 @@ int main(int ac, char *av[])
         auto &random_cylinder_particles = main_methods.addStateDynamics<RandomizeParticlePositionCK>(cylinder);
         auto &random_water_block_particles = main_methods.addStateDynamics<RandomizeParticlePositionCK>(water_block);
 
-        auto &cylinder_relaxation_residue =
-            main_methods.addInteractionDynamics<RelaxationResidueCK, NoKernelCorrectionCK>(cylinder_inner)
+        auto &cylinder_relaxation_residual =
+            main_methods.addInteractionDynamics<RelaxationResidualCK, NoKernelCorrectionCK>(cylinder_inner)
                 .addPostStateDynamics<LevelsetKernelGradientIntegral>(cylinder, *cylinder_level_set_shape);
         auto &cylinder_relaxation_scaling = main_methods.addReduceDynamics<RelaxationScalingCK>(cylinder);
         auto &cylinder_update_particle_position = main_methods.addStateDynamics<PositionRelaxationCK>(cylinder);
         auto &cylinder_level_set_bounding = main_methods.addStateDynamics<LevelsetBounding>(near_cylinder_surface);
 
-        auto &water_block_relaxation_residue =
-            main_methods.addInteractionDynamics<RelaxationResidueCK, NoKernelCorrectionCK>(water_block_inner)
+        auto &water_block_relaxation_residual =
+            main_methods.addInteractionDynamics<RelaxationResidualCK, NoKernelCorrectionCK>(water_block_inner)
                 .addContactInteraction<Boundary, NoKernelCorrectionCK>(water_block_contact)
                 .addPostStateDynamics<LevelsetKernelGradientIntegral>(water_block, *outer_level_set_shape);
         auto &water_block_relaxation_scaling = main_methods.addReduceDynamics<RelaxationScalingCK>(water_block);
@@ -148,14 +148,14 @@ int main(int ac, char *av[])
             cylinder_cell_linked_list.exec();
             cylinder_update_inner_relation.exec();
 
-            cylinder_relaxation_residue.exec();
+            cylinder_relaxation_residual.exec();
             Real cylinder_relaxation_step = cylinder_relaxation_scaling.exec();
             cylinder_update_particle_position.exec(cylinder_relaxation_step);
             cylinder_level_set_bounding.exec();
 
             water_block_cell_linked_list.exec();
             water_block_update_complex_relation.exec();
-            water_block_relaxation_residue.exec();
+            water_block_relaxation_residual.exec();
             Real water_block_relaxation_step = water_block_relaxation_scaling.exec();
             water_block_update_particle_position.exec(water_block_relaxation_step);
             water_block_level_set_bounding.exec();

--- a/tests/2d_examples/2d_examples_ck/test_2d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
@@ -307,7 +307,7 @@ int main(int ac, char *av[])
         fluid_density_regularization(water_body_inner, water_wall_contact);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::FreeSurfaceIndicationComplexSpatialTemporalCK>
         fluid_boundary_indicator(water_body_inner, water_wall_contact);
-    InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityCorrectionWallNoCorrectionBulkParticlesCK>
+    InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityCorrectionComplexBulkParticlesCK>
         transport_correction_ck(water_body_inner, water_wall_contact);
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AdvectionTimeStepCK> fluid_advection_time_step(water_body, U_f);
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK<>> fluid_acoustic_time_step(water_body);

--- a/tests/2d_examples/2d_examples_ck/test_2d_particle_generator_single_resolution_ck/particle_generator_single_resolution.cpp
+++ b/tests/2d_examples/2d_examples_ck/test_2d_particle_generator_single_resolution_ck/particle_generator_single_resolution.cpp
@@ -92,15 +92,15 @@ int main(int ac, char *av[])
     auto &random_input_body_particles = host_methods.addStateDynamics<RandomizeParticlePositionCK>(input_body);
     auto &random_filler_particles = host_methods.addStateDynamics<RandomizeParticlePositionCK>(filler);
 
-    auto &relaxation_residue =
-        main_methods.addInteractionDynamics<RelaxationResidueCK, NoKernelCorrectionCK>(input_body_inner)
+    auto &relaxation_residual =
+        main_methods.addInteractionDynamics<RelaxationResidualCK, NoKernelCorrectionCK>(input_body_inner)
             .addPostStateDynamics<LevelsetKernelGradientIntegral>(input_body, *level_set_shape);
     auto &relaxation_scaling = main_methods.addReduceDynamics<RelaxationScalingCK>(input_body);
     auto &update_particle_position = main_methods.addStateDynamics<PositionRelaxationCK>(input_body);
     auto &level_set_bounding = main_methods.addStateDynamics<LevelsetBounding>(near_body_surface);
 
-    auto &filler_relaxation_residue =
-        main_methods.addInteractionDynamics<RelaxationResidueCK, NoKernelCorrectionCK>(filler_inner)
+    auto &filler_relaxation_residual =
+        main_methods.addInteractionDynamics<RelaxationResidualCK, NoKernelCorrectionCK>(filler_inner)
             .addContactInteraction<Boundary, NoKernelCorrectionCK>(filler_contact);
     auto &filler_relaxation_scaling = main_methods.addReduceDynamics<RelaxationScalingCK>(filler);
     auto &filler_update_particle_position = main_methods.addStateDynamics<PositionRelaxationCK>(filler);
@@ -130,12 +130,12 @@ int main(int ac, char *av[])
         input_body_update_inner_relation.exec();
         filler_update_complex_relation.exec();
 
-        relaxation_residue.exec();
+        relaxation_residual.exec();
         Real relaxation_step = relaxation_scaling.exec();
         update_particle_position.exec(relaxation_step);
         level_set_bounding.exec();
 
-        filler_relaxation_residue.exec();
+        filler_relaxation_residual.exec();
         Real filler_relaxation_step = filler_relaxation_scaling.exec();
         filler_update_particle_position.exec(filler_relaxation_step);
 

--- a/tests/2d_examples/test_2d_cohesive_soil_failure/cohesive_soil_failure.h
+++ b/tests/2d_examples/test_2d_cohesive_soil_failure/cohesive_soil_failure.h
@@ -120,7 +120,7 @@ class TransportVelocityCorrection<Inner<ResolutionType, LimiterType>, CommonCont
                 inconsistency -= (this->kernel_correction_(index_i) + this->kernel_correction_(index_j)) *
                                  inner_neighborhood.dW_ij_[n] * this->Vol_[index_j] * inner_neighborhood.e_ij_[n];
             }
-            this->zero_gradient_residue_[index_i] = inconsistency;
+            this->zero_gradient_residual_[index_i] = inconsistency;
         }
     };
     void update(size_t index_i, Real dt = 0.0)
@@ -128,9 +128,9 @@ class TransportVelocityCorrection<Inner<ResolutionType, LimiterType>, CommonCont
         if (this->within_scope_(index_i))
         {
             Real inv_h_ratio = 1.0 / h_ratio_(index_i);
-            Real squared_norm = this->zero_gradient_residue_[index_i].squaredNorm();
+            Real squared_norm = this->zero_gradient_residual_[index_i].squaredNorm();
             Vecd pos_transport = correction_scaling_ * limiter_(squared_norm) *
-                                 this->zero_gradient_residue_[index_i] * inv_h_ratio * inv_h_ratio;
+                                 this->zero_gradient_residual_[index_i] * inv_h_ratio * inv_h_ratio;
             if (this->indicator_[index_i])
             {
                 pos_transport = pos_transport - pos_transport.dot(this->surface_normal_[index_i]) * this->surface_normal_[index_i];
@@ -185,7 +185,7 @@ class TransportVelocityCorrection<Contact<Boundary>, CommonControlTypes...>
                                      wall_Vol_k[index_j] * contact_neighborhood.e_ij_[n];
                 }
             }
-            this->zero_gradient_residue_[index_i] += inconsistency;
+            this->zero_gradient_residual_[index_i] += inconsistency;
         }
     };
 

--- a/tests/3d_examples/3d_examples_ck/test_3d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
+++ b/tests/3d_examples/3d_examples_ck/test_3d_mixed_poiseuille_flow_ck/mixed_poiseuille_flow.cpp
@@ -287,7 +287,7 @@ int main(int ac, char *av[])
         fluid_density_regularization(water_body_inner, water_wall_contact);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::FreeSurfaceIndicationComplexSpatialTemporalCK>
         fluid_boundary_indicator(water_body_inner, water_wall_contact);
-    InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityCorrectionWallNoCorrectionBulkParticlesCK>
+    InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityCorrectionComplexBulkParticlesCK>
         transport_correction_ck(water_body_inner, water_wall_contact);
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AdvectionTimeStepCK> fluid_advection_time_step(water_body, U_f);
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK<>> fluid_acoustic_time_step(water_body);

--- a/tests/3d_examples/3d_examples_ck/test_3d_particle_relaxation_single_resolution_ck/particle_relaxation_single_resolution_3D.cpp
+++ b/tests/3d_examples/3d_examples_ck/test_3d_particle_relaxation_single_resolution_ck/particle_relaxation_single_resolution_3D.cpp
@@ -148,8 +148,8 @@ int main(int ac, char *av[])
         auto &input_body_cell_linked_list = main_methods.addCellLinkedListDynamics(input_body);
         auto &input_body_update_inner_relation = main_methods.addRelationDynamics(input_body_inner);
         auto &random_input_body_particles = host_methods.addStateDynamics<RandomizeParticlePositionCK>(input_body);
-        auto &relaxation_residue =
-            main_methods.addInteractionDynamics<RelaxationResidueCK, NoKernelCorrectionCK>(input_body_inner)
+        auto &relaxation_residual =
+            main_methods.addInteractionDynamics<RelaxationResidualCK, NoKernelCorrectionCK>(input_body_inner)
                 .addPostStateDynamics<LevelsetKernelGradientIntegral>(input_body, *level_set_shape);
         auto &relaxation_scaling = main_methods.addReduceDynamics<RelaxationScalingCK>(input_body);
         auto &update_particle_position =
@@ -178,7 +178,7 @@ int main(int ac, char *av[])
             input_body_cell_linked_list.exec();
             input_body_update_inner_relation.exec();
 
-            relaxation_residue.exec();
+            relaxation_residual.exec();
             Real relaxation_step = relaxation_scaling.exec();
             update_particle_position.exec(relaxation_step);
             level_set_bounding.exec();

--- a/tests/3d_examples/test_3d_FVM_incompressible_channel_flow/data/ChannelFluent.msh
+++ b/tests/3d_examples/test_3d_FVM_incompressible_channel_flow/data/ChannelFluent.msh
@@ -19886,7 +19886,7 @@ a8 3 23 22 21 3 20 1f 1e 3 1d 1c 1b 3 1a 19 18 3 17 16 15 3 14 13 1b 3 12 11 10 
 (gocart/boundary/split-warp-threshold 0.1)
 (gocart/morph/method lyon)
 (gocart/morph/solver bcgstab)
-(gocart/morph/solver-residue 1e-08)
+(gocart/morph/solver-residual 1e-08)
 (gocart/morph/surfaces? #t)
 (gocart/morph/surface/steps 2)
 (gocart/morph/reduce-support? #t)

--- a/tests/tests_sycl/2d_examples/test_2d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -307,7 +307,7 @@ int main(int ac, char *av[])
         fluid_density_regularization(water_body_inner, water_wall_contact);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::FreeSurfaceIndicationComplexSpatialTemporalCK>
         fluid_boundary_indicator(water_body_inner, water_wall_contact);
-    InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityCorrectionWallNoCorrectionBulkParticlesCK>
+    InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityCorrectionComplexBulkParticlesCK>
         transport_correction_ck(water_body_inner, water_wall_contact);
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AdvectionTimeStepCK> fluid_advection_time_step(water_body, U_f);
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK<>> fluid_acoustic_time_step(water_body);

--- a/tests/tests_sycl/2d_examples/test_2d_particle_generator_single_resolution_sycl/particle_generator_single_resolution.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_particle_generator_single_resolution_sycl/particle_generator_single_resolution.cpp
@@ -77,8 +77,8 @@ int main(int ac, char *av[])
     auto &input_body_cell_linked_list = main_methods.addCellLinkedListDynamics(input_body);
     auto &input_body_update_inner_relation = main_methods.addRelationDynamics(input_body_inner);
     auto &random_input_body_particles = host_methods.addStateDynamics<RandomizeParticlePositionCK>(input_body);
-    auto &relaxation_residue =
-        main_methods.addInteractionDynamics<RelaxationResidueCK, NoKernelCorrectionCK>(input_body_inner)
+    auto &relaxation_residual =
+        main_methods.addInteractionDynamics<RelaxationResidualCK, NoKernelCorrectionCK>(input_body_inner)
             .addPostStateDynamics<LevelsetKernelGradientIntegral>(input_body, *level_set_shape);
     auto &relaxation_scaling = main_methods.addReduceDynamics<RelaxationScalingCK>(input_body);
     auto &update_particle_position =
@@ -107,7 +107,7 @@ int main(int ac, char *av[])
         input_body_cell_linked_list.exec();
         input_body_update_inner_relation.exec();
 
-        relaxation_residue.exec();
+        relaxation_residual.exec();
         Real relaxation_step = relaxation_scaling.exec();
         update_particle_position.exec(relaxation_step);
         level_set_bounding.exec();

--- a/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -287,7 +287,7 @@ int main(int ac, char *av[])
         fluid_density_regularization(water_body_inner, water_wall_contact);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::FreeSurfaceIndicationComplexSpatialTemporalCK>
         fluid_boundary_indicator(water_body_inner, water_wall_contact);
-    InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityCorrectionWallNoCorrectionBulkParticlesCK>
+    InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::TransportVelocityCorrectionComplexBulkParticlesCK>
         transport_correction_ck(water_body_inner, water_wall_contact);
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AdvectionTimeStepCK> fluid_advection_time_step(water_body, U_f);
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK<>> fluid_acoustic_time_step(water_body);

--- a/tests/tests_sycl/3d_examples/test_3d_particle_relaxation_single_resolution_sycl/particle_relaxation_single_resolution_3D.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_particle_relaxation_single_resolution_sycl/particle_relaxation_single_resolution_3D.cpp
@@ -132,8 +132,8 @@ int main(int ac, char *av[])
     auto &input_body_cell_linked_list = main_methods.addCellLinkedListDynamics(input_body);
     auto &input_body_update_inner_relation = main_methods.addRelationDynamics(input_body_inner);
     auto &random_input_body_particles = host_methods.addStateDynamics<RandomizeParticlePositionCK>(input_body);
-    auto &relaxation_residue =
-        main_methods.addInteractionDynamics<RelaxationResidueCK, NoKernelCorrectionCK>(input_body_inner)
+    auto &relaxation_residual =
+        main_methods.addInteractionDynamics<RelaxationResidualCK, NoKernelCorrectionCK>(input_body_inner)
             .addPostStateDynamics<LevelsetKernelGradientIntegral>(input_body, *level_set_shape);
     auto &relaxation_scaling = main_methods.addReduceDynamics<RelaxationScalingCK>(input_body);
     auto &update_particle_position =
@@ -162,7 +162,7 @@ int main(int ac, char *av[])
         input_body_cell_linked_list.exec();
         input_body_update_inner_relation.exec();
 
-        relaxation_residue.exec();
+        relaxation_residual.exec();
         Real relaxation_step = relaxation_scaling.exec();
         update_particle_position.exec(relaxation_step);
         level_set_bounding.exec();

--- a/tests/tests_sycl/3d_examples/test_3d_taylor_bar_sycl/taylor_bar_sycl.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_taylor_bar_sycl/taylor_bar_sycl.cpp
@@ -46,8 +46,8 @@ int main(int ac, char *av[])
         auto &input_body_cell_linked_list = main_methods.addCellLinkedListDynamics(column);
         auto &input_body_update_inner_relation = main_methods.addRelationDynamics(column_inner);
         auto &random_input_body_particles = host_methods.addStateDynamics<RandomizeParticlePositionCK>(column);
-        auto &relaxation_residue =
-            main_methods.addInteractionDynamics<RelaxationResidueCK, NoKernelCorrectionCK>(column_inner)
+        auto &relaxation_residual =
+            main_methods.addInteractionDynamics<RelaxationResidualCK, NoKernelCorrectionCK>(column_inner)
                 .addPostStateDynamics<LevelsetKernelGradientIntegral>(column, *level_set_shape);
         auto &relaxation_scaling = main_methods.addReduceDynamics<RelaxationScalingCK>(column);
         auto &update_particle_position = main_methods.addStateDynamics<PositionRelaxationCK>(column);
@@ -81,7 +81,7 @@ int main(int ac, char *av[])
             input_body_cell_linked_list.exec();
             input_body_update_inner_relation.exec();
 
-            relaxation_residue.exec();
+            relaxation_residual.exec();
             Real relaxation_step = relaxation_scaling.exec();
             update_particle_position.exec(relaxation_step);
             level_set_bounding.exec();


### PR DESCRIPTION
This pull request performs a comprehensive renaming and refactoring of classes and variables related to "residue" to use the term "residual" instead, across the relaxation and transport velocity correction modules. The changes improve naming consistency and clarity throughout the codebase, affecting both class names and member variables. No logic or algorithmic changes are introduced; the modifications are purely related to naming.

**Major renaming for clarity and consistency:**

* All classes previously named `RelaxationResidue` are renamed to `RelaxationResidual`, including all specializations and related template usages. [[1]](diffhunk://#diff-ad51df8e227d1a456e204227c7213e72cd532e340eb8ffaa4a3f56606e4e0078L64-R89) [[2]](diffhunk://#diff-ad51df8e227d1a456e204227c7213e72cd532e340eb8ffaa4a3f56606e4e0078L98-R106) [[3]](diffhunk://#diff-ad51df8e227d1a456e204227c7213e72cd532e340eb8ffaa4a3f56606e4e0078L115-R123) [[4]](diffhunk://#diff-ad51df8e227d1a456e204227c7213e72cd532e340eb8ffaa4a3f56606e4e0078L132-R140) [[5]](diffhunk://#diff-ad51df8e227d1a456e204227c7213e72cd532e340eb8ffaa4a3f56606e4e0078L150-R162) [[6]](diffhunk://#diff-e106181aa516c5ed47008a7042bf13129927e0ad2469ef8c15b923d36e79c291L66-R66) [[7]](diffhunk://#diff-b08d573af2d64212405a3fd190763be26a466a9567616559d6613a58ee0ddc53L8-R44)
* All member variables and function parameters previously named `residue` or `residue_` are renamed to `residual` or `residual_` in all relevant classes and functions. [[1]](diffhunk://#diff-ad51df8e227d1a456e204227c7213e72cd532e340eb8ffaa4a3f56606e4e0078L64-R89) [[2]](diffhunk://#diff-ad51df8e227d1a456e204227c7213e72cd532e340eb8ffaa4a3f56606e4e0078L182-R182) [[3]](diffhunk://#diff-ad51df8e227d1a456e204227c7213e72cd532e340eb8ffaa4a3f56606e4e0078L194-R194) [[4]](diffhunk://#diff-b08d573af2d64212405a3fd190763be26a466a9567616559d6613a58ee0ddc53L8-R44) [[5]](diffhunk://#diff-b08d573af2d64212405a3fd190763be26a466a9567616559d6613a58ee0ddc53L109-R132) [[6]](diffhunk://#diff-b08d573af2d64212405a3fd190763be26a466a9567616559d6613a58ee0ddc53L144-R148)

**Consistent naming in transport velocity correction:**

* The variable `zero_gradient_residue_` is renamed to `zero_gradient_residual_` throughout the `TransportVelocityCorrection` class and its related methods. [[1]](diffhunk://#diff-8bca669958f8298a3a6ecd384be899157a9554b525eb859450e5d0455c8d35f8L58-R58) [[2]](diffhunk://#diff-4b248069d5792a9071cb8d85bc9f866b62e632e09670f52fc239e2922e53e5dfL15-R15) [[3]](diffhunk://#diff-4b248069d5792a9071cb8d85bc9f866b62e632e09670f52fc239e2922e53e5dfL51-R51) [[4]](diffhunk://#diff-4b248069d5792a9071cb8d85bc9f866b62e632e09670f52fc239e2922e53e5dfL62-R64) [[5]](diffhunk://#diff-4b248069d5792a9071cb8d85bc9f866b62e632e09670f52fc239e2922e53e5dfL98-R98) [[6]](diffhunk://#diff-4b248069d5792a9071cb8d85bc9f866b62e632e09670f52fc239e2922e53e5dfL135-R135)

**Template and type updates:**

* All template and type references are updated to use `RelaxationResidual` instead of `RelaxationResidue`. [[1]](diffhunk://#diff-ad51df8e227d1a456e204227c7213e72cd532e340eb8ffaa4a3f56606e4e0078L218-R218) [[2]](diffhunk://#diff-e106181aa516c5ed47008a7042bf13129927e0ad2469ef8c15b923d36e79c291L66-R66)

These changes are purely for code clarity and maintainability, with no impact on runtime behavior.