### PR TITLE
I do know why this is working, may be related with include dependency

### DIFF
--- a/src/shared/include/sphinxsys.h
+++ b/src/shared/include/sphinxsys.h
@@ -28,6 +28,18 @@
 #ifndef SPHINXSYS_H
 #define SPHINXSYS_H
 
+#if SPHINXSYS_USE_SYCL
+#include "base_configuration_dynamics_sycl.h"
+#include "device_copyable_variable.h"
+#include "mesh_iterators_sycl.hpp"
+#include "particle_iterators_sycl.h"
+#include "particle_sort_sycl.hpp"
+#include "sphinxsys_buffer_array_sycl.hpp"
+#include "sphinxsys_constant_sycl.hpp"
+#include "sphinxsys_variable_array_sycl.hpp"
+#include "sphinxsys_variable_sycl.hpp"
+#endif // SPHINXSYS_USE_SYCL
+
 #include "all_bodies.h"
 #include "all_body_relations.h"
 #include "all_closures.h"
@@ -45,17 +57,5 @@
 #include "particle_method_container.h"
 #include "sph_solver.h"
 #include "sph_system.hpp"
-
-#if SPHINXSYS_USE_SYCL
-#include "base_configuration_dynamics_sycl.h"
-#include "device_copyable_variable.h"
-#include "mesh_iterators_sycl.hpp"
-#include "particle_iterators_sycl.h"
-#include "particle_sort_sycl.hpp"
-#include "sphinxsys_buffer_array_sycl.hpp"
-#include "sphinxsys_constant_sycl.hpp"
-#include "sphinxsys_variable_array_sycl.hpp"
-#include "sphinxsys_variable_sycl.hpp"
-#endif // SPHINXSYS_USE_SYCL
 
 #endif // SPHINXSYS_H


### PR DESCRIPTION
This pull request updates the `sphinxsys.h` header to move the SYCL-specific includes to the top of the file. This change helps ensure that SYCL-related code is included earlier in the compilation process, which can improve clarity and reduce potential ordering issues.

* SYCL-specific includes (`base_configuration_dynamics_sycl.h`, `device_copyable_variable.h`, etc.) are now grouped and placed at the top of `sphinxsys.h`, before the main body includes.
* The previous placement of SYCL-specific includes at the bottom of the file has been removed to avoid duplication and confusion.