### PR TITLE
Xiangyu/revise viscous force

### DIFF
--- a/src/shared/particle_dynamics/particle_functors.h
+++ b/src/shared/particle_dynamics/particle_functors.h
@@ -163,7 +163,7 @@ class GeomAverage : public ParticleAverage
 template <typename T>
 class PairGeomAverageFixed : public GeomAverage
 {
-    const T geom_average_;
+    T geom_average_;
 
   public:
     PairGeomAverageFixed(const T &c1, const T &c2)

--- a/src/shared/physical_closure/materials/viscosity.h
+++ b/src/shared/physical_closure/materials/viscosity.h
@@ -48,12 +48,20 @@ class Viscosity
     virtual void registerLocalParametersFromReload(BaseParticles *base_particles) {};
     virtual void initializeLocalParameters(BaseParticles *base_particles) {};
 
-    class ComputingKernel : public ParameterFixed<Real>
+    typedef ParameterFixed<Real> OneSideViscosity;
+
+    template <typename ExecutionPolicy>
+    ParameterFixed<Real> getOneSideViscosity(const ExecutionPolicy &ex_policy)
     {
-      public:
-        template <class ExecutionPolicy, class EncloserType>
-        ComputingKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
-            : ParameterFixed<Real>(encloser.mu_){};
+        return ParameterFixed<Real>(mu_);
+    };
+
+    typedef PairGeomAverageFixed<Real> InterParticleViscosity;
+
+    template <typename ExecutionPolicy>
+    PairGeomAverageFixed<Real> getInterParticleViscosity(const ExecutionPolicy &ex_policy, Viscosity &other_viscosity)
+    {
+        return PairGeomAverageFixed<Real>(mu_, other_viscosity.ReferenceViscosity());
     };
 };
 

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.hpp
@@ -23,7 +23,7 @@ template <typename ViscosityType, class KernelCorrectionType, typename... Parame
 ViscousForceCK<Inner<WithUpdate, ViscosityType, KernelCorrectionType, Parameters...>>::
     ViscousForceCK(Inner<Parameters...> &inner_relation)
     : BaseViscousForceType(inner_relation),
-      ForcePriorCK(this->particles_, this->dv_current_force_) {}
+      ForcePriorCK(this->particles_, this->dv_viscous_force_) {}
 //=================================================================================================//
 template <typename ViscosityType, class KernelCorrectionType, typename... Parameters>
 template <class ExecutionPolicy, class EncloserType>
@@ -74,6 +74,7 @@ ViscousForceCK<Contact<Wall, ViscosityType, KernelCorrectionType, Parameters...>
       Vol_(encloser.dv_Vol_->DelegatedData(ex_policy)),
       contact_Vol_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)),
       vel_(encloser.dv_vel_->DelegatedData(ex_policy)),
+      viscous_force_(encloser.dv_viscous_force_->DelegatedData(ex_policy)),
       wall_vel_ave_(encloser.dv_wall_vel_ave_[contact_index]->DelegatedData(ex_policy)),
       smoothing_length_sq_(encloser.smoothing_length_sq_) {}
 //=================================================================================================//

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.hpp
@@ -13,20 +13,25 @@ template <class BaseRelationType>
 ViscousForceCK<Base, ViscosityType, KernelCorrectionType, RelationType<Parameters...>>::
     ViscousForceCK(BaseRelationType &base_relation)
     : Interaction<RelationType<Parameters...>>(base_relation),
-      ForcePriorCK(this->particles_, "ViscousForce"),
       viscosity_model_(DynamicCast<ViscosityType>(this, this->particles_->getBaseMaterial())),
       kernel_correction_(this->particles_),
       dv_vel_(this->particles_->template getVariableByName<Vecd>("Velocity")),
-      dv_viscous_force_(this->dv_current_force_),
+      dv_viscous_force_(this->particles_->template registerStateVariable<Vecd>("ViscousForce")),
       smoothing_length_sq_(pow(this->sph_body_.getSPHAdaptation().ReferenceSmoothingLength(), 2)) {}
 //=================================================================================================//
-template <typename ViscosityType, class KernelCorrectionType,
-          template <typename...> class RelationType, typename... Parameters>
-template <class ExecutionPolicy, class EncloserType, typename... Args>
-ViscousForceCK<Base, ViscosityType, KernelCorrectionType, RelationType<Parameters...>>::InteractKernel::
-    InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, Args &&...args)
-    : Interaction<RelationType<Parameters...>>::InteractKernel(ex_policy, encloser, std::forward<Args>(args)...),
-      viscosity_(ex_policy, encloser.viscosity_model_),
+template <typename ViscosityType, class KernelCorrectionType, typename... Parameters>
+ViscousForceCK<Inner<WithUpdate, ViscosityType, KernelCorrectionType, Parameters...>>::
+    ViscousForceCK(Inner<Parameters...> &inner_relation)
+    : BaseViscousForceType(inner_relation),
+      ForcePriorCK(this->particles_, this->dv_current_force_) {}
+//=================================================================================================//
+template <typename ViscosityType, class KernelCorrectionType, typename... Parameters>
+template <class ExecutionPolicy, class EncloserType>
+ViscousForceCK<Inner<WithUpdate, ViscosityType, KernelCorrectionType, Parameters...>>::
+    InteractKernel::InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
+    : BaseViscousForceType::InteractKernel(ex_policy, encloser),
+      inter_particle_viscosity_(
+          encloser.viscosity_model_.getInterParticleViscosity(ex_policy, encloser.viscosity_model_)),
       correction_(ex_policy, encloser.kernel_correction_),
       Vol_(encloser.dv_Vol_->DelegatedData(ex_policy)),
       vel_(encloser.dv_vel_->DelegatedData(ex_policy)),
@@ -42,16 +47,35 @@ void ViscousForceCK<Inner<WithUpdate, ViscosityType, KernelCorrectionType, Param
     {
         UnsignedInt index_j = this->neighbor_index_[n];
         Vecd e_ij = this->e_ij(index_i, index_j);
+        Real dW_ijV_j = this->dW_ij(index_i, index_j) * Vol_[index_j];
         Vecd vec_r_ij = this->vec_r_ij(index_i, index_j);
-        Vecd vel_derivative = (this->vel_[index_i] - this->vel_[index_j]) /
-                              (vec_r_ij.squaredNorm() + 0.01 * this->smoothing_length_sq_);
 
-        force += vec_r_ij.dot((this->correction_(index_i) + this->correction_(index_j)) * e_ij) *
-                 harmonic_average(this->viscosity_(index_i), this->viscosity_(index_j)) *
-                 vel_derivative * this->dW_ij(index_i, index_j) * this->Vol_[index_j];
+        Vecd vel_derivative = (vel_[index_i] - vel_[index_j]) /
+                              (vec_r_ij.squaredNorm() + 0.01 * smoothing_length_sq_);
+
+        force += vec_r_ij.dot((correction_(index_i) + correction_(index_j)) * e_ij) *
+                 inter_particle_viscosity_(index_i, index_j) * vel_derivative * dW_ijV_j;
     }
-    this->viscous_force_[index_i] = force * this->Vol_[index_i];
+    viscous_force_[index_i] = force * Vol_[index_i];
 }
+//=================================================================================================//
+template <typename ViscosityType, class KernelCorrectionType, typename... Parameters>
+ViscousForceCK<Contact<Wall, ViscosityType, KernelCorrectionType, Parameters...>>::
+    ViscousForceCK(Contact<Parameters...> &contact_relation)
+    : BaseViscousForceType(contact_relation), Interaction<Wall>(contact_relation) {}
+//=================================================================================================//
+template <typename ViscosityType, class KernelCorrectionType, typename... Parameters>
+template <class ExecutionPolicy, class EncloserType>
+ViscousForceCK<Contact<Wall, ViscosityType, KernelCorrectionType, Parameters...>>::InteractKernel::
+    InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, size_t contact_index)
+    : BaseViscousForceType::InteractKernel(ex_policy, encloser, contact_index),
+      one_side_viscosity_(encloser.viscosity_model_.getOneSideViscosity(ex_policy)),
+      correction_(ex_policy, encloser.kernel_correction_),
+      Vol_(encloser.dv_Vol_->DelegatedData(ex_policy)),
+      contact_Vol_(encloser.dv_contact_Vol_[contact_index]->DelegatedData(ex_policy)),
+      vel_(encloser.dv_vel_->DelegatedData(ex_policy)),
+      wall_vel_ave_(encloser.dv_wall_vel_ave_[contact_index]->DelegatedData(ex_policy)),
+      smoothing_length_sq_(encloser.smoothing_length_sq_) {}
 //=================================================================================================//
 template <typename ViscosityType, class KernelCorrectionType, typename... Parameters>
 void ViscousForceCK<Contact<Wall, ViscosityType, KernelCorrectionType, Parameters...>>::
@@ -62,15 +86,16 @@ void ViscousForceCK<Contact<Wall, ViscosityType, KernelCorrectionType, Parameter
     {
         UnsignedInt index_j = this->neighbor_index_[n];
         Vecd e_ij = this->e_ij(index_i, index_j);
+        Real dW_ijV_j = this->dW_ij(index_i, index_j) * contact_Vol_[index_j];
         Vecd vec_r_ij = this->vec_r_ij(index_i, index_j);
-        Vecd vel_derivative = 2.0 * (this->vel_[index_i] - this->wall_vel_ave_[index_j]) /
-                              (vec_r_ij.squaredNorm() + 0.01 * this->smoothing_length_sq_);
 
-        force += 2.0 * vec_r_ij.dot(this->correction_(index_i) * e_ij) *
-                 this->viscosity_(index_i) * vel_derivative *
-                 this->dW_ij(index_i, index_j) * this->contact_Vol_[index_j];
+        Vecd vel_derivative = 2.0 * (vel_[index_i] - wall_vel_ave_[index_j]) /
+                              (vec_r_ij.squaredNorm() + 0.01 * smoothing_length_sq_);
+
+        force += 2.0 * vec_r_ij.dot(correction_(index_i) * e_ij) *
+                 one_side_viscosity_(index_i) * vel_derivative * dW_ijV_j;
     }
-    this->viscous_force_[index_i] += force * this->Vol_[index_i];
+    viscous_force_[index_i] += force * Vol_[index_i];
 }
 //=================================================================================================//
 } // namespace fluid_dynamics

--- a/src/shared/shared_ck/particle_dynamics/fluid_structure_interaction/force_on_structure.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_structure_interaction/force_on_structure.h
@@ -79,7 +79,7 @@ template <typename ViscosityType, class KernelCorrectionType, typename... Parame
 class ViscousForceFromFluid<Contact<WithUpdate, ViscosityType, KernelCorrectionType, Parameters...>>
     : public ForceFromFluid<KernelCorrectionType, Parameters...>
 {
-    using ViscosityKernel = typename ViscosityType::ComputingKernel;
+    using OneSideViscosity = typename ViscosityType::OneSideViscosity;
     using BaseForceFromFluid = ForceFromFluid<KernelCorrectionType, Parameters...>;
 
   public:
@@ -94,7 +94,7 @@ class ViscousForceFromFluid<Contact<WithUpdate, ViscosityType, KernelCorrectionT
         void interact(size_t index_i, Real dt = 0.0);
 
       protected:
-        ViscosityKernel viscosity_;
+        OneSideViscosity one_side_viscosity_;
         Real smoothing_length_sq_;
     };
 

--- a/src/shared/shared_ck/particle_dynamics/fluid_structure_interaction/force_on_structure.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_structure_interaction/force_on_structure.hpp
@@ -14,7 +14,7 @@ ForceFromFluid<KernelCorrectionType, Parameters...>::
     ForceFromFluid(ContactRelationType &contact_relation, const std::string &force_name)
     : Interaction<Contact<Parameters...>>(contact_relation), ForcePriorCK(this->particles_, force_name),
       solid_(DynamicCast<Solid>(this, this->sph_body_.getBaseMaterial())),
-      dv_force_from_fluid_(this->dv_current_force_),
+      dv_force_from_fluid_(ForcePriorCK::getCurrentForce()),
       dv_vel_ave_(solid_.AverageVelocityVariable(this->particles_))
 {
     for (size_t k = 0; k != this->contact_particles_.size(); ++k)
@@ -55,7 +55,7 @@ template <class ExecutionPolicy, class EncloserType>
 ViscousForceFromFluid<Contact<WithUpdate, ViscosityType, KernelCorrectionType, Parameters...>>::InteractKernel::
     InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt contact_index)
     : BaseForceFromFluid::InteractKernel(ex_policy, encloser, contact_index),
-      viscosity_(ex_policy, *encloser.contact_viscosity_model_[contact_index]),
+      one_side_viscosity_(encloser.contact_viscosity_model_[contact_index]->getOneSideViscosity(ex_policy)),
       smoothing_length_sq_(encloser.contact_smoothing_length_sq_[contact_index]) {}
 //=================================================================================================//
 template <typename ViscosityType, class KernelCorrectionType, typename... Parameters>
@@ -72,7 +72,7 @@ void ViscousForceFromFluid<Contact<WithUpdate, ViscosityType, KernelCorrectionTy
                               (vec_r_ij.squaredNorm() + 0.01 * smoothing_length_sq_);
 
         force += vec_r_ij.dot(this->contact_correction_(index_j) * e_ij) *
-                 viscosity_(index_j) * vel_derivative *
+                 one_side_viscosity_(index_j) * vel_derivative *
                  this->dW_ij(index_i, index_j) * this->contact_Vol_[index_j];
     }
 

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/force_prior_ck.cpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/force_prior_ck.cpp
@@ -1,0 +1,18 @@
+#include "force_prior_ck.h"
+
+namespace SPH
+{
+//=================================================================================================//
+ForcePriorCK::ForcePriorCK(BaseParticles *particles, DiscreteVariable<Vecd> *dv_current_force)
+    : dv_force_prior_(particles->registerStateVariable<Vecd>("ForcePrior")),
+      dv_current_force_(dv_current_force),
+      dv_previous_force_(particles->registerStateVariable<Vecd>("Previous" + dv_current_force->Name()))
+{
+    particles->addEvolvingVariable<Vecd>(dv_force_prior_);
+    particles->addEvolvingVariable<Vecd>("Previous" + dv_current_force_->Name());
+}
+//=================================================================================================//
+ForcePriorCK::ForcePriorCK(BaseParticles *particles, const std::string &force_name)
+    : ForcePriorCK(particles, particles->template registerStateVariable<Vecd>(force_name)) {}
+//=================================================================================================//
+} // namespace SPH

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/force_prior_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/force_prior_ck.h
@@ -37,10 +37,13 @@ namespace SPH
 
 class ForcePriorCK
 {
+    DiscreteVariable<Vecd> *dv_force_prior_, *dv_current_force_, *dv_previous_force_;
+
   public:
     ForcePriorCK(BaseParticles *particles, DiscreteVariable<Vecd> *dv_current_force);
     ForcePriorCK(BaseParticles *particles, const std::string &force_name);
     virtual ~ForcePriorCK() {};
+    DiscreteVariable<Vecd> *getCurrentForce() { return dv_current_force_; }
 
     class UpdateKernel
     {
@@ -56,9 +59,6 @@ class ForcePriorCK
       protected:
         Vecd *force_prior_, *current_force_, *previous_force_;
     };
-
-  protected:
-    DiscreteVariable<Vecd> *dv_force_prior_, *dv_current_force_, *dv_previous_force_;
 };
 
 template <class GravityType>

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/force_prior_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/force_prior_ck.h
@@ -38,14 +38,8 @@ namespace SPH
 class ForcePriorCK
 {
   public:
-    ForcePriorCK(BaseParticles *particles, const std::string &force_name)
-        : dv_force_prior_(particles->registerStateVariable<Vecd>("ForcePrior")),
-          dv_current_force_(particles->registerStateVariable<Vecd>(force_name)),
-          dv_previous_force_(particles->registerStateVariable<Vecd>("Previous" + force_name))
-    {
-        particles->addEvolvingVariable<Vecd>(dv_force_prior_);
-        particles->addEvolvingVariable<Vecd>("Previous" + force_name);
-    };
+    ForcePriorCK(BaseParticles *particles, DiscreteVariable<Vecd> *dv_current_force);
+    ForcePriorCK(BaseParticles *particles, const std::string &force_name);
     virtual ~ForcePriorCK() {};
 
     class UpdateKernel


### PR DESCRIPTION
This pull request refactors how viscosity and force kernels are handled in fluid and fluid-structure interaction dynamics. The changes introduce more explicit types for different viscosity calculations, improve encapsulation of force variables, and simplify the interaction kernels for maintainability and clarity. The main themes are improvements to viscosity modeling, kernel interaction logic, and force variable management.

**Viscosity Modeling Improvements:**
* Introduced explicit typedefs for `OneSideViscosity` and `InterParticleViscosity` in the `Viscosity` class, with corresponding getter methods for each, making viscosity calculations more modular and clear.
* Refactored classes and kernels to use these new viscosity types (`OneSideViscosity`, `InterParticleViscosity`) instead of the previous generic `ComputingKernel`, including in fluid-structure interaction logic. [[1]](diffhunk://#diff-0585913a8694fbbc7190bd27865355416948d2b8115ff59f93bbb9f0c3cf5a58L82-R82) [[2]](diffhunk://#diff-0585913a8694fbbc7190bd27865355416948d2b8115ff59f93bbb9f0c3cf5a58L97-R97) [[3]](diffhunk://#diff-c429365b376b9fefd1e5b363c066e44b761d389a4691659b99274e49cf8713e3L58-R58) [[4]](diffhunk://#diff-c429365b376b9fefd1e5b363c066e44b761d389a4691659b99274e49cf8713e3L75-R75)

**Kernel Interaction Logic Simplification:**
* Reworked the `InteractKernel` classes for both inner and contact relations to use the new viscosity types and simplified their member variables, improving readability and maintainability. [[1]](diffhunk://#diff-ba7c26d6c42e7b42438d500a9e3870728c7d74a4e54eb225a831f4eae3c8af07L85-R89) [[2]](diffhunk://#diff-ba7c26d6c42e7b42438d500a9e3870728c7d74a4e54eb225a831f4eae3c8af07R98-R118) [[3]](diffhunk://#diff-2700a8d53949c455ca8ff54d5af9c99c87b4f37ece119b094992a3a091ceb42fR50-R81) [[4]](diffhunk://#diff-2700a8d53949c455ca8ff54d5af9c99c87b4f37ece119b094992a3a091ceb42fR90-R99)
* Updated the force calculation logic in the interaction kernels to use the new viscosity members and clarified variable usage, such as replacing direct member access with local variables. [[1]](diffhunk://#diff-2700a8d53949c455ca8ff54d5af9c99c87b4f37ece119b094992a3a091ceb42fR50-R81) [[2]](diffhunk://#diff-2700a8d53949c455ca8ff54d5af9c99c87b4f37ece119b094992a3a091ceb42fR90-R99)

**Force Variable Management and Encapsulation:**
* Refactored the `ForcePriorCK` class to encapsulate force variables more cleanly, providing constructors that accept either a force name or a pointer to the current force variable, and a getter for the current force. [[1]](diffhunk://#diff-9ce5848a883d2f2c766071ef80135ed06f7a4c0acf2a5af1e5b5a45899dfe1f6R1-R18) [[2]](diffhunk://#diff-4bdbe54fb1c6c5a99e07c38af597e9df517388c97cf56eb950ed071d03146344R40-R46)
* Updated force registration and variable initialization to use the new encapsulated force variable logic, improving consistency across the codebase. [[1]](diffhunk://#diff-c429365b376b9fefd1e5b363c066e44b761d389a4691659b99274e49cf8713e3L17-R17) [[2]](diffhunk://#diff-2700a8d53949c455ca8ff54d5af9c99c87b4f37ece119b094992a3a091ceb42fL16-R34)

**Minor Structural and Interface Changes:**
* Removed unnecessary inheritance from `ForcePriorCK` in base interaction classes and moved it to the appropriate derived classes, clarifying class responsibilities. [[1]](diffhunk://#diff-ba7c26d6c42e7b42438d500a9e3870728c7d74a4e54eb225a831f4eae3c8af07L49-L76) [[2]](diffhunk://#diff-ba7c26d6c42e7b42438d500a9e3870728c7d74a4e54eb225a831f4eae3c8af07L85-R89)
* Changed the member variable in `PairGeomAverageFixed` from `const T` to `T` to allow for more flexible usage.