### PR TITLE
Fix on return reference on parameter kernel

### DIFF
--- a/src/shared/particle_dynamics/particle_functors.h
+++ b/src/shared/particle_dynamics/particle_functors.h
@@ -107,7 +107,7 @@ class ParameterFixed : public ParticleParameter
 
   public:
     explicit ParameterFixed(const T &c) : ParticleParameter(), parameter_(c) {};
-    T operator()(size_t index_i)
+    T &operator()(size_t index_i)
     {
         return parameter_;
     };
@@ -120,7 +120,7 @@ class ParameterVariable : public ParticleParameter
 
   public:
     explicit ParameterVariable(T *v) : ParticleParameter(), v_(v) {};
-    T operator()(size_t index_i)
+    T &operator()(size_t index_i)
     {
         return v_[index_i];
     };
@@ -142,7 +142,7 @@ class PairAverageFixed : public ParticleAverage
         : ParticleAverage(), average_(0.5 * (c1 + c2)) {};
     explicit PairAverageFixed(const T &c)
         : PairAverageFixed(c, c) {};
-    T operator()(size_t index_i, size_t index_j)
+    T &operator()(size_t index_i, size_t index_j)
     {
         return average_;
     };
@@ -170,7 +170,7 @@ class PairGeomAverageFixed : public GeomAverage
         : GeomAverage(), geom_average_(2.0 * c1 * c2 * inverse(c1 + c2)) {};
     explicit PairGeomAverageFixed(const T &c)
         : PairGeomAverageFixed(c, c) {};
-    T operator()(size_t index_i, size_t index_j)
+    T &operator()(size_t index_i, size_t index_j)
     {
         return geom_average_;
     };

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.hpp
@@ -213,8 +213,8 @@ void AcousticStep1stHalf<Contact<RiemannSolverType, KernelCorrectionType, Parame
         Vecd e_ij = this->e_ij(index_i, index_j);
 
         force -= riemann_solver_.AverageP(
-                     CorrectionDataType(contact_correction_(index_j) * p_[index_i]),
-                     CorrectionDataType(correction_(index_i) * contact_p_[index_j])) *
+                     static_cast<CorrectionDataType>(contact_correction_(index_j) * p_[index_i]),
+                     static_cast<CorrectionDataType>(correction_(index_i) * contact_p_[index_j])) *
                  2.0 * dW_ijV_j * e_ij;
         rho_dissipation += riemann_solver_.DissipativeUJump(p_[index_i] - contact_p_[index_j]) * dW_ijV_j;
     }

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.h
@@ -32,6 +32,7 @@
 #define KERNEL_CORRECTION_CK_H
 
 #include "base_general_dynamics.h"
+#include "interaction_ck.h"
 
 namespace SPH
 {
@@ -135,7 +136,7 @@ using LinearCorrectionMatrixComplex = LinearCorrectionMatrix<Inner<WithUpdate>, 
 class NoKernelCorrectionCK : public KernelCorrection
 {
   public:
-     typedef Real CorrectionDataType;
+    typedef Real CorrectionDataType;
     NoKernelCorrectionCK(BaseParticles *particles) : KernelCorrection() {};
 
     class ComputingKernel : public ParameterFixed<Real>

--- a/src/shared/shared_ck/particle_dynamics/solid_dynamics/solid_constraint.h
+++ b/src/shared/shared_ck/particle_dynamics/solid_dynamics/solid_constraint.h
@@ -48,6 +48,7 @@ class ConstraintBySimBodyCK : public BaseLocalDynamics<DynamicsIdentifier>
                                    SimTK::MobilizedBody &mobod, SimTK::RungeKuttaMersonIntegrator &integ);
     virtual ~ConstraintBySimBodyCK() {};
     virtual void setupDynamics(Real dt = 0.0) override;
+    SingularVariable<SimbodyState> *svSimbodyState() { return sv_simbody_state_; };
 
     class UpdateKernel
     {


### PR DESCRIPTION
This pull request updates several functor classes and fluid dynamics routines to improve type safety and code clarity. The most significant changes involve modifying operator overloads to return references instead of values, ensuring compatibility with code that expects reference semantics. Additionally, some improvements were made to kernel correction handling and SimBody constraint interfaces.

**Functor operator return type changes:**

* Changed the return type of the `operator()` in `ParameterFixed`, `ParameterVariable`, `PairAverageFixed`, and `PairGeomAverageFixed` classes to return a reference (`T&`) instead of a value (`T`). This change increases efficiency and allows modification of the underlying data when necessary. (`src/shared/particle_dynamics/particle_functors.h`) [[1]](diffhunk://#diff-db495a7ba74ab75600df0c8ae0d53291bbe9ad50b614dc626a3e2e7e7d918bd3L110-R110) [[2]](diffhunk://#diff-db495a7ba74ab75600df0c8ae0d53291bbe9ad50b614dc626a3e2e7e7d918bd3L123-R123) [[3]](diffhunk://#diff-db495a7ba74ab75600df0c8ae0d53291bbe9ad50b614dc626a3e2e7e7d918bd3L145-R145) [[4]](diffhunk://#diff-db495a7ba74ab75600df0c8ae0d53291bbe9ad50b614dc626a3e2e7e7d918bd3L173-R173)

**Fluid dynamics and kernel correction improvements:**

* Updated the `AcousticStep1stHalf` routine to use `static_cast` for converting values to `CorrectionDataType`, ensuring type correctness during force calculations. (`src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.hpp`)
* Added an explicit include for `interaction_ck.h` in the kernel correction header to ensure all required dependencies are available. (`src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.h`)

**SimBody constraint interface:**

* Added a getter method `svSimbodyState()` to provide access to the `sv_simbody_state_` member in the `ConstraintBySimBodyCK` class, improving encapsulation and usability. (`src/shared/shared_ck/particle_dynamics/solid_dynamics/solid_constraint.h`)