### PR TITLE
Xiangyu/use kernel grodient integral

### DIFF
--- a/src/shared/particle_dynamics/fluid_dynamics/transport_velocity_correction.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/transport_velocity_correction.h
@@ -55,7 +55,7 @@ class TransportVelocityCorrection<Base, DataDelegationType, KernelCorrectionType
     virtual ~TransportVelocityCorrection() {};
 
   protected:
-    Vecd *zero_gradient_residual_;
+    Vecd *kernel_gradient_integral_;
     KernelCorrectionType kernel_correction_;
     ParticleScope within_scope_;
 };

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.h
@@ -220,7 +220,7 @@ class PressureVelocityCondition : public BaseLocalDynamics<AlignedBoxByCell>,
         CorrectionKernel correction_kernel_;
         ConditionType condition_;
         Real *physical_time_;
-        Vecd *zero_gradient_residual_;
+        Vecd *kernel_gradient_integral_;
         int axis_;
         Transform *transform_;
     };
@@ -230,7 +230,7 @@ class PressureVelocityCondition : public BaseLocalDynamics<AlignedBoxByCell>,
     KernelCorrectionType kernel_correction_method_;
     ConditionType condition_;
     SingularVariable<Real> *sv_physical_time_;
-    DiscreteVariable<Vecd> *dv_zero_gradient_residual_;
+    DiscreteVariable<Vecd> *dv_kernel_gradient_integral_;
 };
 
 template <typename ExecutionPolicy, class KernelCorrectionType, class ConditionType>

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.hpp
@@ -124,7 +124,7 @@ PressureVelocityCondition<KernelCorrectionType, ConditionType>::
       kernel_correction_method_(this->particles_),
       condition_(std::forward<Args>(args)...),
       sv_physical_time_(this->sph_system_.template getSystemVariableByName<Real>("PhysicalTime")),
-      dv_zero_gradient_residual_(this->particles_->template getVariableByName<Vecd>("ZeroGradientResidual")) {}
+      dv_kernel_gradient_integral_(this->particles_->template getVariableByName<Vecd>("KernelGradientIntegral")) {}
 //=================================================================================================//
 template <class KernelCorrectionType, typename ConditionType>
 template <class ExecutionPolicy, class EncloserType>
@@ -135,7 +135,7 @@ PressureVelocityCondition<KernelCorrectionType, ConditionType>::UpdateKernel::
       correction_kernel_(ex_policy, encloser.kernel_correction_method_),
       condition_(encloser.condition_),
       physical_time_(encloser.sv_physical_time_->DelegatedData(ex_policy)),
-      zero_gradient_residual_(encloser.dv_zero_gradient_residual_->DelegatedData(ex_policy)),
+      kernel_gradient_integral_(encloser.dv_kernel_gradient_integral_->DelegatedData(ex_policy)),
       axis_(aligned_box_->AlignmentAxis()), transform_(&aligned_box_->getTransform()) {}
 //=================================================================================================//
 template <class KernelCorrectionType, typename ConditionType>
@@ -144,7 +144,7 @@ void PressureVelocityCondition<KernelCorrectionType, ConditionType>::
 {
     if (aligned_box_->checkContain(pos_[index_i]))
     {
-        Vecd corrected_residual = correction_kernel_(index_i) * zero_gradient_residual_[index_i];
+        Vecd corrected_residual = correction_kernel_(index_i) * kernel_gradient_integral_[index_i];
         vel_[index_i] -= dt * condition_.getPressure(p_[index_i], *physical_time_) /
                          rho_[index_i] * corrected_residual;
 

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.h
@@ -5,7 +5,7 @@
 #include "interaction_ck.hpp"
 #include "kernel_correction_ck.hpp"
 #include "particle_functors_ck.h"
-#include "zero_gradient_residual.hpp"
+#include "kernel_gradient_integral.hpp"
 
 namespace SPH
 {
@@ -17,9 +17,9 @@ class TransportVelocityCorrectionCK;
 template <class KernelCorrectionType, class LimiterType, class ParticleScopeType, typename... Parameters>
 class TransportVelocityCorrectionCK<
     Inner<WithUpdate, KernelCorrectionType, LimiterType, ParticleScopeType, Parameters...>>
-    : public ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>
+    : public KernelGradientIntegral<Inner<KernelCorrectionType, Parameters...>>
 {
-    using BaseInteraction = ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>;
+    using BaseInteraction = KernelGradientIntegral<Inner<KernelCorrectionType, Parameters...>>;
     using ParticleScopeTypeKernel = typename ParticleScopeTypeCK<ParticleScopeType>::ComputingKernel;
     using SmoothingRatio = typename Inner<Parameters...>::NeighborMethodType::SmoothingRatio;
 
@@ -39,7 +39,7 @@ class TransportVelocityCorrectionCK<
         SmoothingRatio h_ratio_;
         LimiterType limiter_;
         Vecd *dpos_;
-        Vecd *zero_gradient_residual_;
+        Vecd *kernel_gradient_integral_;
         ParticleScopeTypeKernel within_scope_;
     };
 
@@ -54,9 +54,9 @@ class TransportVelocityCorrectionCK<
 
 template <class KernelCorrectionType, typename... Parameters>
 class TransportVelocityCorrectionCK<Contact<Boundary, KernelCorrectionType, Parameters...>>
-    : public ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...>>
+    : public KernelGradientIntegral<Contact<Boundary, KernelCorrectionType, Parameters...>>
 {
-    using BaseInteraction = ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...>>;
+    using BaseInteraction = KernelGradientIntegral<Contact<Boundary, KernelCorrectionType, Parameters...>>;
 
       public:
         explicit TransportVelocityCorrectionCK(Contact<Parameters...> & contact_relation)

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.hpp
@@ -33,7 +33,7 @@ TransportVelocityCorrectionCK<
     : correction_scaling_(encloser.correction_scaling_),
       h_ratio_(encloser.h_ratio_), limiter_(encloser.limiter_),
       dpos_(encloser.dv_dpos_->DelegatedData(ex_policy)),
-      zero_gradient_residual_(encloser.dv_zero_gradient_residual_->DelegatedData(ex_policy)),
+      kernel_gradient_integral_(encloser.dv_kernel_gradient_integral_->DelegatedData(ex_policy)),
       within_scope_(ex_policy, encloser.within_scope_method_, *this) {}
 //=================================================================================================//
 template <class KernelCorrectionType, class LimiterType, class ParticleScopeType, typename... Parameters>
@@ -44,10 +44,10 @@ void TransportVelocityCorrectionCK<
     if (this->within_scope_(index_i))
     {
         Real inv_h_ratio = 1.0 / h_ratio_(index_i);
-        Vecd residual = this->zero_gradient_residual_[index_i];
+        Vecd residual = this->kernel_gradient_integral_[index_i];
         Real squared_norm = residual.squaredNorm();
         dpos_[index_i] += correction_scaling_ * limiter_(squared_norm) *
-                          this->zero_gradient_residual_[index_i] * inv_h_ratio * inv_h_ratio;
+                          this->kernel_gradient_integral_[index_i] * inv_h_ratio * inv_h_ratio;
     }
 }
 } // end namespace fluid_dynamics

--- a/src/shared/shared_ck/particle_dynamics/fluid_structure_interaction/force_on_structure.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_structure_interaction/force_on_structure.hpp
@@ -36,9 +36,9 @@ ForceFromFluid<KernelCorrectionType, Parameters...>::InteractKernel::
       contact_Vol_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)),
       contact_vel_(encloser.dv_contact_vel_[contact_index]->DelegatedData(ex_policy)) {}
 //=================================================================================================//
-template <typename ViscousForceType, typename... Parameters>
+template <typename ViscosityType, class KernelCorrectionType, typename... Parameters>
 template <class ContactRelationType>
-ViscousForceFromFluid<Contact<WithUpdate, ViscousForceType, Parameters...>>::
+ViscousForceFromFluid<Contact<WithUpdate, ViscosityType, KernelCorrectionType, Parameters...>>::
     ViscousForceFromFluid(ContactRelationType &contact_relation)
     : BaseForceFromFluid(contact_relation, "ViscousForceFromFluid")
 {
@@ -50,16 +50,16 @@ ViscousForceFromFluid<Contact<WithUpdate, ViscousForceType, Parameters...>>::
     }
 }
 //=================================================================================================//
-template <typename ViscousForceType, typename... Parameters>
+template <typename ViscosityType, class KernelCorrectionType, typename... Parameters>
 template <class ExecutionPolicy, class EncloserType>
-ViscousForceFromFluid<Contact<WithUpdate, ViscousForceType, Parameters...>>::InteractKernel::
+ViscousForceFromFluid<Contact<WithUpdate, ViscosityType, KernelCorrectionType, Parameters...>>::InteractKernel::
     InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt contact_index)
     : BaseForceFromFluid::InteractKernel(ex_policy, encloser, contact_index),
       viscosity_(ex_policy, *encloser.contact_viscosity_model_[contact_index]),
       smoothing_length_sq_(encloser.contact_smoothing_length_sq_[contact_index]) {}
 //=================================================================================================//
-template <typename ViscousForceType, typename... Parameters>
-void ViscousForceFromFluid<Contact<WithUpdate, ViscousForceType, Parameters...>>::
+template <typename ViscosityType, class KernelCorrectionType, typename... Parameters>
+void ViscousForceFromFluid<Contact<WithUpdate, ViscosityType, KernelCorrectionType, Parameters...>>::
     InteractKernel::interact(size_t index_i, Real dt)
 {
     Vecd force = Vecd::Zero();
@@ -79,9 +79,9 @@ void ViscousForceFromFluid<Contact<WithUpdate, ViscousForceType, Parameters...>>
     this->force_from_fluid_[index_i] = force * this->Vol_[index_i];
 }
 //=================================================================================================//
-template <class AcousticStep2ndHalfType, typename... Parameters>
+template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 template <class ContactRelationType>
-PressureForceFromFluid<Contact<WithUpdate, AcousticStep2ndHalfType, Parameters...>>::
+PressureForceFromFluid<Contact<WithUpdate, RiemannSolverType, KernelCorrectionType, Parameters...>>::
     PressureForceFromFluid(ContactRelationType &contact_relation)
     : BaseForceFromFluid(contact_relation, "PressureForceFromFluid"),
       dv_acc_ave_(this->solid_.AverageAccelerationVariable(this->particles_)),
@@ -98,9 +98,9 @@ PressureForceFromFluid<Contact<WithUpdate, AcousticStep2ndHalfType, Parameters..
     }
 }
 //=================================================================================================//
-template <class AcousticStep2ndHalfType, typename... Parameters>
+template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 template <class ExecutionPolicy, class EncloserType>
-PressureForceFromFluid<Contact<WithUpdate, AcousticStep2ndHalfType, Parameters...>>::InteractKernel::
+PressureForceFromFluid<Contact<WithUpdate, RiemannSolverType, KernelCorrectionType, Parameters...>>::InteractKernel::
     InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt contact_index)
     : BaseForceFromFluid::InteractKernel(ex_policy, encloser, contact_index),
       acc_ave_(encloser.dv_acc_ave_->DelegatedData(ex_policy)),
@@ -111,8 +111,8 @@ PressureForceFromFluid<Contact<WithUpdate, AcousticStep2ndHalfType, Parameters..
       contact_p_(encloser.dv_contact_p_[contact_index]->DelegatedData(ex_policy)),
       contact_force_prior_(encloser.dv_contact_force_prior_[contact_index]->DelegatedData(ex_policy)) {}
 //=================================================================================================//
-template <class AcousticStep2ndHalfType, typename... Parameters>
-void PressureForceFromFluid<Contact<WithUpdate, AcousticStep2ndHalfType, Parameters...>>::
+template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
+void PressureForceFromFluid<Contact<WithUpdate, RiemannSolverType, KernelCorrectionType, Parameters...>>::
     InteractKernel::interact(size_t index_i, Real dt)
 {
     Vecd force = Vecd::Zero();

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_gradient_integral.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_gradient_integral.h
@@ -21,43 +21,43 @@
  *                                                                           *
  * ------------------------------------------------------------------------- */
 /**
- * @file zero_gradient_residual.h
+ * @file kernel_gradient_integral.h
  * @brief The error residual for computing the gradient of unit.
  * @author	Xiangyu Hu
  */
 
-#ifndef ZERO_GRADIENT_RESIDUAL_H
-#define ZERO_GRADIENT_RESIDUAL_H
+#ifndef KERNEL_GRADIENT_INTEGRAL_H
+#define KERNEL_GRADIENT_INTEGRAL_H
 
 #include "base_general_dynamics.h"
 
 namespace SPH
 {
 template <class BaseInteractionType>
-class ZeroGradientResidualBase : public BaseInteractionType
+class KernelGradientIntegralBase : public BaseInteractionType
 {
   public:
     template <class DynamicsIdentifier>
-    explicit ZeroGradientResidualBase(DynamicsIdentifier &identifier);
-    virtual ~ZeroGradientResidualBase() {}
+    explicit KernelGradientIntegralBase(DynamicsIdentifier &identifier);
+    virtual ~KernelGradientIntegralBase() {}
 
   protected:
-    DiscreteVariable<Vecd> *dv_zero_gradient_residual_; ///< "ZeroGradientResidual"
+    DiscreteVariable<Vecd> *dv_kernel_gradient_integral_; ///< "KernelGradientIntegral"
 };
 
 template <typename...>
-class ZeroGradientResidual;
+class KernelGradientIntegral;
 
 template <class KernelCorrectionType, typename... Parameters>
-class ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>
-    : public ZeroGradientResidualBase<Interaction<Inner<Parameters...>>>
+class KernelGradientIntegral<Inner<KernelCorrectionType, Parameters...>>
+    : public KernelGradientIntegralBase<Interaction<Inner<Parameters...>>>
 {
-    using BaseInteraction = ZeroGradientResidualBase<Interaction<Inner<Parameters...>>>;
+    using BaseInteraction = KernelGradientIntegralBase<Interaction<Inner<Parameters...>>>;
     using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
 
   public:
-    explicit ZeroGradientResidual(Inner<Parameters...> &inner_relation);
-    virtual ~ZeroGradientResidual() {}
+    explicit KernelGradientIntegral(Inner<Parameters...> &inner_relation);
+    virtual ~KernelGradientIntegral() {}
 
     class InteractKernel : public BaseInteraction::InteractKernel
     {
@@ -68,7 +68,7 @@ class ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>
 
       protected:
         CorrectionKernel correction_;
-        Vecd *zero_gradient_residual_;
+        Vecd *kernel_gradient_integral_;
         Real *Vol_;
     };
 
@@ -77,15 +77,15 @@ class ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>
 };
 
 template <class KernelCorrectionType, typename... Parameters>
-class ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...>>
-    : public ZeroGradientResidualBase<Interaction<Contact<Parameters...>>>
+class KernelGradientIntegral<Contact<Boundary, KernelCorrectionType, Parameters...>>
+    : public KernelGradientIntegralBase<Interaction<Contact<Parameters...>>>
 {
-    using BaseInteraction = ZeroGradientResidualBase<Interaction<Contact<Parameters...>>>;
+    using BaseInteraction = KernelGradientIntegralBase<Interaction<Contact<Parameters...>>>;
     using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
 
   public:
-    explicit ZeroGradientResidual(Contact<Parameters...> &contact_relation);
-    virtual ~ZeroGradientResidual() {}
+    explicit KernelGradientIntegral(Contact<Parameters...> &contact_relation);
+    virtual ~KernelGradientIntegral() {}
 
     class InteractKernel : public BaseInteraction::InteractKernel
     {
@@ -96,7 +96,7 @@ class ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...
 
       protected:
         CorrectionKernel correction_;
-        Vecd *zero_gradient_residual_;
+        Vecd *kernel_gradient_integral_;
         Real *contact_Vol_;
     };
 
@@ -104,4 +104,4 @@ class ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...
     KernelCorrectionType kernel_correction_;
 };
 } // namespace SPH
-#endif // ZERO_GRADIENT_RESIDUAL_H
+#endif // KERNEL_GRADIENT_RESIDUAL_H

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_gradient_integral.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_gradient_integral.hpp
@@ -1,22 +1,22 @@
-#ifndef ZERO_GRADIENT_RESIDUAL_HPP
-#define ZERO_GRADIENT_RESIDUAL_HPP
+#ifndef KERNEL_GRADIENT_INTEGRAL_HPP
+#define KERNEL_GRADIENT_INTEGRAL_HPP
 
-#include "zero_gradient_residual.h"
+#include "kernel_gradient_integral.h"
 
 namespace SPH
 {
 //=================================================================================================//
 template <class BaseInteractionType>
 template <class DynamicsIdentifier>
-ZeroGradientResidualBase<BaseInteractionType>::ZeroGradientResidualBase(DynamicsIdentifier &identifier)
+KernelGradientIntegralBase<BaseInteractionType>::KernelGradientIntegralBase(DynamicsIdentifier &identifier)
     : BaseInteractionType(identifier),
-      dv_zero_gradient_residual_(
-          this->particles_->template registerStateVariable<Vecd>("ZeroGradientResidual")) {}
+      dv_kernel_gradient_integral_(
+          this->particles_->template registerStateVariable<Vecd>("KernelGradientIntegral")) {}
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
-ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>::ZeroGradientResidual(
+KernelGradientIntegral<Inner<KernelCorrectionType, Parameters...>>::KernelGradientIntegral(
     Inner<Parameters...> &inner_relation)
-    : ZeroGradientResidualBase<Interaction<Inner<Parameters...>>>(inner_relation),
+    : KernelGradientIntegralBase<Interaction<Inner<Parameters...>>>(inner_relation),
       kernel_correction_(this->particles_)
 {
     static_assert(std::is_base_of<KernelCorrection, KernelCorrectionType>::value,
@@ -25,15 +25,15 @@ ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>::ZeroGradientRe
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
 template <class ExecutionPolicy, class EncloserType>
-ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>::InteractKernel::
+KernelGradientIntegral<Inner<KernelCorrectionType, Parameters...>>::InteractKernel::
     InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
     : BaseInteraction::InteractKernel(ex_policy, encloser),
       correction_(ex_policy, encloser.kernel_correction_),
-      zero_gradient_residual_(encloser.dv_zero_gradient_residual_->DelegatedData(ex_policy)),
+      kernel_gradient_integral_(encloser.dv_kernel_gradient_integral_->DelegatedData(ex_policy)),
       Vol_(encloser.dv_Vol_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
-void ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>::
+void KernelGradientIntegral<Inner<KernelCorrectionType, Parameters...>>::
     InteractKernel::interact(size_t index_i, Real dt)
 {
     Vecd inconsistency = Vecd::Zero();
@@ -44,13 +44,13 @@ void ZeroGradientResidual<Inner<KernelCorrectionType, Parameters...>>::
         const Vecd e_ij = this->e_ij(index_i, index_j);
         inconsistency -= (correction_(index_i) + correction_(index_j)) * dW_ijV_j * e_ij;
     }
-    zero_gradient_residual_[index_i] = inconsistency;
+    kernel_gradient_integral_[index_i] = inconsistency;
 }
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
-ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...>>::
-    ZeroGradientResidual(Contact<Parameters...> &contact_relation)
-    : ZeroGradientResidualBase<Interaction<Contact<Parameters...>>>(contact_relation),
+KernelGradientIntegral<Contact<Boundary, KernelCorrectionType, Parameters...>>::
+    KernelGradientIntegral(Contact<Parameters...> &contact_relation)
+    : KernelGradientIntegralBase<Interaction<Contact<Parameters...>>>(contact_relation),
       kernel_correction_(this->particles_)
 {
     static_assert(std::is_base_of<KernelCorrection, KernelCorrectionType>::value,
@@ -59,15 +59,15 @@ ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...>>::
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
 template <class ExecutionPolicy, class EncloserType>
-ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...>>::InteractKernel::
+KernelGradientIntegral<Contact<Boundary, KernelCorrectionType, Parameters...>>::InteractKernel::
     InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt contact_index)
     : BaseInteraction::InteractKernel(ex_policy, encloser, contact_index),
       correction_(ex_policy, encloser.kernel_correction_),
-      zero_gradient_residual_(encloser.dv_zero_gradient_residual_->DelegatedData(ex_policy)),
+      kernel_gradient_integral_(encloser.dv_kernel_gradient_integral_->DelegatedData(ex_policy)),
       contact_Vol_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
-void ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...>>::
+void KernelGradientIntegral<Contact<Boundary, KernelCorrectionType, Parameters...>>::
     InteractKernel::interact(size_t index_i, Real dt)
 {
     Vecd inconsistency = Vecd::Zero();
@@ -78,8 +78,8 @@ void ZeroGradientResidual<Contact<Boundary, KernelCorrectionType, Parameters...>
         const Vecd e_ij = this->e_ij(index_i, index_j);
         inconsistency -= 2.0 * correction_(index_i) * dW_ijV_j * e_ij;
     }
-    zero_gradient_residual_[index_i] += inconsistency;
+    kernel_gradient_integral_[index_i] += inconsistency;
 }
 //=================================================================================================//
 } // namespace SPH
-#endif // ZERO_GRADIENT_RESIDUAL_HPP
+#endif // KERNEL_GRADIENT_RESIDUAL_HPP

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/level_set_correction.cpp
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/level_set_correction.cpp
@@ -12,7 +12,7 @@ LevelsetBounding::LevelsetBounding(NearShapeSurface &body_part)
 LevelsetKernelGradientIntegral::LevelsetKernelGradientIntegral(SPHBody &sph_body, LevelSetShape &level_set_shape)
     : LocalDynamics(sph_body),
       dv_pos_(particles_->getVariableByName<Vecd>("Position")),
-      dv_residual_(particles_->registerStateVariable<Vecd>("ZeroGradientResidual")),
+      dv_residual_(particles_->registerStateVariable<Vecd>("KernelGradientIntegral")),
       level_set_(level_set_shape.getLevelSet()) {}
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_residual_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_residual_ck.hpp
@@ -11,7 +11,7 @@ template <class DynamicsIdentifier>
 RelaxationResidualBase<BaseInteractionType>::RelaxationResidualBase(DynamicsIdentifier &identifier)
     : BaseInteractionType(identifier),
       dv_pos_(this->particles_->template getVariableByName<Vecd>("Position")),
-      dv_residual_(this->particles_->template registerStateVariable<Vecd>("ZeroGradientResidual")) {}
+      dv_residual_(this->particles_->template registerStateVariable<Vecd>("KernelGradientIntegral")) {}
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
 RelaxationResidualCK<Inner<KernelCorrectionType, Parameters...>>::

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_stepping_ck.cpp
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_stepping_ck.cpp
@@ -5,7 +5,7 @@ namespace SPH
 //=================================================================================================//
 RelaxationScalingCK::RelaxationScalingCK(SPHBody &sph_body)
     : LocalDynamicsReduce<ReduceMax>(sph_body),
-      dv_residual_(particles_->getVariableByName<Vecd>("ZeroGradientResidual")),
+      dv_residual_(particles_->getVariableByName<Vecd>("KernelGradientIntegral")),
       h_ref_(sph_body.getSPHAdaptation().ReferenceSmoothingLength()) {}
 //=================================================================================================//
 RelaxationScalingCK::FinishDynamics::FinishDynamics(RelaxationScalingCK &encloser)
@@ -19,6 +19,6 @@ Real RelaxationScalingCK::FinishDynamics::Result(Real reduced_value)
 PositionRelaxationCK::PositionRelaxationCK(SPHBody &sph_body)
     : LocalDynamics(sph_body),
       pos_(particles_->getVariableByName<Vecd>("Position")),
-      residual_(particles_->getVariableByName<Vecd>("ZeroGradientResidual")) {}
+      residual_(particles_->getVariableByName<Vecd>("KernelGradientIntegral")) {}
 //=================================================================================================//
 } // namespace SPH

--- a/tests/2d_examples/test_2d_cohesive_soil_failure/cohesive_soil_failure.h
+++ b/tests/2d_examples/test_2d_cohesive_soil_failure/cohesive_soil_failure.h
@@ -120,7 +120,7 @@ class TransportVelocityCorrection<Inner<ResolutionType, LimiterType>, CommonCont
                 inconsistency -= (this->kernel_correction_(index_i) + this->kernel_correction_(index_j)) *
                                  inner_neighborhood.dW_ij_[n] * this->Vol_[index_j] * inner_neighborhood.e_ij_[n];
             }
-            this->zero_gradient_residual_[index_i] = inconsistency;
+            this->kernel_gradient_integral_[index_i] = inconsistency;
         }
     };
     void update(size_t index_i, Real dt = 0.0)
@@ -128,9 +128,9 @@ class TransportVelocityCorrection<Inner<ResolutionType, LimiterType>, CommonCont
         if (this->within_scope_(index_i))
         {
             Real inv_h_ratio = 1.0 / h_ratio_(index_i);
-            Real squared_norm = this->zero_gradient_residual_[index_i].squaredNorm();
+            Real squared_norm = this->kernel_gradient_integral_[index_i].squaredNorm();
             Vecd pos_transport = correction_scaling_ * limiter_(squared_norm) *
-                                 this->zero_gradient_residual_[index_i] * inv_h_ratio * inv_h_ratio;
+                                 this->kernel_gradient_integral_[index_i] * inv_h_ratio * inv_h_ratio;
             if (this->indicator_[index_i])
             {
                 pos_transport = pos_transport - pos_transport.dot(this->surface_normal_[index_i]) * this->surface_normal_[index_i];
@@ -185,7 +185,7 @@ class TransportVelocityCorrection<Contact<Boundary>, CommonControlTypes...>
                                      wall_Vol_k[index_j] * contact_neighborhood.e_ij_[n];
                 }
             }
-            this->zero_gradient_residual_[index_i] += inconsistency;
+            this->kernel_gradient_integral_[index_i] += inconsistency;
         }
     };
 


### PR DESCRIPTION
This pull request refactors several fluid dynamics and fluid-structure interaction classes to replace the use of the `ZeroGradientResidual` variable and related types with `KernelGradientIntegral`. It also updates class hierarchies and template parameters for force computation classes, improving clarity and consistency in the codebase. The changes affect both the core SPH fluid dynamics logic and its boundary/structure interaction modules.

### Variable renaming and type updates

* The state variable `zero_gradient_residual_` and related data delegation types are renamed to `kernel_gradient_integral_` throughout fluid dynamics classes and their boundary condition counterparts (`TransportVelocityCorrection`, `PressureVelocityCondition`, and related CK classes). All references and usages are updated accordingly. [[1]](diffhunk://#diff-8bca669958f8298a3a6ecd384be899157a9554b525eb859450e5d0455c8d35f8L58-R58) [[2]](diffhunk://#diff-4b248069d5792a9071cb8d85bc9f866b62e632e09670f52fc239e2922e53e5dfL15-R15) [[3]](diffhunk://#diff-4b248069d5792a9071cb8d85bc9f866b62e632e09670f52fc239e2922e53e5dfL51-R51) [[4]](diffhunk://#diff-4b248069d5792a9071cb8d85bc9f866b62e632e09670f52fc239e2922e53e5dfL62-R64) [[5]](diffhunk://#diff-4b248069d5792a9071cb8d85bc9f866b62e632e09670f52fc239e2922e53e5dfL98-R98) [[6]](diffhunk://#diff-4b248069d5792a9071cb8d85bc9f866b62e632e09670f52fc239e2922e53e5dfL135-R135) [[7]](diffhunk://#diff-c3263ac0eee833c8ca0c31374dee93c4e59a2c04513d868a870d550fd912b685L223-R223) [[8]](diffhunk://#diff-c3263ac0eee833c8ca0c31374dee93c4e59a2c04513d868a870d550fd912b685L233-R233) [[9]](diffhunk://#diff-b954f48bf1e83927957e63129708fecf5a675c89fdd9ef8418a717d207423540L127-R127) [[10]](diffhunk://#diff-b954f48bf1e83927957e63129708fecf5a675c89fdd9ef8418a717d207423540L138-R138) [[11]](diffhunk://#diff-b954f48bf1e83927957e63129708fecf5a675c89fdd9ef8418a717d207423540L147-R147) [[12]](diffhunk://#diff-ef55017961967def7b42c6a8dfc91ddc07d081e97fc83d0919a75c03bb401549L8-R8) [[13]](diffhunk://#diff-ef55017961967def7b42c6a8dfc91ddc07d081e97fc83d0919a75c03bb401549L20-R22) [[14]](diffhunk://#diff-ef55017961967def7b42c6a8dfc91ddc07d081e97fc83d0919a75c03bb401549L42-R42) [[15]](diffhunk://#diff-ef55017961967def7b42c6a8dfc91ddc07d081e97fc83d0919a75c03bb401549L57-R59) [[16]](diffhunk://#diff-3428a5cabc10529f32c69861cca9ed12e61ed0e562d15e510ff02b3ebad073bfL36-R36) [[17]](diffhunk://#diff-3428a5cabc10529f32c69861cca9ed12e61ed0e562d15e510ff02b3ebad073bfL47-R50)

### Class inheritance and file inclusion changes

* The inheritance for `TransportVelocityCorrectionCK` and related classes is changed from `ZeroGradientResidual` to `KernelGradientIntegral`, and the corresponding header file inclusion is updated. [[1]](diffhunk://#diff-ef55017961967def7b42c6a8dfc91ddc07d081e97fc83d0919a75c03bb401549L8-R8) [[2]](diffhunk://#diff-ef55017961967def7b42c6a8dfc91ddc07d081e97fc83d0919a75c03bb401549L20-R22) [[3]](diffhunk://#diff-ef55017961967def7b42c6a8dfc91ddc07d081e97fc83d0919a75c03bb401549L57-R59)

### Fluid-structure interaction template refactoring

* The template parameters for `ViscousForceFromFluid` and `PressureForceFromFluid` classes are refactored to explicitly include both viscosity and kernel correction types, rather than deducing them from other types. This adds clarity and flexibility for future extensions. [[1]](diffhunk://#diff-0585913a8694fbbc7190bd27865355416948d2b8115ff59f93bbb9f0c3cf5a58L78-R83) [[2]](diffhunk://#diff-0585913a8694fbbc7190bd27865355416948d2b8115ff59f93bbb9f0c3cf5a58R105-R132) [[3]](diffhunk://#diff-0585913a8694fbbc7190bd27865355416948d2b8115ff59f93bbb9f0c3cf5a58R159-R179) [[4]](diffhunk://#diff-c429365b376b9fefd1e5b363c066e44b761d389a4691659b99274e49cf8713e3L39-R41) [[5]](diffhunk://#diff-c429365b376b9fefd1e5b363c066e44b761d389a4691659b99274e49cf8713e3L53-R62) [[6]](diffhunk://#diff-c429365b376b9fefd1e5b363c066e44b761d389a4691659b99274e49cf8713e3L82-R84)

### Backwards compatibility and transition classes

* Transitional template specializations are added for `ViscousForceFromFluid` and `PressureForceFromFluid` to maintain backwards compatibility with previous usages that relied on implicit type deduction. [[1]](diffhunk://#diff-0585913a8694fbbc7190bd27865355416948d2b8115ff59f93bbb9f0c3cf5a58R105-R132) [[2]](diffhunk://#diff-0585913a8694fbbc7190bd27865355416948d2b8115ff59f93bbb9f0c3cf5a58R159-R179)

---

These changes streamline the codebase by making variable names and class hierarchies more descriptive and consistent, and by clarifying template usage in fluid-structure interaction modules.