### PR TITLE
Xiangyu/sync mesh variables

### DIFF
--- a/src/for_2D_build/geometries/multi_polygon_shape.h
+++ b/src/for_2D_build/geometries/multi_polygon_shape.h
@@ -120,11 +120,10 @@ class MultiPolygonShape : public Shape
     virtual bool isValid() override;
     virtual bool checkContain(const Vecd &probe_point, bool BOUNDARY_INCLUDED = true) override;
     virtual Vecd findClosestPoint(const Vecd &probe_point) override;
+    virtual BoundingBox findBounds() override;
 
   protected:
     MultiPolygon multi_polygon_;
-
-    virtual BoundingBox findBounds() override;
 };
 } // namespace SPH
 

--- a/src/for_2D_build/meshes/sparse_storage_mesh/mesh_with_data_packages.hpp
+++ b/src/for_2D_build/meshes/sparse_storage_mesh/mesh_with_data_packages.hpp
@@ -14,19 +14,19 @@ void MeshWithGridDataPackages<PKG_SIZE>::writeMeshVariableToPlt(std::ofstream &o
     output_file << " VARIABLES = " << "x, " << "y";
 
     constexpr int type_index_unsigned = DataTypeIndex<UnsignedInt>::value;
-    for (MeshVariable<UnsignedInt> *variable : std::get<type_index_unsigned>(mesh_variable_to_write_))
+    for (MeshVariable<UnsignedInt> *variable : std::get<type_index_unsigned>(mesh_variables_to_write_))
     {
         output_file << ",\"" << variable->Name() << "\"";
     };
 
     constexpr int type_index_int = DataTypeIndex<int>::value;
-    for (MeshVariable<int> *variable : std::get<type_index_int>(mesh_variable_to_write_))
+    for (MeshVariable<int> *variable : std::get<type_index_int>(mesh_variables_to_write_))
     {
         output_file << ",\"" << variable->Name() << "\"";
     };
 
     constexpr int type_index_Vecd = DataTypeIndex<Vecd>::value;
-    for (MeshVariable<Vecd> *variable : std::get<type_index_Vecd>(mesh_variable_to_write_))
+    for (MeshVariable<Vecd> *variable : std::get<type_index_Vecd>(mesh_variables_to_write_))
     {
         std::string variable_name = variable->Name();
         output_file << ",\"" << variable_name << "_x\""
@@ -34,7 +34,7 @@ void MeshWithGridDataPackages<PKG_SIZE>::writeMeshVariableToPlt(std::ofstream &o
     };
 
     constexpr int type_index_Real = DataTypeIndex<Real>::value;
-    for (MeshVariable<Real> *variable : std::get<type_index_Real>(mesh_variable_to_write_))
+    for (MeshVariable<Real> *variable : std::get<type_index_Real>(mesh_variables_to_write_))
     {
         output_file << ",\"" << variable->Name() << "\"";
     };
@@ -52,25 +52,25 @@ void MeshWithGridDataPackages<PKG_SIZE>::writeMeshVariableToPlt(std::ofstream &o
             Vecd data_position = global_mesh_.GridPositionFromIndex(global_index);
             output_file << data_position[0] << " " << data_position[1] << " ";
 
-            for (MeshVariable<UnsignedInt> *variable : std::get<type_index_unsigned>(mesh_variable_to_write_))
+            for (MeshVariable<UnsignedInt> *variable : std::get<type_index_unsigned>(mesh_variables_to_write_))
             {
                 UnsignedInt value = DataValueFromGlobalIndex(variable->Data(), global_index, this, bmv_cell_pkg_index_.Data());
                 output_file << value << " ";
             };
 
-            for (MeshVariable<int> *variable : std::get<type_index_int>(mesh_variable_to_write_))
+            for (MeshVariable<int> *variable : std::get<type_index_int>(mesh_variables_to_write_))
             {
                 int value = DataValueFromGlobalIndex(variable->Data(), global_index, this, bmv_cell_pkg_index_.Data());
                 output_file << value << " ";
             };
 
-            for (MeshVariable<Vecd> *variable : std::get<type_index_Vecd>(mesh_variable_to_write_))
+            for (MeshVariable<Vecd> *variable : std::get<type_index_Vecd>(mesh_variables_to_write_))
             {
                 Vecd value = DataValueFromGlobalIndex(variable->Data(), global_index, this, bmv_cell_pkg_index_.Data());
                 output_file << value[0] << " " << value[1] << " ";
             };
 
-            for (MeshVariable<Real> *variable : std::get<type_index_Real>(mesh_variable_to_write_))
+            for (MeshVariable<Real> *variable : std::get<type_index_Real>(mesh_variables_to_write_))
             {
                 Real value = DataValueFromGlobalIndex(variable->Data(), global_index, this, bmv_cell_pkg_index_.Data());
                 output_file << value << " ";
@@ -88,19 +88,19 @@ void MeshWithGridDataPackages<PKG_SIZE>::writeBKGMeshVariableToPlt(std::ofstream
     output_file << " VARIABLES = " << "x, " << "y";
 
     constexpr int type_index_unsigned = DataTypeIndex<UnsignedInt>::value;
-    for (DiscreteVariable<UnsignedInt> *variable : std::get<type_index_unsigned>(bkg_mesh_variable_to_write_))
+    for (DiscreteVariable<UnsignedInt> *variable : std::get<type_index_unsigned>(bkg_mesh_variables_to_write_))
     {
         output_file << ",\"" << variable->Name() << "\"";
     };
 
     constexpr int type_index_int = DataTypeIndex<int>::value;
-    for (DiscreteVariable<int> *variable : std::get<type_index_int>(bkg_mesh_variable_to_write_))
+    for (DiscreteVariable<int> *variable : std::get<type_index_int>(bkg_mesh_variables_to_write_))
     {
         output_file << ",\"" << variable->Name() << "\"";
     };
 
     constexpr int type_index_Vecd = DataTypeIndex<Vecd>::value;
-    for (DiscreteVariable<Vecd> *variable : std::get<type_index_Vecd>(bkg_mesh_variable_to_write_))
+    for (DiscreteVariable<Vecd> *variable : std::get<type_index_Vecd>(bkg_mesh_variables_to_write_))
     {
         std::string variable_name = variable->Name();
         output_file << ",\"" << variable_name << "_x\""
@@ -108,7 +108,7 @@ void MeshWithGridDataPackages<PKG_SIZE>::writeBKGMeshVariableToPlt(std::ofstream
     };
 
     constexpr int type_index_Real = DataTypeIndex<Real>::value;
-    for (DiscreteVariable<Real> *variable : std::get<type_index_Real>(bkg_mesh_variable_to_write_))
+    for (DiscreteVariable<Real> *variable : std::get<type_index_Real>(bkg_mesh_variables_to_write_))
     {
         output_file << ",\"" << variable->Name() << "\"";
     };
@@ -127,25 +127,25 @@ void MeshWithGridDataPackages<PKG_SIZE>::writeBKGMeshVariableToPlt(std::ofstream
             Vecd data_position = CellPositionFromIndex(cell_index);
             output_file << data_position[0] << " " << data_position[1] << " ";
 
-            for (DiscreteVariable<UnsignedInt> *variable : std::get<type_index_unsigned>(bkg_mesh_variable_to_write_))
+            for (DiscreteVariable<UnsignedInt> *variable : std::get<type_index_unsigned>(bkg_mesh_variables_to_write_))
             {
                 UnsignedInt value = variable->Data()[linear_index];
                 output_file << value << " ";
             };
 
-            for (DiscreteVariable<int> *variable : std::get<type_index_int>(bkg_mesh_variable_to_write_))
+            for (DiscreteVariable<int> *variable : std::get<type_index_int>(bkg_mesh_variables_to_write_))
             {
                 int value = variable->Data()[linear_index];
                 output_file << value << " ";
             };
 
-            for (DiscreteVariable<Vecd> *variable : std::get<type_index_Vecd>(bkg_mesh_variable_to_write_))
+            for (DiscreteVariable<Vecd> *variable : std::get<type_index_Vecd>(bkg_mesh_variables_to_write_))
             {
                 Vecd value = variable->Data()[linear_index];
                 output_file << value[0] << " " << value[1] << " ";
             };
 
-            for (DiscreteVariable<Real> *variable : std::get<type_index_Real>(bkg_mesh_variable_to_write_))
+            for (DiscreteVariable<Real> *variable : std::get<type_index_Real>(bkg_mesh_variables_to_write_))
             {
                 Real value = variable->Data()[linear_index];
                 output_file << value << " ";

--- a/src/for_3D_build/geometries/image_shape.h
+++ b/src/for_3D_build/geometries/image_shape.h
@@ -51,15 +51,14 @@ class ImageShape : public Shape
 
     virtual bool checkContain(const Vecd &probe_point, bool BOUNDARY_INCLUDED = true) override;
     virtual Vecd findClosestPoint(const Vecd &probe_point) override;
-
+    virtual BoundingBox findBounds() override;
+    
   protected:
     Vecd translation_;
     Matd rotation_;
     std::unique_ptr<ImageMHD<float, 3>> image_;
     Real max_distance_;
     Real min_distance_;
-
-    virtual BoundingBox findBounds() override;
 };
 
 class ImageShapeFromFile : public ImageShape

--- a/src/for_3D_build/geometries/triangle_mesh_shape.h
+++ b/src/for_3D_build/geometries/triangle_mesh_shape.h
@@ -56,6 +56,7 @@ class TriangleMeshShape : public Shape
      * when probe distance is far from the surface. */
     virtual bool checkContain(const Vec3d &probe_point, bool BOUNDARY_INCLUDED = true) override;
     virtual Vec3d findClosestPoint(const Vec3d &probe_point) override;
+    virtual BoundingBox findBounds() override;
     StdVec<std::array<Real, 3>> &getVertices() { return vertices_; }
     StdVec<std::array<int, 3>> &getFaces() { return faces_; }
 
@@ -65,7 +66,6 @@ class TriangleMeshShape : public Shape
     tmd::TriangleMeshDistance triangle_mesh_distance_;
     void initializeFromPolygonalMesh(const SimTK::PolygonalMesh &poly_mesh);
     void initializeFromSTLMesh(const std::string &file_path_name, Vec3d translation, Real scale_factor);
-    virtual BoundingBox findBounds() override;
 };
 
 /**

--- a/src/for_3D_build/mesh_dynamics/mesh_local_dynamics.hpp
+++ b/src/for_3D_build/mesh_dynamics/mesh_local_dynamics.hpp
@@ -270,9 +270,8 @@ inline void ReinitializeLevelSet::UpdateKernel::update(const UnsignedInt &packag
         });
 }
 //=============================================================================================//
-inline void MarkNearInterface::UpdateKernel::update(const UnsignedInt &package_index, Real small_shift_factor)
+inline void MarkCutInterfaces::UpdateKernel::update(const UnsignedInt &package_index, Real dt)
 {
-    Real small_shift = data_spacing_ * small_shift_factor;
     auto &phi_addrs = phi_[package_index];
     auto &near_interface_id_addrs = near_interface_id_[package_index];
 
@@ -291,7 +290,7 @@ inline void MarkNearInterface::UpdateKernel::update(const UnsignedInt &package_i
             // first assume far cells
             Real phi_0 = phi_addrs[i][j][k];
             int near_interface_id = phi_0 > 0.0 ? 2 : -2;
-            if (fabs(phi_0) < small_shift)
+            if (fabs(phi_0) < perturbation_)
             {
                 near_interface_id = 0;
                 Real phi_average_0 = corner_averages[i][j][k];
@@ -300,9 +299,9 @@ inline void MarkNearInterface::UpdateKernel::update(const UnsignedInt &package_i
                     [&](int l, int m, int n)
                     {
                         Real phi_average = corner_averages[i + l][j + m][k + n];
-                        if ((phi_average_0 - small_shift) * (phi_average - small_shift) < 0.0)
+                        if ((phi_average_0 - perturbation_) * (phi_average - perturbation_) < 0.0)
                             near_interface_id = 1;
-                        if ((phi_average_0 + small_shift) * (phi_average + small_shift) < 0.0)
+                        if ((phi_average_0 + perturbation_) * (phi_average + perturbation_) < 0.0)
                             near_interface_id = -1;
                     });
                 // find zero cut cells
@@ -316,6 +315,43 @@ inline void MarkNearInterface::UpdateKernel::update(const UnsignedInt &package_i
             }
             // assign this is to package
             near_interface_id_addrs[i][j][k] = near_interface_id;
+        });
+}
+//=============================================================================================//
+inline void MarkNearInterface::UpdateKernel::update(const UnsignedInt &package_index, Real dt)
+{
+    mesh_for_each3d<0, pkg_size>(
+        [&](int i, int j, int k)
+        {
+            near_interface_id_[package_index][i][j][k] = 3; // undetermined
+            Real phi0 = phi_[package_index][i][j][k];
+            if (ABS(phi0) < 2.0 * threshold_) // only consider data close to the interface
+            {
+                bool is_sign_changed = mesh_any_of3d<-1, 2>( // check in the 3x3x3 neighborhood
+                    [&](int l, int m, int n) -> bool
+                    {
+                        PackageGridPair neighbour_index = NeighbourIndexShift<pkg_size>(
+                            Arrayi(i + l, j + m, k + n), cell_neighborhood_[package_index]);
+
+                        return phi0 * phi_[neighbour_index.first]
+                                          [neighbour_index.second[0]]
+                                          [neighbour_index.second[1]]
+                                          [neighbour_index.second[2]] <
+                               0.0;
+                    });
+
+                if (is_sign_changed)
+                {
+                    if (ABS(phi0) < threshold_)
+                    {
+                        near_interface_id_[package_index][i][j][k] = 0; // cut cell
+                    }
+                }
+                else
+                {
+                    near_interface_id_[package_index][i][j][k] = phi0 > 0.0 ? 1 : -1; // in the band
+                }
+            }
         });
 }
 //=============================================================================================//
@@ -418,27 +454,41 @@ inline void DiffuseLevelSetSign::UpdateKernel::update(const UnsignedInt &package
     mesh_for_each3d<0, pkg_size>(
         [&](int i, int j, int k)
         {
-            // near interface cells are not considered
-            if (abs(near_interface_id_[package_index][i][j][k]) > 1)
+            if (near_interface_id_[package_index][i][j][k] == 3) // check undetermined only
             {
-                mesh_find_if3d<-1, 2>(
-                    [&](int l, int m, int n) -> bool
-                    {
-                        PackageGridPair neighbour_index = NeighbourIndexShift<pkg_size>(
-                            Arrayi(i + l, j + m, k + n), cell_neighborhood_[package_index]);
-                        int near_interface_id = near_interface_id_[neighbour_index.first]
-                                                                  [neighbour_index.second[0]]
-                                                                  [neighbour_index.second[1]]
-                                                                  [neighbour_index.second[2]];
-                        bool is_found = abs(near_interface_id) == 1;
-                        if (is_found)
+                Real phi = phi_[package_index][i][j][k];
+                if (mesh_any_of3d<-1, 2>(
+                        [&](int l, int m, int n) -> bool
                         {
-                            Real phi_0 = phi_[package_index][i][j][k];
-                            near_interface_id_[package_index][i][j][k] = near_interface_id;
-                            phi_[package_index][i][j][k] = near_interface_id == 1 ? fabs(phi_0) : -fabs(phi_0);
-                        }
-                        return is_found;
-                    });
+                            PackageGridPair neighbour_index = NeighbourIndexShift<pkg_size>(
+                                Arrayi(i + l, j + m, k + n), cell_neighborhood_[package_index]);
+                            return near_interface_id_[neighbour_index.first]
+                                                     [neighbour_index.second[0]]
+                                                     [neighbour_index.second[1]]
+                                                     [neighbour_index.second[2]] == 1;
+                        }))
+                {
+                    phi_[package_index][i][j][k] = ABS(phi);
+                    near_interface_id_[package_index][i][j][k] = 1; // mark as positive band
+                    AtomicRef<UnsignedInt> count_modified_data(*count_modified_);
+                    ++count_modified_data;
+                }
+                else if (mesh_any_of3d<-1, 2>(
+                             [&](int l, int m, int n) -> bool
+                             {
+                                 PackageGridPair neighbour_index = NeighbourIndexShift<pkg_size>(
+                                     Arrayi(i + l, j + m, k + n), cell_neighborhood_[package_index]);
+                                 return near_interface_id_[neighbour_index.first]
+                                                          [neighbour_index.second[0]]
+                                                          [neighbour_index.second[1]]
+                                                          [neighbour_index.second[2]] == -1;
+                             }))
+                {
+                    phi_[package_index][i][j][k] = -ABS(phi);
+                    near_interface_id_[package_index][i][j][k] = -1; // mark as negative band
+                    AtomicRef<UnsignedInt> count_modified_data(*count_modified_);
+                    ++count_modified_data;
+                }
             }
         });
 }

--- a/src/for_3D_build/meshes/sparse_storage_mesh/mesh_with_data_packages.hpp
+++ b/src/for_3D_build/meshes/sparse_storage_mesh/mesh_with_data_packages.hpp
@@ -29,13 +29,13 @@ void MeshWithGridDataPackages<PKG_SIZE>::writeMeshVariableToPlt(std::ofstream &o
     output_file << " VARIABLES = " << "x, " << "y, " << "z";
 
     constexpr int type_index_int = DataTypeIndex<int>::value;
-    for (MeshVariable<int> *variable : std::get<type_index_int>(mesh_variable_to_write_))
+    for (MeshVariable<int> *variable : std::get<type_index_int>(mesh_variables_to_write_))
     {
         output_file << ",\"" << variable->Name() << "\"";
     };
 
     constexpr int type_index_Vecd = DataTypeIndex<Vec3d>::value;
-    for (MeshVariable<Vec3d> *variable : std::get<type_index_Vecd>(mesh_variable_to_write_))
+    for (MeshVariable<Vec3d> *variable : std::get<type_index_Vecd>(mesh_variables_to_write_))
     {
         std::string variable_name = variable->Name();
         output_file << ",\"" << variable_name << "_x\""
@@ -44,7 +44,7 @@ void MeshWithGridDataPackages<PKG_SIZE>::writeMeshVariableToPlt(std::ofstream &o
     };
 
     constexpr int type_index_Real = DataTypeIndex<Real>::value;
-    for (MeshVariable<Real> *variable : std::get<type_index_Real>(mesh_variable_to_write_))
+    for (MeshVariable<Real> *variable : std::get<type_index_Real>(mesh_variables_to_write_))
     {
         output_file << ",\"" << variable->Name() << "\"";
     };
@@ -74,21 +74,21 @@ void MeshWithGridDataPackages<PKG_SIZE>::writeMeshVariableToPlt(std::ofstream &o
                 output_file << data_position[0] << " " << data_position[1] << " " << data_position[2] << " ";
 
                 constexpr int type_index_int = DataTypeIndex<int>::value;
-                for (MeshVariable<int> *variable : std::get<type_index_int>(mesh_variable_to_write_))
+                for (MeshVariable<int> *variable : std::get<type_index_int>(mesh_variables_to_write_))
                 {
                     int value = DataValueFromGlobalIndex(variable->Data(), global_index, this, bmv_cell_pkg_index_.Data());
                     output_file << value << " ";
                 };
 
                 constexpr int type_index_Vecd = DataTypeIndex<Vec3d>::value;
-                for (MeshVariable<Vec3d> *variable : std::get<type_index_Vecd>(mesh_variable_to_write_))
+                for (MeshVariable<Vec3d> *variable : std::get<type_index_Vecd>(mesh_variables_to_write_))
                 {
                     Vec3d value = DataValueFromGlobalIndex(variable->Data(), global_index, this, bmv_cell_pkg_index_.Data());
                     output_file << value[0] << " " << value[1] << " " << value[2] << " ";
                 };
 
                 constexpr int type_index_Real = DataTypeIndex<Real>::value;
-                for (MeshVariable<Real> *variable : std::get<type_index_Real>(mesh_variable_to_write_))
+                for (MeshVariable<Real> *variable : std::get<type_index_Real>(mesh_variables_to_write_))
                 {
                     Real value = DataValueFromGlobalIndex(variable->Data(), global_index, this, bmv_cell_pkg_index_.Data());
                     output_file << value << " ";
@@ -107,19 +107,19 @@ void MeshWithGridDataPackages<PKG_SIZE>::writeBKGMeshVariableToPlt(std::ofstream
     output_file << " VARIABLES = " << "x, " << "y, " << "z";
 
     constexpr int type_index_unsigned = DataTypeIndex<UnsignedInt>::value;
-    for (DiscreteVariable<UnsignedInt> *variable : std::get<type_index_unsigned>(bkg_mesh_variable_to_write_))
+    for (DiscreteVariable<UnsignedInt> *variable : std::get<type_index_unsigned>(bkg_mesh_variables_to_write_))
     {
         output_file << ",\"" << variable->Name() << "\"";
     };
 
     constexpr int type_index_int = DataTypeIndex<int>::value;
-    for (DiscreteVariable<int> *variable : std::get<type_index_int>(bkg_mesh_variable_to_write_))
+    for (DiscreteVariable<int> *variable : std::get<type_index_int>(bkg_mesh_variables_to_write_))
     {
         output_file << ",\"" << variable->Name() << "\"";
     };
 
     constexpr int type_index_Vecd = DataTypeIndex<Vecd>::value;
-    for (DiscreteVariable<Vecd> *variable : std::get<type_index_Vecd>(bkg_mesh_variable_to_write_))
+    for (DiscreteVariable<Vecd> *variable : std::get<type_index_Vecd>(bkg_mesh_variables_to_write_))
     {
         std::string variable_name = variable->Name();
         output_file << ",\"" << variable_name << "_x\""
@@ -128,7 +128,7 @@ void MeshWithGridDataPackages<PKG_SIZE>::writeBKGMeshVariableToPlt(std::ofstream
     };
 
     constexpr int type_index_Real = DataTypeIndex<Real>::value;
-    for (DiscreteVariable<Real> *variable : std::get<type_index_Real>(bkg_mesh_variable_to_write_))
+    for (DiscreteVariable<Real> *variable : std::get<type_index_Real>(bkg_mesh_variables_to_write_))
     {
         output_file << ",\"" << variable->Name() << "\"";
     };
@@ -147,25 +147,25 @@ void MeshWithGridDataPackages<PKG_SIZE>::writeBKGMeshVariableToPlt(std::ofstream
             Vecd data_position = CellPositionFromIndex(cell_index);
             output_file << data_position[0] << " " << data_position[1] << " " << data_position[2] << " ";
 
-            for (DiscreteVariable<UnsignedInt> *variable : std::get<type_index_unsigned>(bkg_mesh_variable_to_write_))
+            for (DiscreteVariable<UnsignedInt> *variable : std::get<type_index_unsigned>(bkg_mesh_variables_to_write_))
             {
                 UnsignedInt value = variable->Data()[linear_index];
                 output_file << value << " ";
             };
 
-            for (DiscreteVariable<int> *variable : std::get<type_index_int>(bkg_mesh_variable_to_write_))
+            for (DiscreteVariable<int> *variable : std::get<type_index_int>(bkg_mesh_variables_to_write_))
             {
                 int value = variable->Data()[linear_index];
                 output_file << value << " ";
             };
 
-            for (DiscreteVariable<Vecd> *variable : std::get<type_index_Vecd>(bkg_mesh_variable_to_write_))
+            for (DiscreteVariable<Vecd> *variable : std::get<type_index_Vecd>(bkg_mesh_variables_to_write_))
             {
                 Vecd value = variable->Data()[linear_index];
                 output_file << value[0] << " " << value[1] << " " << value[2] << " ";
             };
 
-            for (DiscreteVariable<Real> *variable : std::get<type_index_Real>(bkg_mesh_variable_to_write_))
+            for (DiscreteVariable<Real> *variable : std::get<type_index_Real>(bkg_mesh_variables_to_write_))
             {
                 Real value = variable->Data()[linear_index];
                 output_file << value << " ";

--- a/src/shared/adaptations/adaptation.cpp
+++ b/src/shared/adaptations/adaptation.cpp
@@ -159,7 +159,7 @@ UniquePtr<BaseCellLinkedList> ParticleWithLocalRefinement::
 UniquePtr<MultilevelLevelSet> ParticleWithLocalRefinement::createLevelSet(Shape &shape, Real refinement_ratio)
 {
     return makeUnique<MultilevelLevelSet>(shape.getBounds(), ReferenceSpacing() / refinement_ratio,
-                                          getLevelSetTotalLevel(), shape, *this);
+                                          getLevelSetTotalLevel(), shape, *this, refinement_ratio);
 }
 //=================================================================================================//
 Real ParticleRefinementByShape::smoothedSpacing(const Real &measure, const Real &transition_thickness)

--- a/src/shared/geometries/base_geometry.h
+++ b/src/shared/geometries/base_geometry.h
@@ -83,13 +83,12 @@ class Shape
     Real findSignedDistance(const Vecd &probe_point);
     /** Normal direction point toward outside of the shape. */
     Vecd findNormalDirection(const Vecd &probe_point);
+    virtual BoundingBox findBounds() = 0;
 
   protected:
     std::string name_;
     bool is_bounds_found_;
     std::shared_ptr<spdlog::logger> logger_;
-
-    virtual BoundingBox findBounds() = 0;
 };
 
 using SubShapeAndOp = std::pair<Shape *, ShapeBooleanOps>;
@@ -136,6 +135,7 @@ class BinaryShapes : public Shape
     virtual bool isValid() override;
     virtual bool checkContain(const Vecd &pnt, bool BOUNDARY_INCLUDED = true) override;
     virtual Vecd findClosestPoint(const Vecd &probe_point) override;
+    virtual BoundingBox findBounds() override;
     Shape *getSubShapeByName(const std::string &name);
     SubShapeAndOp *getSubShapeAndOpByName(const std::string &name);
     size_t getSubShapeIndexByName(const std::string &name);
@@ -143,8 +143,6 @@ class BinaryShapes : public Shape
   protected:
     UniquePtrsKeeper<Shape> sub_shape_ptrs_keeper_;
     StdVec<SubShapeAndOp> sub_shapes_and_ops_;
-
-    virtual BoundingBox findBounds() override;
 };
 
 /**

--- a/src/shared/geometries/level_set.cpp
+++ b/src/shared/geometries/level_set.cpp
@@ -95,14 +95,17 @@ size_t MultilevelLevelSet::getCoarseLevel(Real h_ratio)
     return 999; // means an error in level searching
 };
 //=================================================================================================//
-void MultilevelLevelSet::cleanInterface(Real small_shift_factor)
+void MultilevelLevelSet::cleanInterface(UnsignedInt repeat_times)
 {
-    clean_interface_keeper_->exec(small_shift_factor);
+    DynamicCast<RepeatTimes>(this, *clean_interface_keeper_.get())(repeat_times);
+    clean_interface_keeper_->exec();
+    sync_mesh_variables_to_probe_();
 }
 //=============================================================================================//
-void MultilevelLevelSet::correctTopology(Real small_shift_factor)
+void MultilevelLevelSet::correctTopology()
 {
-    correct_topology_keeper_->exec(small_shift_factor);
+    correct_topology_keeper_->exec();
+    sync_mesh_variables_to_probe_();
 }
 //=============================================================================================//
 Real MultilevelLevelSet::probeSignedDistance(const Vecd &position)
@@ -196,8 +199,7 @@ bool MultilevelLevelSet::probeIsWithinMeshBound(const Vecd &position)
 //=================================================================================================//
 void MultilevelLevelSet::writeMeshFieldToPlt(const std::string &partial_file_name)
 {
-    sync_mesh_variable_data_();
-    resetProbes();
+    sync_mesh_variables_to_write_();
     for (size_t l = 0; l != total_levels_; ++l)
     {
         std::string full_file_name = partial_file_name + "_" + std::to_string(l) + ".dat";
@@ -209,6 +211,7 @@ void MultilevelLevelSet::writeMeshFieldToPlt(const std::string &partial_file_nam
 //=================================================================================================//
 void MultilevelLevelSet::writeBKGMeshToPlt(const std::string &partial_file_name)
 {
+    sync_bkg_mesh_variables_to_write_();
     for (size_t l = 0; l != total_levels_; ++l)
     {
         std::string full_file_name = partial_file_name + "_" + std::to_string(l) + ".dat";

--- a/src/shared/geometries/level_set.h
+++ b/src/shared/geometries/level_set.h
@@ -68,8 +68,8 @@ class MultilevelLevelSet : public BaseMeshField
 
     template <class ExecutionPolicy>
     void finishInitialization(const ExecutionPolicy &ex_policy, UsageType usage_type);
-    void cleanInterface(Real small_shift_factor);
-    void correctTopology(Real small_shift_factor);
+    void cleanInterface(UnsignedInt repeat_times);
+    void correctTopology();
     bool probeIsWithinMeshBound(const Vecd &position);
     Real probeSignedDistance(const Vecd &position);
     Vecd probeNormalDirection(const Vecd &position);
@@ -85,33 +85,12 @@ class MultilevelLevelSet : public BaseMeshField
     template <typename DataType>
     void addBKGMeshVariableToWrite(const std::string &variable_name);
     void writeBKGMeshToPlt(const std::string &partial_file_name) override;
-
     template <class ExecutionPolicy>
-    void syncMeshVariableData(ExecutionPolicy &ex_policy)
-    {
-        for (size_t l = 0; l != total_levels_; l++)
-            mesh_data_set_[l]->syncMeshVariableData(ex_policy);
-    }
-
-    void resetProbes()
-    {
-        probe_signed_distance_set_.clear();
-        probe_normal_direction_set_.clear();
-        probe_level_set_gradient_set_.clear();
-        probe_kernel_integral_set_.clear();
-        probe_kernel_gradient_integral_set_.clear();
-        probe_kernel_second_gradient_integral_set_.clear();
-        cell_pkg_index_set_.clear();
-        pkg_cell_info_set_.clear();
-        for (size_t l = 0; l != total_levels_; l++)
-        {
-            registerProbes(execution::par_host, l);
-            cell_pkg_index_set_.push_back(
-                mesh_data_set_[l]->getCellPackageIndex().DelegatedData(execution::par_host));
-            pkg_cell_info_set_.push_back(
-                mesh_data_set_[l]->dvPkgCellInfo().DelegatedData(execution::par_host));
-        }
-    }
+    void syncMeshVariablesToWrite(ExecutionPolicy &ex_policy);
+    template <class ExecutionPolicy>
+    void syncBKGMeshVariablesToWrite(ExecutionPolicy &ex_policy);
+    template <class ExecutionPolicy>
+    void syncMeshVariablesToProbe(ExecutionPolicy &ex_policy);
 
   protected:
     inline size_t getProbeLevel(const Vecd &position);
@@ -124,7 +103,9 @@ class MultilevelLevelSet : public BaseMeshField
     template <class ExecutionPolicy>
     void initializeKernelIntegralVariables(const ExecutionPolicy &ex_policy);
     template <class ExecutionPolicy>
-    void registerProbes(const ExecutionPolicy &ex_policy, size_t level);
+    void registerProbes(const ExecutionPolicy &ex_policy);
+    template <class ExecutionPolicy>
+    void registerKernelIntegralProbes(const ExecutionPolicy &ex_policy);
 
     Shape &shape_;        /**< the geometry is described by the level set. */
     size_t total_levels_; /**< level 0 is the coarsest */
@@ -150,7 +131,7 @@ class MultilevelLevelSet : public BaseMeshField
     UniquePtr<BaseDynamics<void>> correct_topology_keeper_;
     UniquePtr<BaseDynamics<void>> clean_interface_keeper_;
     UniquePtrsKeeper<NeighborMethod<SingleValued>> neighbor_method_keeper_;
-    std::function<void()> sync_mesh_variable_data_;
+    std::function<void()> sync_mesh_variables_to_write_, sync_bkg_mesh_variables_to_write_, sync_mesh_variables_to_probe_;
 
     template <class ExecutionPolicy>
     void configLevelSetPostProcesses(const ExecutionPolicy &ex_policy);

--- a/src/shared/geometries/level_set.hpp
+++ b/src/shared/geometries/level_set.hpp
@@ -23,26 +23,53 @@ void MultilevelLevelSet::initializeMeshVariables(const ExecutionPolicy &ex_polic
         MeshInnerDynamics<ExecutionPolicy, UpdateLevelSetGradient>
             update_level_set_gradient{*mesh_data_set_[level]};
         update_level_set_gradient.exec();
-
-        registerProbes(ex_policy, level);
-        cell_pkg_index_set_.push_back(
-            mesh_data_set_[level]->getCellPackageIndex().DelegatedData(ex_policy));
-        pkg_cell_info_set_.push_back(
-            mesh_data_set_[level]->dvPkgCellInfo().DelegatedData(ex_policy));
     }
+}
+//=================================================================================================//
+template <class ExecutionPolicy>
+void MultilevelLevelSet::syncMeshVariablesToWrite(ExecutionPolicy &ex_policy)
+{
+    for (size_t l = 0; l != total_levels_; l++)
+        mesh_data_set_[l]->syncMeshVariablesToWrite(ex_policy);
+}
+//=================================================================================================//
+template <class ExecutionPolicy>
+void MultilevelLevelSet::syncBKGMeshVariablesToWrite(ExecutionPolicy &ex_policy)
+{
+    for (size_t l = 0; l != total_levels_; l++)
+        mesh_data_set_[l]->syncBKGMeshVariablesToWrite(ex_policy);
+}
+//=================================================================================================//
+template <class ExecutionPolicy>
+void MultilevelLevelSet::syncMeshVariablesToProbe(ExecutionPolicy &ex_policy)
+{
+    for (size_t l = 0; l != total_levels_; l++)
+        mesh_data_set_[l]->syncMeshVariablesToProbe(ex_policy);
 }
 //=================================================================================================//
 template <class ExecutionPolicy>
 void MultilevelLevelSet::finishInitialization(const ExecutionPolicy &ex_policy, UsageType usage_type)
 {
     initializeMeshVariables(ex_policy);
+    registerProbes(execution::par_host); // register probes on host
+
     if (usage_type == UsageType::Volumetric)
     {
         initializeKernelIntegralVariables(ex_policy);
+        registerKernelIntegralProbes(execution::par_host); // register probes on host
         configLevelSetPostProcesses(ex_policy);
     }
-    sync_mesh_variable_data_ = [&]()
-    { this->syncMeshVariableData(ex_policy); };
+
+    sync_mesh_variables_to_write_ = [&]() // for latter usage
+    { this->syncMeshVariablesToWrite(ex_policy); };
+
+    sync_bkg_mesh_variables_to_write_ = [&]() // for latter usage
+    { this->syncBKGMeshVariablesToWrite(ex_policy); };
+
+    sync_mesh_variables_to_probe_ = [&]() // for latter usage
+    { this->syncMeshVariablesToProbe(ex_policy); };
+
+    this->syncMeshVariablesToProbe(ex_policy);
 }
 //=================================================================================================//
 template <class ExecutionPolicy>
@@ -53,16 +80,6 @@ void MultilevelLevelSet::initializeKernelIntegralVariables(const ExecutionPolicy
         MeshInnerDynamics<ExecutionPolicy, UpdateKernelIntegrals>
             update_kernel_integrals{*mesh_data_set_[level], *neighbor_method_set_[level]};
         update_kernel_integrals.exec();
-
-        probe_kernel_integral_set_.push_back(
-            probe_kernel_integral_vector_keeper_
-                .template createPtr<ProbeKernelIntegral>(ex_policy, mesh_data_set_[level]));
-        probe_kernel_gradient_integral_set_.push_back(
-            probe_kernel_gradient_integral_vector_keeper_
-                .template createPtr<ProbeKernelGradientIntegral>(ex_policy, mesh_data_set_[level]));
-        probe_kernel_second_gradient_integral_set_.push_back(
-            probe_kernel_second_gradient_integral_vector_keeper_
-                .template createPtr<ProbeKernelSecondGradientIntegral>(ex_policy, mesh_data_set_[level]));
     }
 }
 //=================================================================================================//
@@ -85,17 +102,46 @@ ProbeKernelGradientIntegral MultilevelLevelSet::getProbeKernelGradientIntegral(c
 }
 //=================================================================================================//
 template <class ExecutionPolicy>
-void MultilevelLevelSet::registerProbes(const ExecutionPolicy &ex_policy, size_t level)
+void MultilevelLevelSet::registerProbes(const ExecutionPolicy &ex_policy)
 {
-    probe_signed_distance_set_.push_back(
-        probe_signed_distance_vector_keeper_
-            .template createPtr<ProbeSignedDistance>(ex_policy, mesh_data_set_[level]));
-    probe_normal_direction_set_.push_back(
-        probe_normal_direction_vector_keeper_
-            .template createPtr<ProbeNormalDirection>(ex_policy, mesh_data_set_[level]));
-    probe_level_set_gradient_set_.push_back(
-        probe_level_set_gradient_vector_keeper_
-            .template createPtr<ProbeLevelSetGradient>(ex_policy, mesh_data_set_[level]));
+    for (size_t level = 0; level < total_levels_; level++)
+    {
+        probe_signed_distance_set_.push_back(
+            probe_signed_distance_vector_keeper_
+                .template createPtr<ProbeSignedDistance>(ex_policy, mesh_data_set_[level]));
+        probe_normal_direction_set_.push_back(
+            probe_normal_direction_vector_keeper_
+                .template createPtr<ProbeNormalDirection>(ex_policy, mesh_data_set_[level]));
+        probe_level_set_gradient_set_.push_back(
+            probe_level_set_gradient_vector_keeper_
+                .template createPtr<ProbeLevelSetGradient>(ex_policy, mesh_data_set_[level]));
+
+        mesh_data_set_[level]->addMeshVariableToProbe<Real>("LevelSet");
+        mesh_data_set_[level]->addMeshVariableToProbe<Vecd>("LevelSetGradient"); // shared with normal direction
+
+        cell_pkg_index_set_.push_back(mesh_data_set_[level]->getCellPackageIndex().DelegatedData(ex_policy));
+        pkg_cell_info_set_.push_back(mesh_data_set_[level]->dvPkgCellInfo().DelegatedData(ex_policy));
+    }
+}
+//=================================================================================================//
+template <class ExecutionPolicy>
+void MultilevelLevelSet::registerKernelIntegralProbes(const ExecutionPolicy &ex_policy)
+{
+    for (size_t level = 0; level < total_levels_; level++)
+    {
+        probe_kernel_integral_set_.push_back(
+            probe_kernel_integral_vector_keeper_
+                .template createPtr<ProbeKernelIntegral>(ex_policy, mesh_data_set_[level]));
+        probe_kernel_gradient_integral_set_.push_back(
+            probe_kernel_gradient_integral_vector_keeper_
+                .template createPtr<ProbeKernelGradientIntegral>(ex_policy, mesh_data_set_[level]));
+        probe_kernel_second_gradient_integral_set_.push_back(
+            probe_kernel_second_gradient_integral_vector_keeper_
+                .template createPtr<ProbeKernelSecondGradientIntegral>(ex_policy, mesh_data_set_[level]));
+        mesh_data_set_[level]->addMeshVariableToProbe<Real>("KernelWeight");
+        mesh_data_set_[level]->addMeshVariableToProbe<Vecd>("KernelGradient");
+        mesh_data_set_[level]->addMeshVariableToProbe<Matd>("KernelSecondGradient");
+    }
 }
 //=================================================================================================//
 template <typename DataType>
@@ -117,5 +163,4 @@ void MultilevelLevelSet::addBKGMeshVariableToWrite(const std::string &variable_n
 }
 //=================================================================================================//
 } // namespace SPH
-
 #endif

--- a/src/shared/geometries/level_set_shape.cpp
+++ b/src/shared/geometries/level_set_shape.cpp
@@ -55,15 +55,15 @@ LevelSetShape *LevelSetShape::writeBKGMesh(SPHSystem &sph_system)
     return this;
 }
 //=================================================================================================//
-LevelSetShape *LevelSetShape::cleanLevelSet(Real small_shift_factor)
+LevelSetShape *LevelSetShape::cleanLevelSet(UnsignedInt repeat_times)
 {
-    level_set_.cleanInterface(small_shift_factor);
+    level_set_.cleanInterface(repeat_times);
     return this;
 }
 //=================================================================================================//
-LevelSetShape *LevelSetShape::correctLevelSetSign(Real small_shift_factor)
+LevelSetShape *LevelSetShape::correctLevelSetSign()
 {
-    level_set_.correctTopology(small_shift_factor);
+    level_set_.correctTopology();
     return this;
 }
 //=================================================================================================//

--- a/src/shared/geometries/level_set_shape.h
+++ b/src/shared/geometries/level_set_shape.h
@@ -75,6 +75,7 @@ class LevelSetShape : public Shape
 
     virtual bool checkContain(const Vecd &probe_point, bool BOUNDARY_INCLUDED = true) override;
     virtual Vecd findClosestPoint(const Vecd &probe_point) override;
+    virtual BoundingBox findBounds() override;
 
     template <class ExecutionPolicy>
     void finishInitialization(const ExecutionPolicy &ex_policy, UsageType usage_type)
@@ -86,9 +87,9 @@ class LevelSetShape : public Shape
     Vecd computeKernelGradientIntegral(const Vecd &probe_point, Real h_ratio = 1.0);
     Matd computeKernelSecondGradientIntegral(const Vecd &probe_point, Real h_ratio = 1.0);
     /** small_shift_factor = 1.0 by default, can be increased for difficult geometries for smoothing */
-    LevelSetShape *cleanLevelSet(Real small_shift_factor = 1.0);
+    LevelSetShape *cleanLevelSet(UnsignedInt repeat_times = 1);
     /** required to build level set from triangular mesh in stl file format. */
-    LevelSetShape *correctLevelSetSign(Real small_shift_factor = 1.0);
+    LevelSetShape *correctLevelSetSign();
     LevelSetShape *writeLevelSet(SPHSystem &sph_system);
     LevelSetShape *writeBKGMesh(SPHSystem &sph_system);
     MultilevelLevelSet &getLevelSet() { return level_set_; }
@@ -112,7 +113,6 @@ class LevelSetShape : public Shape
                   SharedPtr<SPHAdaptation> sph_adaptation, Real refinement_ratio);
     LevelSetShape(BoundingBox bounding_box, SPHBody &sph_body, Shape &shape, Real refinement_ratio);
     MultilevelLevelSet &level_set_; /**< narrow bounded level set mesh. */
-    virtual BoundingBox findBounds() override;
 };
 } // namespace SPH
 #endif // LEVEL_SET_SHAPE_H

--- a/src/shared/geometries/transform_geometry.h
+++ b/src/shared/geometries/transform_geometry.h
@@ -93,7 +93,6 @@ class TransformShape : public TransformGeometry<GeometryType>, public Shape
         return TransformGeometry<GeometryType>::findClosestPoint(probe_point);
     };
 
-  protected:
     // Returns the AABB of the rotated underlying shape's AABB
     // It is not the tight fit AABB of the underlying shape
     // But at least it encloses the underlying shape fully

--- a/src/shared/mesh_dynamics/all_mesh_dynamics.h
+++ b/src/shared/mesh_dynamics/all_mesh_dynamics.h
@@ -60,7 +60,7 @@ class FinishDataPackages
   private:
     MeshWithGridDataPackagesType &mesh_data_;
     Shape &shape_;
-    SingularVariable<UnsignedInt> sv_count_modified_{"CountModified", 1};
+    SingularVariable<UnsignedInt> sv_count_modified_{"CountModifiedCell", 1};
 
     MeshInnerDynamics<execution::ParallelPolicy, InitializeCellNeighborhood> initialize_cell_neighborhood{mesh_data_};
     MeshInnerDynamics<execution::ParallelPolicy, InitializeBasicPackageData> initialize_basic_data_for_a_package{mesh_data_, shape_};
@@ -68,21 +68,42 @@ class FinishDataPackages
     MeshAllDynamics<execution::ParallelPolicy, CellContainDiffusion> cell_contain_diffusion{mesh_data_, sv_count_modified_};
 };
 
-template <class ExecutionPolicy>
-class CleanInterface : public BaseMeshDynamics, public BaseDynamics<void>
+class RepeatTimes
 {
   public:
-    explicit CleanInterface(MeshWithGridDataPackagesType &mesh_data, NeighborMethod<SingleValued> &neighbor_method)
-        : BaseMeshDynamics(mesh_data),
-          BaseDynamics<void>(),
+    explicit RepeatTimes(){};
+    virtual ~RepeatTimes() {};
+    void operator()(UnsignedInt repeat_times) { repeat_times_ = repeat_times; }
+
+  protected:
+    UnsignedInt repeat_times_ = 1;
+};
+
+template <class ExecutionPolicy>
+class CleanInterface : public RepeatTimes, public BaseMeshDynamics, public BaseDynamics<void>
+{
+  public:
+    explicit CleanInterface(MeshWithGridDataPackagesType &mesh_data,
+                            NeighborMethod<SingleValued> &neighbor_method)
+        : RepeatTimes(), BaseMeshDynamics(mesh_data), BaseDynamics<void>(),
           neighbor_method_(neighbor_method) {};
     virtual ~CleanInterface() {};
 
-    void exec(Real small_shift_factor) override
+    void exec(Real dt = 0.0) override
     {
-        mark_near_interface.exec(small_shift_factor);
-        redistance_interface.exec();
-        reinitialize_level_set.exec();
+        for (UnsignedInt k = 0; k != 2 * repeat_times_; ++k)
+        {
+            for (UnsignedInt l = 0; l != 2; ++l)
+            {
+                mark_cut_interfaces.exec();
+                redistance_interface.exec();
+            }
+
+            for (UnsignedInt m = 0; m != 10; ++m)
+            {
+                reinitialize_level_set.exec();
+            }
+        }
         update_level_set_gradient.exec();
         update_kernel_integrals.exec();
     }
@@ -91,7 +112,7 @@ class CleanInterface : public BaseMeshDynamics, public BaseDynamics<void>
     NeighborMethod<SingleValued> &neighbor_method_;
     MeshInnerDynamics<ExecutionPolicy, UpdateLevelSetGradient> update_level_set_gradient{mesh_data_};
     MeshInnerDynamics<ExecutionPolicy, UpdateKernelIntegrals> update_kernel_integrals{mesh_data_, neighbor_method_};
-    MeshInnerDynamics<ExecutionPolicy, MarkNearInterface> mark_near_interface{mesh_data_};
+    MeshInnerDynamics<ExecutionPolicy, MarkCutInterfaces> mark_cut_interfaces{mesh_data_, 0.5};
     MeshCoreDynamics<ExecutionPolicy, RedistanceInterface> redistance_interface{mesh_data_};
     MeshInnerDynamics<ExecutionPolicy, ReinitializeLevelSet> reinitialize_level_set{mesh_data_};
 };
@@ -106,21 +127,25 @@ class CorrectTopology : public BaseMeshDynamics, public BaseDynamics<void>
           neighbor_method_(neighbor_method) {};
     virtual ~CorrectTopology() {};
 
-    void exec(Real small_shift_factor) override
+    void exec(Real dt = 0.0) override
     {
-        mark_near_interface.exec(small_shift_factor);
-        for (UnsignedInt i = 0; i != 10; ++i)
+        mark_near_interface.exec();
+        while (sv_count_modified_.getValue() > 0)
+        {
+            sv_count_modified_.setValue(0);
             diffuse_level_set_sign.exec();
+        }
         update_level_set_gradient.exec();
         update_kernel_integrals.exec();
     }
 
   private:
     NeighborMethod<SingleValued> &neighbor_method_;
+    SingularVariable<UnsignedInt> sv_count_modified_{"CountModifiedData", 1};
     MeshInnerDynamics<ExecutionPolicy, UpdateLevelSetGradient> update_level_set_gradient{mesh_data_};
     MeshInnerDynamics<ExecutionPolicy, UpdateKernelIntegrals> update_kernel_integrals{mesh_data_, neighbor_method_};
     MeshInnerDynamics<ExecutionPolicy, MarkNearInterface> mark_near_interface{mesh_data_};
-    MeshInnerDynamics<ExecutionPolicy, DiffuseLevelSetSign> diffuse_level_set_sign{mesh_data_};
+    MeshInnerDynamics<ExecutionPolicy, DiffuseLevelSetSign> diffuse_level_set_sign{mesh_data_, sv_count_modified_};
 };
 } // namespace SPH
 #endif // ALL_MESH_DYNAMICS_H

--- a/src/shared/mesh_dynamics/mesh_local_dynamics.cpp
+++ b/src/shared/mesh_dynamics/mesh_local_dynamics.cpp
@@ -186,8 +186,17 @@ UpdateKernelIntegrals::UpdateKernelIntegrals(
     initializeSingularPackages(1, far_field_distance);
 }
 //=============================================================================================//
+MarkCutInterfaces::MarkCutInterfaces(MeshWithGridDataPackagesType &data_mesh, Real perturbation_ratio)
+    : BaseMeshLocalDynamics(data_mesh),
+      threshold_(data_spacing_ * std::pow(Dimensions, 1.0 / Real(Dimensions))),
+      perturbation_ratio_(perturbation_ratio),
+      mv_phi_(*data_mesh.getMeshVariable<Real>("LevelSet")),
+      mv_near_interface_id_(*data_mesh.getMeshVariable<int>("NearInterfaceID")),
+      dv_cell_neighborhood_(data_mesh.getCellNeighborhood()) {}
+//=============================================================================================//
 MarkNearInterface::MarkNearInterface(MeshWithGridDataPackagesType &data_mesh)
     : BaseMeshLocalDynamics(data_mesh),
+      threshold_(data_spacing_ * std::pow(Dimensions, 1.0 / Real(Dimensions))),
       mv_phi_(*data_mesh.getMeshVariable<Real>("LevelSet")),
       mv_near_interface_id_(*data_mesh.getMeshVariable<int>("NearInterfaceID")),
       dv_cell_neighborhood_(data_mesh.getCellNeighborhood()) {}
@@ -205,10 +214,12 @@ RedistanceInterface::RedistanceInterface(MeshWithGridDataPackagesType &data_mesh
       mv_near_interface_id_(*data_mesh.getMeshVariable<int>("NearInterfaceID")),
       dv_cell_neighborhood_(data_mesh.getCellNeighborhood()) {}
 //=============================================================================================//
-DiffuseLevelSetSign::DiffuseLevelSetSign(MeshWithGridDataPackagesType &data_mesh)
+DiffuseLevelSetSign::DiffuseLevelSetSign(
+    MeshWithGridDataPackagesType &data_mesh, SingularVariable<UnsignedInt> &sv_count_modified)
     : BaseMeshLocalDynamics(data_mesh),
       mv_phi_(*data_mesh.getMeshVariable<Real>("LevelSet")),
       mv_near_interface_id_(*data_mesh.getMeshVariable<int>("NearInterfaceID")),
-      dv_cell_neighborhood_(data_mesh.getCellNeighborhood()) {}
+      dv_cell_neighborhood_(data_mesh.getCellNeighborhood()),
+      sv_count_modified_(sv_count_modified) {}
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/mesh_dynamics/mesh_local_dynamics.h
+++ b/src/shared/mesh_dynamics/mesh_local_dynamics.h
@@ -595,6 +595,38 @@ class ReinitializeLevelSet : public BaseMeshLocalDynamics
     DiscreteVariable<CellNeighborhood> &dv_cell_neighborhood_;
 };
 
+class MarkCutInterfaces : public BaseMeshLocalDynamics
+{
+  public:
+    explicit MarkCutInterfaces(MeshWithGridDataPackagesType &data_mesh, Real perturbation_ratio = 1.0);
+    virtual ~MarkCutInterfaces() {};
+
+    class UpdateKernel
+    {
+      public:
+        template <class ExecutionPolicy, class EncloserType>
+        UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
+            : threshold_(encloser.threshold_),
+              perturbation_(threshold_ * encloser.perturbation_ratio_),
+              phi_(encloser.mv_phi_.DelegatedData(ex_policy)),
+              near_interface_id_(encloser.mv_near_interface_id_.DelegatedData(ex_policy)),
+              cell_neighborhood_(encloser.dv_cell_neighborhood_.DelegatedData(ex_policy)){};
+        void update(const UnsignedInt &index, Real dt = 0.0);
+
+      protected:
+        Real threshold_, perturbation_;
+        MeshVariableData<Real> *phi_;
+        MeshVariableData<int> *near_interface_id_;
+        CellNeighborhood *cell_neighborhood_;
+    };
+
+  protected:
+    Real threshold_, perturbation_ratio_;
+    MeshVariable<Real> &mv_phi_;
+    MeshVariable<int> &mv_near_interface_id_;
+    DiscreteVariable<CellNeighborhood> &dv_cell_neighborhood_;
+};
+
 class MarkNearInterface : public BaseMeshLocalDynamics
 {
   public:
@@ -606,20 +638,21 @@ class MarkNearInterface : public BaseMeshLocalDynamics
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
-            : data_spacing_(encloser.data_spacing_),
+            : threshold_(encloser.threshold_),
               phi_(encloser.mv_phi_.DelegatedData(ex_policy)),
               near_interface_id_(encloser.mv_near_interface_id_.DelegatedData(ex_policy)),
               cell_neighborhood_(encloser.dv_cell_neighborhood_.DelegatedData(ex_policy)){};
-        void update(const UnsignedInt &index, Real small_shift_factor);
+        void update(const UnsignedInt &index, Real dt = 0.0);
 
       protected:
-        Real data_spacing_;
+        Real threshold_;
         MeshVariableData<Real> *phi_;
         MeshVariableData<int> *near_interface_id_;
         CellNeighborhood *cell_neighborhood_;
     };
 
   protected:
+    Real threshold_;
     MeshVariable<Real> &mv_phi_;
     MeshVariable<int> &mv_near_interface_id_;
     DiscreteVariable<CellNeighborhood> &dv_cell_neighborhood_;
@@ -681,7 +714,8 @@ class RedistanceInterface : public BaseMeshLocalDynamics
 class DiffuseLevelSetSign : public BaseMeshLocalDynamics
 {
   public:
-    explicit DiffuseLevelSetSign(MeshWithGridDataPackagesType &data_mesh);
+    explicit DiffuseLevelSetSign(MeshWithGridDataPackagesType &data_mesh,
+                                 SingularVariable<UnsignedInt> &sv_count_modified);
     virtual ~DiffuseLevelSetSign() {};
 
     class UpdateKernel
@@ -691,19 +725,22 @@ class DiffuseLevelSetSign : public BaseMeshLocalDynamics
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
             : phi_(encloser.mv_phi_.DelegatedData(ex_policy)),
               near_interface_id_(encloser.mv_near_interface_id_.DelegatedData(ex_policy)),
-              cell_neighborhood_(encloser.dv_cell_neighborhood_.DelegatedData(ex_policy)){};
+              cell_neighborhood_(encloser.dv_cell_neighborhood_.DelegatedData(ex_policy)),
+              count_modified_(encloser.sv_count_modified_.DelegatedData(ex_policy)){};
         void update(const UnsignedInt &index);
 
       protected:
         MeshVariableData<Real> *phi_;
         MeshVariableData<int> *near_interface_id_;
         CellNeighborhood *cell_neighborhood_;
+        UnsignedInt *count_modified_;
     };
 
   protected:
     MeshVariable<Real> &mv_phi_;
     MeshVariable<int> &mv_near_interface_id_;
     DiscreteVariable<CellNeighborhood> &dv_cell_neighborhood_;
+    SingularVariable<UnsignedInt> &sv_count_modified_;
 };
 
 class ProbeIsWithinMeshBound : public BaseMeshLocalDynamics

--- a/src/shared/meshes/cell_linked_list.h
+++ b/src/shared/meshes/cell_linked_list.h
@@ -51,9 +51,10 @@ class CellLinkedList;
 class BaseCellLinkedList : public BaseMeshField
 {
   protected:
+    BaseParticles &base_particles_;
     DataContainerUniquePtrAssemble<DiscreteVariable> all_discrete_variable_ptrs_;
     UniquePtrsKeeper<Entity> unique_variable_ptrs_;
-    UniquePtrsKeeper<Mesh> mesh_ptrs_keeper_;
+    UniquePtrsKeeper<SingularVariable<Mesh>> mesh_ptrs_keeper_;
     StdVec<Mesh *> meshes_;
     StdVec<UnsignedInt> mesh_offsets_; // off sets linear index for each mesh
 
@@ -62,6 +63,7 @@ class BaseCellLinkedList : public BaseMeshField
     virtual ~BaseCellLinkedList();
     StdVec<Mesh *> &getMeshes() { return meshes_; };
     StdVec<UnsignedInt> &getMeshOffsets() { return mesh_offsets_; };
+    BaseParticles &getBaseParticles() { return base_particles_; };
     void UpdateCellLists(BaseParticles &base_particles);
     /** Insert a cell-linked_list entry to the concurrent index list. */
     virtual void insertParticleIndex(UnsignedInt particle_index, const Vecd &particle_position) = 0;
@@ -150,12 +152,14 @@ class CellLinkedList : public BaseCellLinkedList
 {
   protected:
     Mesh *mesh_;
+    SingularVariable<Mesh> *sv_mesh_;
 
   public:
     CellLinkedList(BoundingBox tentative_bounds, Real grid_spacing,
                    BaseParticles &base_particles, SPHAdaptation &sph_adaptation);
     ~CellLinkedList(){};
     Mesh &getMesh() { return *mesh_; };
+    SingularVariable<Mesh> *svMesh() { return sv_mesh_; };
     void insertParticleIndex(UnsignedInt particle_index, const Vecd &particle_position) override;
     void InsertListDataEntry(UnsignedInt particle_index, const Vecd &particle_position) override;
     virtual ListData findNearestListDataEntry(const Vecd &position) override;

--- a/src/shared/particle_dynamics/base_local_dynamics.h
+++ b/src/shared/particle_dynamics/base_local_dynamics.h
@@ -65,6 +65,7 @@ class BaseLocalDynamics
     virtual ~BaseLocalDynamics() {};
     using Identifier = typename DynamicsIdentifier::BaseIdentifier;
     SPHBody &getSPHBody() { return *sph_body_; };
+    BaseParticles &getBaseParticles() { return *particles_; };
     SPHAdaptation &getSPHAdaptation() { return *sph_adaptation_; };
     virtual void setupDynamics(Real dt = 0.0) {}; // setup global parameters
 

--- a/src/shared/particle_dynamics/dissipation_dynamics/particle_dynamics_dissipation.h
+++ b/src/shared/particle_dynamics/dissipation_dynamics/particle_dynamics_dissipation.h
@@ -38,10 +38,6 @@
 
 namespace SPH
 {
-/* Base class to indicate the concept of operator splitting */
-class OperatorSplitting
-{
-};
 
 template <typename DataType>
 struct ErrorAndParameters
@@ -77,7 +73,7 @@ class Damping;
 
 template <typename DataType, typename DampingRateType, class DataDelegationType>
 class Damping<Base, DataType, DampingRateType, DataDelegationType>
-    : public LocalDynamics, public DataDelegationType, public OperatorSplitting
+    : public LocalDynamics, public DataDelegationType
 {
   public:
     template <class BaseRelationType, typename... Args>

--- a/src/shared/particle_dynamics/dissipation_dynamics/particle_dynamics_dissipation.hpp
+++ b/src/shared/particle_dynamics/dissipation_dynamics/particle_dynamics_dissipation.hpp
@@ -10,7 +10,7 @@ template <typename DataType, typename DampingRateType, class DataDelegationType>
 template <class BaseRelationType, typename... Args>
 Damping<Base, DataType, DampingRateType, DataDelegationType>::
     Damping(BaseRelationType &base_relation, const std::string &name, Args &&...args)
-    : LocalDynamics(base_relation.getSPHBody()), DataDelegationType(base_relation), OperatorSplitting(),
+    : LocalDynamics(base_relation.getSPHBody()), DataDelegationType(base_relation),
       name_(name), damping_(this->particles_, std::forward<Args>(args)...),
       Vol_(this->particles_->template getVariableDataByName<Real>("VolumetricMeasure")),
       data_field_(this->particles_->template getVariableDataByName<DataType>(name)) {}

--- a/src/shared/particle_dynamics/fluid_dynamics/boundary_condition/near_wall_boundary.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/boundary_condition/near_wall_boundary.h
@@ -43,7 +43,7 @@ class NearWallDistance : public LocalDynamics, public DataDelegateContact
 {
   public:
     explicit NearWallDistance(BaseContactRelation &wall_contact_relation);
-    virtual ~NearWallDistance(){};
+    virtual ~NearWallDistance() {};
 
   protected:
     Real spacing_ref_, distance_default_;
@@ -58,7 +58,7 @@ class DistanceFromWall : public NearWallDistance
 {
   public:
     explicit DistanceFromWall(BaseContactRelation &wall_contact_relation);
-    virtual ~DistanceFromWall(){};
+    virtual ~DistanceFromWall() {};
     void interaction(size_t index_i, Real dt = 0.0);
 
   protected:
@@ -69,7 +69,7 @@ class BoundingFromWall : public NearWallDistance
 {
   public:
     explicit BoundingFromWall(BaseContactRelation &wall_contact_relation);
-    virtual ~BoundingFromWall(){};
+    virtual ~BoundingFromWall() {};
     void interaction(size_t index_i, Real dt = 0.0);
 
   protected:

--- a/src/shared/shared_ck/particle_dynamics/particle_iterators_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/particle_iterators_ck.h
@@ -38,16 +38,16 @@ namespace SPH
 {
 using namespace execution;
 
-template <class DynamicsIdentifier, class UnaryFunc>
-void particle_for(const LoopRangeCK<SequencedPolicy, DynamicsIdentifier> &loop_range,
+template <class Identifier, class UnaryFunc>
+void particle_for(const LoopRangeCK<SequencedPolicy, Identifier> &loop_range,
                   const UnaryFunc &unary_func)
 {
     for (size_t i = 0; i < loop_range.LoopBound(); ++i)
         loop_range.computeUnit(unary_func, i);
 };
 
-template <class DynamicsIdentifier, class UnaryFunc>
-void particle_for(const LoopRangeCK<ParallelPolicy, DynamicsIdentifier> &loop_range,
+template <class Identifier, class UnaryFunc>
+void particle_for(const LoopRangeCK<ParallelPolicy, Identifier> &loop_range,
                   const UnaryFunc &unary_func)
 {
     parallel_for(
@@ -62,8 +62,8 @@ void particle_for(const LoopRangeCK<ParallelPolicy, DynamicsIdentifier> &loop_ra
         ap);
 };
 
-template <typename Operation, class DynamicsIdentifier, class ReturnType, class UnaryFunc>
-ReturnType particle_reduce(const LoopRangeCK<SequencedPolicy, DynamicsIdentifier> &loop_range,
+template <typename Operation, class Identifier, class ReturnType, class UnaryFunc>
+ReturnType particle_reduce(const LoopRangeCK<SequencedPolicy, Identifier> &loop_range,
                            ReturnType temp, const UnaryFunc &unary_func)
 {
     Operation operation;
@@ -75,8 +75,8 @@ ReturnType particle_reduce(const LoopRangeCK<SequencedPolicy, DynamicsIdentifier
     return temp0;
 }
 
-template <typename Operation, class DynamicsIdentifier, class ReturnType, class UnaryFunc>
-ReturnType particle_reduce(const LoopRangeCK<ParallelPolicy, DynamicsIdentifier> &loop_range,
+template <typename Operation, class Identifier, class ReturnType, class UnaryFunc>
+ReturnType particle_reduce(const LoopRangeCK<ParallelPolicy, Identifier> &loop_range,
                            ReturnType temp, const UnaryFunc &unary_func)
 {
     Operation operation;

--- a/tests/2d_examples/test_2d_airfoil/airfoil_2d.cpp
+++ b/tests/2d_examples/test_2d_airfoil/airfoil_2d.cpp
@@ -50,7 +50,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     RealBody airfoil(sph_system, makeShared<ImportModel>("AirFoil"));
     airfoil.defineAdaptation<ParticleRefinementNearSurface>(1.15, 1.0, 3);
-    airfoil.defineBodyLevelSetShape()->cleanLevelSet()->writeLevelSet(sph_system);
+    airfoil.defineBodyLevelSetShape()->cleanLevelSet(2.0)->writeLevelSet(sph_system);
     airfoil.generateParticles<BaseParticles, Lattice, Adaptive>();
     //----------------------------------------------------------------------
     //	Define outputs functions.

--- a/tests/2d_examples/test_2d_airfoil/airfoil_2d.cpp
+++ b/tests/2d_examples/test_2d_airfoil/airfoil_2d.cpp
@@ -50,7 +50,7 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     RealBody airfoil(sph_system, makeShared<ImportModel>("AirFoil"));
     airfoil.defineAdaptation<ParticleRefinementNearSurface>(1.15, 1.0, 3);
-    airfoil.defineBodyLevelSetShape()->cleanLevelSet(2.0)->writeLevelSet(sph_system);
+    airfoil.defineBodyLevelSetShape()->cleanLevelSet()->writeLevelSet(sph_system);
     airfoil.generateParticles<BaseParticles, Lattice, Adaptive>();
     //----------------------------------------------------------------------
     //	Define outputs functions.

--- a/tests/2d_examples/test_2d_hydrostatic_fluid_shell/test_2d_hydrostatic_fluid_shell.cpp
+++ b/tests/2d_examples/test_2d_hydrostatic_fluid_shell/test_2d_hydrostatic_fluid_shell.cpp
@@ -181,7 +181,7 @@ void hydrostatic_fsi(const Real particle_spacing_gate, const Real particle_spaci
     //	Creating body, materials and particles.
     //----------------------------------------------------------------------
     FluidBody water_block(sph_system, makeShared<WaterBlock>(createWaterBlockShape(), "WaterBody"));
-    water_block.defineBodyLevelSetShape()->correctLevelSetSign()->cleanLevelSet(0);
+    water_block.defineBodyLevelSetShape();
     water_block.defineMaterial<WeaklyCompressibleFluid>(rho0_f, c_f);
     water_block.generateParticles<BaseParticles, Lattice>();
 

--- a/tests/2d_examples/test_2d_mr_cantilever_beam/test_2d_mr_cantilever_beam.cpp
+++ b/tests/2d_examples/test_2d_mr_cantilever_beam/test_2d_mr_cantilever_beam.cpp
@@ -194,7 +194,7 @@ return_data beam_multi_resolution(Real dp_factor, bool damping_on, int refinemen
     SolidBody beam_body(system, mesh);
     if (refinement_level > 0)
         beam_body.defineAdaptation<ParticleRefinementWithinShape>(1.15, 1.0, refinement_level);
-    beam_body.defineBodyLevelSetShape()->cleanLevelSet(0);
+    beam_body.defineBodyLevelSetShape();
     beam_body.defineMaterial<NeoHookeanSolid>(*material.get());
     if (refinement_level > 0)
         beam_body.generateParticles<BaseParticles, Lattice, Adaptive>(refinement_region);

--- a/tests/2d_examples/test_2d_sliding_solid_shell/test_2d_sliding_solid_shell.cpp
+++ b/tests/2d_examples/test_2d_sliding_solid_shell/test_2d_sliding_solid_shell.cpp
@@ -83,7 +83,7 @@ void run_simulation()
     //	Creating body, materials and particles
     //----------------------------------------------------------------------
     SolidBody free_cube(sph_system, makeShared<Cube>("FreeCube"));
-    free_cube.defineBodyLevelSetShape()->cleanLevelSet(0);
+    free_cube.defineBodyLevelSetShape();
     free_cube.defineMaterial<SaintVenantKirchhoffSolid>(rho0_s, Youngs_modulus, poisson);
     free_cube.generateParticles<BaseParticles, Lattice>();
 

--- a/tests/3d_examples/test_3d_mr_cantilever_beam/test_3d_mr_cantilever_beam.cpp
+++ b/tests/3d_examples/test_3d_mr_cantilever_beam/test_3d_mr_cantilever_beam.cpp
@@ -185,7 +185,7 @@ return_data beam_multi_resolution(Real dp_factor, bool damping_on, int refinemen
     SolidBody beam_body(system, mesh);
     if (refinement_level > 0)
         beam_body.defineAdaptation<ParticleRefinementWithinShape>(1.15, 1.0, refinement_level);
-    beam_body.defineBodyLevelSetShape()->cleanLevelSet(0);
+    beam_body.defineBodyLevelSetShape();
     beam_body.defineMaterial<NeoHookeanSolid>(*material.get());
     if (refinement_level > 0)
         beam_body.generateParticles<BaseParticles, Lattice, Adaptive>(*refinement_region);


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the geometry and mesh dynamics codebase for both 2D and 3D builds. The most significant changes include the renaming and reorganization of interface marking kernels, updates to how interface proximity is determined, and the addition of missing `findBounds()` overrides to shape classes. These changes enhance clarity, maintainability, and correctness in handling mesh variables and interface detection.

### Mesh Dynamics Refactoring and Interface Detection

* Renamed the kernel from `MarkNearInterface` to `MarkCutInterfaces` and updated its signature to use `dt` instead of `small_shift_factor`, improving clarity and consistency in both 2D and 3D mesh dynamics (`mesh_local_dynamics.hpp`). [[1]](diffhunk://#diff-b251b5bc5bae2e17deb142197b7fd0525c402cc1317cb30f83d75ac67a61ac41L237-L240) [[2]](diffhunk://#diff-af318efa4e8834c4f2cbc0ec6d320ac2778b1b245f1c812fde05ab697a02438aL273-L275)
* Updated logic in interface marking kernels to use the `perturbation_` variable instead of `small_shift`, and improved neighborhood checks for interface proximity, resulting in more accurate identification of cut and band cells. [[1]](diffhunk://#diff-b251b5bc5bae2e17deb142197b7fd0525c402cc1317cb30f83d75ac67a61ac41L259-R257) [[2]](diffhunk://#diff-b251b5bc5bae2e17deb142197b7fd0525c402cc1317cb30f83d75ac67a61ac41L268-R268) [[3]](diffhunk://#diff-af318efa4e8834c4f2cbc0ec6d320ac2778b1b245f1c812fde05ab697a02438aL294-R293) [[4]](diffhunk://#diff-af318efa4e8834c4f2cbc0ec6d320ac2778b1b245f1c812fde05ab697a02438aL303-R304)
* Added new `update` methods to `MarkNearInterface` for both 2D and 3D cases, introducing a more robust approach for marking undetermined, cut, and band cells based on sign changes in the neighborhood. [[1]](diffhunk://#diff-b251b5bc5bae2e17deb142197b7fd0525c402cc1317cb30f83d75ac67a61ac41R285-R320) [[2]](diffhunk://#diff-af318efa4e8834c4f2cbc0ec6d320ac2778b1b245f1c812fde05ab697a02438aR321-R357)
* Refactored the `DiffuseLevelSetSign` kernel to operate only on undetermined cells and to mark positive/negative bands more reliably, incrementing a modification counter when changes occur.

### Geometry Class Improvements

* Added missing overrides for the `findBounds()` method in the `MultiPolygonShape`, `ImageShape`, and `TriangleMeshShape` classes, ensuring proper bounding box calculations for these shapes. [[1]](diffhunk://#diff-d06441a0a6f6be645b9aef05fede051274921f025886a0c2a7ecae197499fb19R123-L127) [[2]](diffhunk://#diff-68e44e2de0bffd9e5ac519d991c4d182bbe3019e81821cb750935bb23a82a18bR54-L62) [[3]](diffhunk://#diff-cf1658a06325b29dc54534e5a9225e7a66ddde9b837f9468f545b405d1f19d10R59) [[4]](diffhunk://#diff-cf1658a06325b29dc54534e5a9225e7a66ddde9b837f9468f545b405d1f19d10L68)

### Mesh Variable Output Consistency

* Standardized the mesh variable output routines by renaming internal containers from `mesh_variable_to_write_` and `bkg_mesh_variable_to_write_` to `mesh_variables_to_write_` and `bkg_mesh_variables_to_write_` respectively, improving code readability and consistency in `mesh_with_data_packages.hpp`. [[1]](diffhunk://#diff-2e764cc65773f90a3367066d9166b3acef34c2614f0126ba3d814db2b46e3100L17-R37) [[2]](diffhunk://#diff-2e764cc65773f90a3367066d9166b3acef34c2614f0126ba3d814db2b46e3100L55-R73) [[3]](diffhunk://#diff-2e764cc65773f90a3367066d9166b3acef34c2614f0126ba3d814db2b46e3100L91-R111) [[4]](diffhunk://#diff-2e764cc65773f90a3367066d9166b3acef34c2614f0126ba3d814db2b46e3100L130-R148)