### PR TITLE
Xiangyu/visualize aligned box

### DIFF
--- a/src/for_2D_build/bodies/base_body_part_2d.cpp
+++ b/src/for_2D_build/bodies/base_body_part_2d.cpp
@@ -1,0 +1,11 @@
+#include "base_body_part.h"
+
+namespace SPH
+{
+//=================================================================================================//
+void AlignedBoxPart::writeShapeProxy(SPHSystem &sph_system)
+{
+    std::cout << "The shape proxy for the aligned box part is not available in 2D." << std::endl;
+}
+//=================================================================================================//
+} // namespace SPH

--- a/src/for_3D_build/bodies/base_body_part_3d.cpp
+++ b/src/for_3D_build/bodies/base_body_part_3d.cpp
@@ -1,0 +1,15 @@
+#include "base_body_part.h"
+
+#include "sph_system.h"
+
+namespace SPH
+{
+//=================================================================================================//
+void AlignedBoxPart::writeShapeProxy(SPHSystem &sph_system)
+{
+    TriangleMeshShapeBrick shape_proxy(
+        aligned_box_.HalfSize(), 1, Vecd::Zero(), svAlignedBox()->Name() + "Proxy");
+    shape_proxy.writeMeshToFile(sph_system, aligned_box_.getTransform());
+}
+//=================================================================================================//
+} // namespace SPH

--- a/src/for_3D_build/geometries/triangle_mesh_shape.h
+++ b/src/for_3D_build/geometries/triangle_mesh_shape.h
@@ -43,6 +43,7 @@ namespace fs = std::filesystem;
 
 namespace SPH
 {
+class SPHSystem;
 /**
  * @class TriangleMeshShape
  * @brief Derived class for triangle shape processing.
@@ -59,6 +60,7 @@ class TriangleMeshShape : public Shape
     virtual BoundingBox findBounds() override;
     StdVec<std::array<Real, 3>> &getVertices() { return vertices_; }
     StdVec<std::array<int, 3>> &getFaces() { return faces_; }
+    void writeMeshToFile(SPHSystem &sph_system, Transform transform = Transform());
 
   protected:
     StdVec<std::array<Real, 3>> vertices_;

--- a/src/shared/bodies/base_body_part.h
+++ b/src/shared/bodies/base_body_part.h
@@ -256,6 +256,7 @@ class AlignedBoxPart
     virtual ~AlignedBoxPart() {};
     SingularVariable<AlignedBox> *svAlignedBox() { return sv_aligned_box_keeper_.getPtr(); };
     AlignedBox &getAlignedBox() { return aligned_box_; };
+    void writeShapeProxy(SPHSystem &sph_system);
 
   protected:
     AlignedBox &aligned_box_;

--- a/src/shared/mesh_dynamics/all_mesh_dynamics.h
+++ b/src/shared/mesh_dynamics/all_mesh_dynamics.h
@@ -71,7 +71,7 @@ class FinishDataPackages
 class RepeatTimes
 {
   public:
-    explicit RepeatTimes(){};
+    explicit RepeatTimes() {};
     virtual ~RepeatTimes() {};
     void operator()(UnsignedInt repeat_times) { repeat_times_ = repeat_times; }
 
@@ -112,7 +112,7 @@ class CleanInterface : public RepeatTimes, public BaseMeshDynamics, public BaseD
     NeighborMethod<SingleValued> &neighbor_method_;
     MeshInnerDynamics<ExecutionPolicy, UpdateLevelSetGradient> update_level_set_gradient{mesh_data_};
     MeshInnerDynamics<ExecutionPolicy, UpdateKernelIntegrals> update_kernel_integrals{mesh_data_, neighbor_method_};
-    MeshInnerDynamics<ExecutionPolicy, MarkCutInterfaces> mark_cut_interfaces{mesh_data_, 0.5};
+    MeshInnerDynamics<ExecutionPolicy, MarkCutInterfaces> mark_cut_interfaces{mesh_data_, 1.0};
     MeshCoreDynamics<ExecutionPolicy, RedistanceInterface> redistance_interface{mesh_data_};
     MeshInnerDynamics<ExecutionPolicy, ReinitializeLevelSet> reinitialize_level_set{mesh_data_};
 };

--- a/src/shared/mesh_dynamics/mesh_local_dynamics.cpp
+++ b/src/shared/mesh_dynamics/mesh_local_dynamics.cpp
@@ -188,15 +188,14 @@ UpdateKernelIntegrals::UpdateKernelIntegrals(
 //=============================================================================================//
 MarkCutInterfaces::MarkCutInterfaces(MeshWithGridDataPackagesType &data_mesh, Real perturbation_ratio)
     : BaseMeshLocalDynamics(data_mesh),
-      threshold_(data_spacing_ * std::pow(Dimensions, 1.0 / Real(Dimensions))),
-      perturbation_ratio_(perturbation_ratio),
+      threshold_(data_spacing_ * sqrt(Dimensions)), perturbation_ratio_(perturbation_ratio),
       mv_phi_(*data_mesh.getMeshVariable<Real>("LevelSet")),
       mv_near_interface_id_(*data_mesh.getMeshVariable<int>("NearInterfaceID")),
       dv_cell_neighborhood_(data_mesh.getCellNeighborhood()) {}
 //=============================================================================================//
 MarkNearInterface::MarkNearInterface(MeshWithGridDataPackagesType &data_mesh)
     : BaseMeshLocalDynamics(data_mesh),
-      threshold_(data_spacing_ * std::pow(Dimensions, 1.0 / Real(Dimensions))),
+      threshold_(data_spacing_ * sqrt(Dimensions)),
       mv_phi_(*data_mesh.getMeshVariable<Real>("LevelSet")),
       mv_near_interface_id_(*data_mesh.getMeshVariable<int>("NearInterfaceID")),
       dv_cell_neighborhood_(data_mesh.getCellNeighborhood()) {}

--- a/src/shared/particles/base_particles.hpp
+++ b/src/shared/particles/base_particles.hpp
@@ -332,7 +332,7 @@ DiscreteVariable<DataType> *BaseParticles::
 
     if (variable == nullptr)
     {
-        std::cout << "\n Error: the variable '" << name << "' is  not exist!" << std::endl;
+        std::cout << "\n Error: the " << type_name<DataType>() << " variable '" << name << "' is  not exist!" << std::endl;
         printBodyName();
         exit(1);
     }

--- a/src/shared/particles/particle_operation.h
+++ b/src/shared/particles/particle_operation.h
@@ -65,9 +65,8 @@ class SpawnRealParticle
             UnsignedInt last_real_particle_index = total_real_particles_ref.fetch_add(1);
             if (last_real_particle_index < particles_bound_)
             {
-                UnsignedInt new_original_id = original_id_[last_real_particle_index];
                 copy_particle_state_(copyable_state_data_arrays_, last_real_particle_index, index_i);
-                original_id_[last_real_particle_index] = new_original_id; // keep the original id
+                original_id_[last_real_particle_index] = last_real_particle_index; // reinitialize original id
             }
             return last_real_particle_index;
         };
@@ -111,8 +110,8 @@ class RemoveRealParticle
             {
                 UnsignedInt old_original_id = original_id_[index_i];
                 copy_particle_state_(copyable_state_data_arrays_, index_i, last_real_particle_index);
-                life_status[index_i] = 0;                                     // reset the life status
-                original_id_[last_real_particle_index] = old_original_id;     // swap the original id
+                life_status[index_i] = 0;                                 // reset the life status
+                original_id_[last_real_particle_index] = old_original_id; // swap the original id
             }
         };
 

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.h
@@ -61,7 +61,7 @@ class Regularization<Internal>
                         Regularization<Internal> &encloser,
                         ComputingKernelType &computing_kernel){};
 
-        Real operator()(Real &rho_sum) { return rho_sum; };
+        Real operator()(UnsignedInt index_i, Real &rho_sum) { return rho_sum; };
     };
 };
 
@@ -80,7 +80,7 @@ class Regularization<FreeSurface>
                         ComputingKernelType &computing_kernel)
             : rho0_(computing_kernel.InitialDensity()){};
 
-        Real operator()(Real &rho_sum) { return SMAX(rho_sum, rho0_); };
+        Real operator()(UnsignedInt index_i, Real &rho_sum) { return SMAX(rho_sum, rho0_); };
 
       protected:
         Real rho0_;

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.hpp
@@ -79,7 +79,7 @@ void DensityRegularization<Inner<WithUpdate, RegularizationType, ParticleScopeTy
     UpdateKernel::update(size_t index_i, Real dt)
 {
     if (this->particle_scope_(index_i))
-        this->rho_[index_i] = regularization_(this->rho_sum_[index_i]);
+        this->rho_[index_i] = regularization_(index_i, this->rho_sum_[index_i]);
 }
 //=================================================================================================//
 template <typename... Parameters>

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/geometric_dynamics.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/geometric_dynamics.h
@@ -106,7 +106,7 @@ class RandomizeParticlePositionCK : public LocalDynamics
     explicit RandomizeParticlePositionCK(SPHBody &sph_body, Real randomize_factor = 0.25);
     virtual ~RandomizeParticlePositionCK() {};
 
-    class UpdateKernel : public HostKernel //due to random number generation
+    class UpdateKernel : public HostKernel // due to random number generation
     {
       public:
         template <class ExecutionPolicy, class EncloserType>

--- a/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.h
@@ -111,9 +111,11 @@ class InteractionDynamicsCK<ExecutionPolicy, InteractionType<AlgorithmType>>
 
     template <class UpdateType, typename... Args>
     auto &addPostStateDynamics(Args &&...args);
+    auto &addPostStateDynamics(BaseDynamics<void> &state_dynamics);
 
     template <class UpdateType, typename... Args>
     auto &addPreStateDynamics(Args &&...args);
+    auto &addPreStateDynamics(BaseDynamics<void> &state_dynamics);
 };
 
 template <class ExecutionPolicy, template <typename...> class InteractionType, typename... Parameters>

--- a/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.hpp
@@ -42,6 +42,13 @@ auto &InteractionDynamicsCK<ExecutionPolicy, InteractionType<AlgorithmType>>::
         supplementary_dynamics_keeper_.template createPtr<
             StateDynamics<ExecutionPolicy, UpdateType>>(std::forward<Args>(args)...));
     return *this;
+} //=================================================================================================//
+template <class ExecutionPolicy, typename AlgorithmType, template <typename...> class InteractionType>
+auto &InteractionDynamicsCK<ExecutionPolicy, InteractionType<AlgorithmType>>::
+    addPostStateDynamics(BaseDynamics<void> &state_dynamics)
+{
+    this->post_processes_.push_back(&state_dynamics);
+    return *this;
 }
 //=================================================================================================//
 template <class ExecutionPolicy, typename AlgorithmType, template <typename...> class InteractionType>
@@ -52,6 +59,14 @@ auto &InteractionDynamicsCK<ExecutionPolicy, InteractionType<AlgorithmType>>::
     this->pre_processes_.push_back(
         supplementary_dynamics_keeper_.template createPtr<
             StateDynamics<ExecutionPolicy, UpdateType>>(std::forward<Args>(args)...));
+    return *this;
+}
+//=================================================================================================//
+template <class ExecutionPolicy, typename AlgorithmType, template <typename...> class InteractionType>
+auto &InteractionDynamicsCK<ExecutionPolicy, InteractionType<AlgorithmType>>::
+    addPreStateDynamics(BaseDynamics<void> &state_dynamics)
+{
+    this->pre_processes_.push_back(&state_dynamics);
     return *this;
 }
 //=================================================================================================//

--- a/src/shared/sphinxsys_system/sph_system.cpp
+++ b/src/shared/sphinxsys_system/sph_system.cpp
@@ -19,6 +19,7 @@ SPHSystem::SPHSystem(BoundingBox system_domain_bounds, Real resolution_ref, size
     Log::init();
     spdlog::set_level(static_cast<spdlog::level::level_enum>(log_level_));
     registerSystemVariable<Real>("PhysicalTime", 0.0);
+    Log::get()->info("The reference resolution of the SPHSystem is {}.", resolution_ref_);
 }
 //=================================================================================================//
 void SPHSystem::setLogLevel(size_t log_level)

--- a/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -236,11 +236,14 @@ int main(int ac, char *av[])
     // //	Creating body parts.
     // //----------------------------------------------------------------------
     AlignedBoxByCell left_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(left_bidirectional_translation), bidirectional_buffer_halfsize));
+    left_emitter_by_cell.writeShapeProxy(sph_system);
+
     auto default_normal = Vec3d::UnitX();
     auto rotated_normal = -1 * Vec3d::UnitX();
     auto rotation_axis = Vec3d::UnitY();
     auto rot3d = Rotation3d(std::acos(default_normal.dot(rotated_normal)), rotation_axis);
     AlignedBoxByCell right_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(rot3d, right_bidirectional_translation), bidirectional_buffer_halfsize));
+    right_emitter_by_cell.writeShapeProxy(sph_system);
     // AlignedBoxByCell right_emitter_by_cell(water_body, AlignedBox(xAxis, Transform(left_bidirectional_translation), bidirectional_buffer_halfsize));
     //----------------------------------------------------------------------
     //	Define body relation map.
@@ -248,8 +251,7 @@ int main(int ac, char *av[])
     //	Basically the the range of bodies to build neighbor particle lists.
     //  Generally, we first define all the inner relations, then the contact relations.
     // ----------------------------------------------------------------------
-    Inner<>
-        water_body_inner(water_body);
+    Inner<> water_body_inner(water_body);
     Contact<> water_wall_contact(water_body, {&wall});
     Contact<> velocity_observer_contact(velocity_observer, {&water_body});
     //----------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across the codebase, focusing on mesh output functionality, interface marking logic, particle management, and logging improvements. The main highlights are the addition of a method to export 3D mesh shapes to VTK PolyData files, adjustments to interface marking thresholds, and improvements to particle management and error reporting.

**Mesh Output and Shape Proxy Enhancements:**

- Added a `writeMeshToFile` method to the `TriangleMeshShape` class, enabling the export of triangle mesh data to VTK PolyData (`.vtp`) files for 3D geometries. This includes writing both vertex and face data, and applying coordinate transformations. (`src/for_3D_build/geometries/triangle_mesh_shape.cpp`, `src/for_3D_build/geometries/triangle_mesh_shape.h`, [[1]](diffhunk://#diff-d7cb3a812b677082171b51a8143b0fcee02438875d957b730f062160ac04a79bR3-R72) [[2]](diffhunk://#diff-cf1658a06325b29dc54534e5a9225e7a66ddde9b837f9468f545b405d1f19d10R63)
- Introduced the `writeShapeProxy` method in the `AlignedBoxPart` class. In 3D, this writes a mesh proxy file for the aligned box part using the new mesh export functionality; in 2D, it prints a message indicating the feature is not available. (`src/shared/bodies/base_body_part.h`, `src/for_3D_build/bodies/base_body_part_3d.cpp`, `src/for_2D_build/bodies/base_body_part_2d.cpp`, [[1]](diffhunk://#diff-d6e7fed8f35c0f6a75461bc22dbb6dfeb49c4165d573ddab5e0f2187945fcf51R259) [[2]](diffhunk://#diff-dc565b12cccaf3222e875a5ec4d312b882bd4be5d013d9dfe67e0f38a89e6d58R1-R15) [[3]](diffhunk://#diff-5b4f8d4a1e3e3287a8cb3b9b8a1d5d3917fe417136235a82b0bedebfdedd512fR1-R11)
- Updated a test example to call `writeShapeProxy` for emitter objects, ensuring mesh proxies are generated during test runs. (`tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp`, [tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cppR239-R254](diffhunk://#diff-b10bf253382253a78c43977615709ecb0343b2825fe6a552b355e01d6584e41cR239-R254))

**Mesh Dynamics and Interface Marking:**

- Changed the threshold calculation for marking cut interfaces and near interfaces from `data_spacing_ * std::pow(Dimensions, 1.0 / Real(Dimensions))` to `data_spacing_ * sqrt(Dimensions)`, and updated the perturbation ratio from `0.5` to `1.0` for more robust interface detection. (`src/shared/mesh_dynamics/all_mesh_dynamics.h`, `src/shared/mesh_dynamics/mesh_local_dynamics.cpp`, [[1]](diffhunk://#diff-2036f11ba1f86f4be80eb9f961bcf20e96d3fbb6b2d41dd1bf30d9cf5b18c51aL115-R115) [[2]](diffhunk://#diff-870d6496416e6b29cd5d940d4cdf3e61a9bc48601e17018e4dacc7a44da871edL191-R198)

**Particle Management and Error Reporting:**

- Improved error messages in `BaseParticles` to include the type name of missing variables, aiding debugging. (`src/shared/particles/base_particles.hpp`, [src/shared/particles/base_particles.hppL335-R335](diffhunk://#diff-16ad8c0941eb1e568b8f4282768a4a7d6c18972873003e6e539d4f3756078777L335-R335))
- In `SpawnRealParticle`, reinitialized the `original_id_` of newly spawned particles to their new index, ensuring correct tracking of particle origins. (`src/shared/particles/particle_operation.h`, [src/shared/particles/particle_operation.hL68-R69](diffhunk://#diff-f2bb99cb8cf3624022cac413fb502b7ca2f0698e257630172a88e397fea63a7eL68-R69))

**Dynamics Framework Improvements:**

- Enhanced the density regularization framework by updating the regularization functors to accept the particle index as an argument, and forwarding this in the update logic. (`src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.h`, `src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.hpp`, [[1]](diffhunk://#diff-2c5b9f4e7e8af370168580f556f30143ecf7dfaf5871e6457023d4b59b34ee7dL64-R64) [[2]](diffhunk://#diff-2c5b9f4e7e8af370168580f556f30143ecf7dfaf5871e6457023d4b59b34ee7dL83-R83) [[3]](diffhunk://#diff-315d4f19c5f73adc66ebe158ff7b16f0016b235df60e1146d5dab4466364b80fL82-R82)
- Added overloads for `addPostStateDynamics` and `addPreStateDynamics` in `InteractionDynamicsCK` to accept existing dynamics objects, improving flexibility for composing simulation steps. (`src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.h`, `src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.hpp`, [[1]](diffhunk://#diff-e44d63afa3b67e5413bd9a90b978404ccfde2f1c3f8aa532c7c05b24f5f39756R114-R118) [[2]](diffhunk://#diff-72266441c7ae459f80e2a8b8cccf7b6f949e9a441d0e0a080ef5acebaca0c173R45-R51) [[3]](diffhunk://#diff-72266441c7ae459f80e2a8b8cccf7b6f949e9a441d0e0a080ef5acebaca0c173R65-R72)

**Logging Improvements:**

- Added an informational log message in `SPHSystem` to report the reference resolution at system initialization. (`src/shared/sphinxsys_system/sph_system.cpp`, [src/shared/sphinxsys_system/sph_system.cppR22](diffhunk://#diff-79de432f29aa9fba528130763843cc5741f40343bada480df8e007b787815533R22))