### PR TITLE
Xiangyu/mesh offset in mesh

### DIFF
--- a/src/for_2D_build/mesh_dynamics/mesh_local_dynamics.hpp
+++ b/src/for_2D_build/mesh_dynamics/mesh_local_dynamics.hpp
@@ -11,7 +11,7 @@ inline void NearInterfaceCellTagging::UpdateKernel::update(const UnsignedInt &pa
 {
     UnsignedInt sort_index = data_mesh_->getOccupiedDataPackages()[package_index - num_singular_pkgs_].first;
     Arrayi cell_index = base_dynamics->CellIndexFromSortIndex(sort_index);
-    UnsignedInt index_1d = data_mesh_->LinearCellIndexFromCellIndex(cell_index);
+    UnsignedInt index_1d = data_mesh_->LinearCellIndex(cell_index);
 
     MeshVariableData<Real> &grid_phi = phi_[package_index];
     Real phi0 = grid_phi[0][0];
@@ -27,7 +27,7 @@ inline void NearInterfaceCellTagging::UpdateKernel::update(const UnsignedInt &pa
 //=================================================================================================//
 inline void CellContainDiffusion::UpdateKernel::update(const Arrayi &cell_index)
 {
-    UnsignedInt index_1d = data_mesh_->LinearCellIndexFromCellIndex(cell_index);
+    UnsignedInt index_1d = data_mesh_->LinearCellIndex(cell_index);
     if (cell_contain_id_[index_1d] == 2)
     {
         if (mesh_any_of(
@@ -35,7 +35,7 @@ inline void CellContainDiffusion::UpdateKernel::update(const Arrayi &cell_index)
                 data_mesh_->AllCells().min(cell_index + 2 * Arrayi::Ones()),
                 [&](int l, int m)
                 {
-                    UnsignedInt neighbor_1d = data_mesh_->transferMeshIndexTo1D(data_mesh_->AllCells(), Arrayi(l, m));
+                    UnsignedInt neighbor_1d = data_mesh_->LinearCellIndex(Arrayi(l, m));
                     return cell_contain_id_[neighbor_1d] == -1;
                 }))
         {
@@ -49,7 +49,7 @@ inline void CellContainDiffusion::UpdateKernel::update(const Arrayi &cell_index)
                      data_mesh_->AllCells().min(cell_index + 2 * Arrayi::Ones()),
                      [&](int l, int m)
                      {
-                         UnsignedInt neighbor_1d = data_mesh_->transferMeshIndexTo1D(data_mesh_->AllCells(), Arrayi(l, m));
+                         UnsignedInt neighbor_1d = data_mesh_->LinearCellIndex(Arrayi(l, m));
                          return cell_contain_id_[neighbor_1d] == 1;
                      }))
         {

--- a/src/for_2D_build/meshes/cell_linked_list_2d.cpp
+++ b/src/for_2D_build/meshes/cell_linked_list_2d.cpp
@@ -5,7 +5,7 @@
 namespace SPH
 {
 //=============================================================================================//
-void BaseCellLinkedList::writeMeshFieldToPltByMesh(Mesh &mesh, UnsignedInt mesh_offset, std::ofstream &output_file)
+void BaseCellLinkedList::writeMeshFieldToPltByMesh(Mesh &mesh, std::ofstream &output_file)
 {
     Array2i number_of_operation = mesh.AllCells();
 
@@ -44,15 +44,14 @@ void BaseCellLinkedList::writeMeshFieldToPltByMesh(Mesh &mesh, UnsignedInt mesh_
     {
         for (int i = 0; i != number_of_operation[0]; ++i)
         {
-            UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(Array2i(i, j));
+            UnsignedInt linear_index = mesh.LinearCellIndex(Array2i(i, j));
             output_file << cell_index_lists_[linear_index].size() << " ";
         }
         output_file << " \n";
     }
 }
 //=================================================================================================//
-void BaseCellLinkedList::tagBoundingCellsByMesh(Mesh &mesh, UnsignedInt mesh_offset,
-                                                StdVec<CellLists> &cell_data_lists,
+void BaseCellLinkedList::tagBoundingCellsByMesh(Mesh &mesh, StdVec<CellLists> &cell_data_lists,
                                                 const BoundingBox &bounding_bounds, int axis)
 {
     int second_axis = NextAxis(axis);
@@ -68,7 +67,7 @@ void BaseCellLinkedList::tagBoundingCellsByMesh(Mesh &mesh, UnsignedInt mesh_off
             Array2i cell = Array2i::Zero();
             cell[axis] = i;
             cell[second_axis] = j;
-            UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(cell);
+            UnsignedInt linear_index = mesh.LinearCellIndex(cell);
             cell_data_lists[0].first.push_back(&cell_index_lists_[linear_index]);
             cell_data_lists[0].second.push_back(&cell_data_lists_[linear_index]);
         }
@@ -82,7 +81,7 @@ void BaseCellLinkedList::tagBoundingCellsByMesh(Mesh &mesh, UnsignedInt mesh_off
             Array2i cell = Array2i::Zero();
             cell[axis] = i;
             cell[second_axis] = j;
-            UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(cell);
+            UnsignedInt linear_index = mesh.LinearCellIndex(cell);
             cell_data_lists[1].first.push_back(&cell_index_lists_[linear_index]);
             cell_data_lists[1].second.push_back(&cell_data_lists_[linear_index]);
         }

--- a/src/for_2D_build/meshes/cell_linked_list_2d.cpp
+++ b/src/for_2D_build/meshes/cell_linked_list_2d.cpp
@@ -44,7 +44,7 @@ void BaseCellLinkedList::writeMeshFieldToPltByMesh(Mesh &mesh, UnsignedInt mesh_
     {
         for (int i = 0; i != number_of_operation[0]; ++i)
         {
-            UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndexFromCellIndex(Array2i(i, j));
+            UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(Array2i(i, j));
             output_file << cell_index_lists_[linear_index].size() << " ";
         }
         output_file << " \n";
@@ -68,7 +68,7 @@ void BaseCellLinkedList::tagBoundingCellsByMesh(Mesh &mesh, UnsignedInt mesh_off
             Array2i cell = Array2i::Zero();
             cell[axis] = i;
             cell[second_axis] = j;
-            UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndexFromCellIndex(cell);
+            UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(cell);
             cell_data_lists[0].first.push_back(&cell_index_lists_[linear_index]);
             cell_data_lists[0].second.push_back(&cell_data_lists_[linear_index]);
         }
@@ -82,7 +82,7 @@ void BaseCellLinkedList::tagBoundingCellsByMesh(Mesh &mesh, UnsignedInt mesh_off
             Array2i cell = Array2i::Zero();
             cell[axis] = i;
             cell[second_axis] = j;
-            UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndexFromCellIndex(cell);
+            UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(cell);
             cell_data_lists[1].first.push_back(&cell_index_lists_[linear_index]);
             cell_data_lists[1].second.push_back(&cell_data_lists_[linear_index]);
         }

--- a/src/for_2D_build/meshes/sparse_storage_mesh/mesh_with_data_packages.hpp
+++ b/src/for_2D_build/meshes/sparse_storage_mesh/mesh_with_data_packages.hpp
@@ -123,7 +123,7 @@ void MeshWithGridDataPackages<PKG_SIZE>::writeBKGMeshVariableToPlt(std::ofstream
         Arrayi::Zero(), number_of_operation,
         [&](const Array2i &cell_index)
         {
-            UnsignedInt linear_index = transferMeshIndexTo1D(all_cells_, cell_index);
+            UnsignedInt linear_index = LinearCellIndex(cell_index);
             Vecd data_position = CellPositionFromIndex(cell_index);
             output_file << data_position[0] << " " << data_position[1] << " ";
 

--- a/src/for_3D_build/mesh_dynamics/mesh_local_dynamics.hpp
+++ b/src/for_3D_build/mesh_dynamics/mesh_local_dynamics.hpp
@@ -11,7 +11,7 @@ inline void NearInterfaceCellTagging::UpdateKernel::update(const UnsignedInt &pa
 {
     UnsignedInt sort_index = data_mesh_->getOccupiedDataPackages()[package_index - num_singular_pkgs_].first;
     Arrayi cell_index = base_dynamics->CellIndexFromSortIndex(sort_index);
-    UnsignedInt index_1d = data_mesh_->LinearCellIndexFromCellIndex(cell_index);
+    UnsignedInt index_1d = data_mesh_->LinearCellIndex(cell_index);
 
     MeshVariableData<Real> &grid_phi = phi_[package_index];
     Real phi0 = grid_phi[0][0][0];
@@ -27,7 +27,7 @@ inline void NearInterfaceCellTagging::UpdateKernel::update(const UnsignedInt &pa
 //=================================================================================================//
 inline void CellContainDiffusion::UpdateKernel::update(const Arrayi &cell_index)
 {
-    UnsignedInt index_1d = data_mesh_->LinearCellIndexFromCellIndex(cell_index);
+    UnsignedInt index_1d = data_mesh_->LinearCellIndex(cell_index);
     if (cell_contain_id_[index_1d] == 2)
     {
         if (mesh_any_of(
@@ -35,7 +35,7 @@ inline void CellContainDiffusion::UpdateKernel::update(const Arrayi &cell_index)
                 data_mesh_->AllCells().min(cell_index + 2 * Arrayi::Ones()),
                 [&](int l, int m, int n)
                 {
-                    UnsignedInt neighbor_1d = data_mesh_->transferMeshIndexTo1D(data_mesh_->AllCells(), Arrayi(l, m, n));
+                    UnsignedInt neighbor_1d = data_mesh_->LinearCellIndex(Arrayi(l, m, n));
                     return cell_contain_id_[neighbor_1d] == -1;
                 }))
         {
@@ -49,7 +49,7 @@ inline void CellContainDiffusion::UpdateKernel::update(const Arrayi &cell_index)
                      data_mesh_->AllCells().min(cell_index + 2 * Arrayi::Ones()),
                      [&](int l, int m, int n)
                      {
-                         UnsignedInt neighbor_1d = data_mesh_->transferMeshIndexTo1D(data_mesh_->AllCells(), Arrayi(l, m, n));
+                         UnsignedInt neighbor_1d = data_mesh_->LinearCellIndex(Arrayi(l, m, n));
                          return cell_contain_id_[neighbor_1d] == 1;
                      }))
         {

--- a/src/for_3D_build/meshes/cell_linked_list_3d.cpp
+++ b/src/for_3D_build/meshes/cell_linked_list_3d.cpp
@@ -64,7 +64,7 @@ void BaseCellLinkedList::writeMeshFieldToPltByMesh(Mesh &mesh, UnsignedInt mesh_
         {
             for (int i = 0; i != number_of_operation[0]; ++i)
             {
-                UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndexFromCellIndex(Array3i(i, j, k));
+                UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(Array3i(i, j, k));
                 output_file << cell_data_lists_[linear_index].size() << " ";
             }
             output_file << " \n";
@@ -95,7 +95,7 @@ void BaseCellLinkedList::tagBoundingCellsByMesh(Mesh &mesh, UnsignedInt mesh_off
                 cell[axis] = i;
                 cell[second_axis] = j;
                 cell[third_axis] = k;
-                UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndexFromCellIndex(cell);
+                UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(cell);
                 cell_data_lists[0].first.push_back(&cell_index_lists_[linear_index]);
                 cell_data_lists[0].second.push_back(&cell_data_lists_[linear_index]);
             }
@@ -116,7 +116,7 @@ void BaseCellLinkedList::tagBoundingCellsByMesh(Mesh &mesh, UnsignedInt mesh_off
                 cell[axis] = i;
                 cell[second_axis] = j;
                 cell[third_axis] = k;
-                UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndexFromCellIndex(cell);
+                UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(cell);
                 cell_data_lists[1].first.push_back(&cell_index_lists_[linear_index]);
                 cell_data_lists[1].second.push_back(&cell_data_lists_[linear_index]);
             }

--- a/src/for_3D_build/meshes/cell_linked_list_3d.cpp
+++ b/src/for_3D_build/meshes/cell_linked_list_3d.cpp
@@ -10,7 +10,7 @@
 namespace SPH
 {
 //=================================================================================================//
-void BaseCellLinkedList::writeMeshFieldToPltByMesh(Mesh &mesh, UnsignedInt mesh_offset, std::ofstream &output_file)
+void BaseCellLinkedList::writeMeshFieldToPltByMesh(Mesh &mesh, std::ofstream &output_file)
 {
     Array3i number_of_operation = mesh.AllCells();
 
@@ -64,15 +64,14 @@ void BaseCellLinkedList::writeMeshFieldToPltByMesh(Mesh &mesh, UnsignedInt mesh_
         {
             for (int i = 0; i != number_of_operation[0]; ++i)
             {
-                UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(Array3i(i, j, k));
+                UnsignedInt linear_index = mesh.LinearCellIndex(Array3i(i, j, k));
                 output_file << cell_data_lists_[linear_index].size() << " ";
             }
             output_file << " \n";
         }
 }
 //=================================================================================================//
-void BaseCellLinkedList::tagBoundingCellsByMesh(Mesh &mesh, UnsignedInt mesh_offset,
-                                                StdVec<CellLists> &cell_data_lists,
+void BaseCellLinkedList::tagBoundingCellsByMesh(Mesh &mesh, StdVec<CellLists> &cell_data_lists,
                                                 const BoundingBox &bounding_bounds, int axis)
 {
     int second_axis = NextAxis(axis);
@@ -95,7 +94,7 @@ void BaseCellLinkedList::tagBoundingCellsByMesh(Mesh &mesh, UnsignedInt mesh_off
                 cell[axis] = i;
                 cell[second_axis] = j;
                 cell[third_axis] = k;
-                UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(cell);
+                UnsignedInt linear_index = mesh.LinearCellIndex(cell);
                 cell_data_lists[0].first.push_back(&cell_index_lists_[linear_index]);
                 cell_data_lists[0].second.push_back(&cell_data_lists_[linear_index]);
             }
@@ -116,7 +115,7 @@ void BaseCellLinkedList::tagBoundingCellsByMesh(Mesh &mesh, UnsignedInt mesh_off
                 cell[axis] = i;
                 cell[second_axis] = j;
                 cell[third_axis] = k;
-                UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(cell);
+                UnsignedInt linear_index = mesh.LinearCellIndex(cell);
                 cell_data_lists[1].first.push_back(&cell_index_lists_[linear_index]);
                 cell_data_lists[1].second.push_back(&cell_data_lists_[linear_index]);
             }

--- a/src/for_3D_build/meshes/sparse_storage_mesh/mesh_with_data_packages.hpp
+++ b/src/for_3D_build/meshes/sparse_storage_mesh/mesh_with_data_packages.hpp
@@ -143,7 +143,7 @@ void MeshWithGridDataPackages<PKG_SIZE>::writeBKGMeshVariableToPlt(std::ofstream
         Arrayi::Zero(), number_of_operation,
         [&](const Arrayi &cell_index)
         {
-            UnsignedInt linear_index = transferMeshIndexTo1D(all_cells_, cell_index);
+            UnsignedInt linear_index = LinearCellIndex(cell_index);
             Vecd data_position = CellPositionFromIndex(cell_index);
             output_file << data_position[0] << " " << data_position[1] << " " << data_position[2] << " ";
 

--- a/src/shared/body_relations/contact_body_relation.cpp
+++ b/src/shared/body_relations/contact_body_relation.cpp
@@ -26,7 +26,7 @@ void ContactRelation::updateConfiguration()
     {
         Mesh &mesh = target_cell_linked_lists_[k]->getMesh();
         target_cell_linked_lists_[k]->searchNeighborsByMesh(
-            mesh, 0, sph_body_, contact_configuration_[k],
+            mesh, sph_body_, contact_configuration_[k],
             *get_search_depths_[k], *get_contact_neighbors_[k]);
     }
 }
@@ -63,7 +63,7 @@ void ShellSurfaceContactRelation::updateConfiguration()
     {
         Mesh &mesh = target_cell_linked_lists_[k]->getMesh();
         target_cell_linked_lists_[k]->searchNeighborsByMesh(
-            mesh, 0, *body_surface_layer_, contact_configuration_[k],
+            mesh, *body_surface_layer_, contact_configuration_[k],
             *get_search_depths_[k], *get_contact_neighbors_[k]);
     }
 }
@@ -87,7 +87,7 @@ void ContactRelationToBodyPart::updateConfiguration()
     {
         Mesh &mesh = target_cell_linked_lists_[k]->getMesh();
         target_cell_linked_lists_[k]->searchNeighborsByMesh(
-            mesh, 0, sph_body_, contact_configuration_[k],
+            mesh, sph_body_, contact_configuration_[k],
             *get_search_depths_[k], *get_part_contact_neighbors_[k]);
     }
 }
@@ -122,11 +122,10 @@ void AdaptiveContactRelation::updateConfiguration()
     for (size_t k = 0; k != contact_bodies_.size(); ++k)
     {
         StdVec<Mesh *> &meshes = cell_linked_lists_[k]->getMeshes();
-        StdVec<UnsignedInt> &mesh_offsets = cell_linked_lists_[k]->getMeshOffsets();
         for (size_t l = 0; l != meshes.size(); ++l)
         {
             cell_linked_lists_[k]->searchNeighborsByMesh(
-                *meshes[l], mesh_offsets[l], sph_body_, contact_configuration_[k],
+                *meshes[l], sph_body_, contact_configuration_[k],
                 *get_multi_level_search_range_[k][l], *get_contact_neighbors_adaptive_[k][l]);
         }
     }
@@ -156,7 +155,7 @@ void ContactRelationFromShellToFluid::updateConfiguration()
     {
         Mesh &mesh = target_cell_linked_lists_[k]->getMesh();
         target_cell_linked_lists_[k]->searchNeighborsByMesh(
-            mesh, 0, sph_body_, contact_configuration_[k],
+            mesh, sph_body_, contact_configuration_[k],
             *get_search_depths_[k], *get_shell_contact_neighbors_[k]);
     }
 }
@@ -185,7 +184,7 @@ void ContactRelationFromFluidToShell::updateConfiguration()
     {
         Mesh &mesh = target_cell_linked_lists_[k]->getMesh();
         target_cell_linked_lists_[k]->searchNeighborsByMesh(
-            mesh, 0, sph_body_, contact_configuration_[k],
+            mesh, sph_body_, contact_configuration_[k],
             *get_search_depths_[k], *get_contact_neighbors_[k]);
     }
 }
@@ -245,7 +244,7 @@ void SurfaceContactRelation::updateConfiguration()
     {
         Mesh &mesh = target_cell_linked_lists_[k]->getMesh();
         target_cell_linked_lists_[k]->searchNeighborsByMesh(
-            mesh, 0, *body_surface_layer_, contact_configuration_[k],
+            mesh, *body_surface_layer_, contact_configuration_[k],
             *get_search_depths_[k], *get_contact_neighbors_[k]);
     }
 }

--- a/src/shared/body_relations/inner_body_relation.cpp
+++ b/src/shared/body_relations/inner_body_relation.cpp
@@ -15,7 +15,7 @@ void InnerRelation::updateConfiguration()
 {
     resetNeighborhoodCurrentSize();
     Mesh &mesh = cell_linked_list_.getMesh();
-    cell_linked_list_.searchNeighborsByMesh(mesh, 0, sph_body_, inner_configuration_,
+    cell_linked_list_.searchNeighborsByMesh(mesh, sph_body_, inner_configuration_,
                                             get_single_search_depth_, get_inner_neighbor_);
 }
 //=================================================================================================//
@@ -39,11 +39,10 @@ void AdaptiveInnerRelation::updateConfiguration()
 {
     resetNeighborhoodCurrentSize();
     StdVec<Mesh *> &meshes = multi_level_cell_linked_list_.getMeshes();
-    StdVec<UnsignedInt> &mesh_offsets = multi_level_cell_linked_list_.getMeshOffsets();
     for (size_t l = 0; l != meshes.size(); ++l)
     {
         multi_level_cell_linked_list_.searchNeighborsByMesh(
-            *meshes[l], mesh_offsets[l], sph_body_, inner_configuration_,
+            *meshes[l], sph_body_, inner_configuration_,
             *get_multi_level_search_depth_[l], get_adaptive_inner_neighbor_);
     }
 }
@@ -70,7 +69,7 @@ void SelfSurfaceContactRelation::updateConfiguration()
     resetNeighborhoodCurrentSize();
     Mesh &mesh = cell_linked_list_.getMesh();
     cell_linked_list_.searchNeighborsByMesh(
-        mesh, 0, body_surface_layer_, inner_configuration_,
+        mesh, body_surface_layer_, inner_configuration_,
         get_single_search_depth_, get_self_contact_neighbor_);
 }
 //=================================================================================================//
@@ -94,7 +93,7 @@ void ShellInnerRelationWithContactKernel::updateConfiguration()
     resetNeighborhoodCurrentSize();
     Mesh &mesh = cell_linked_list_.getMesh();
     cell_linked_list_.searchNeighborsByMesh(
-        mesh, 0, sph_body_, inner_configuration_,
+        mesh, sph_body_, inner_configuration_,
         get_contact_search_depth_, get_inner_neighbor_with_contact_kernel_);
 }
 //=================================================================================================//
@@ -109,7 +108,7 @@ void ShellSelfContactRelation::updateConfiguration()
     resetNeighborhoodCurrentSize();
     Mesh &mesh = cell_linked_list_.getMesh();
     cell_linked_list_.searchNeighborsByMesh(
-        mesh, 0, sph_body_, inner_configuration_,
+        mesh, sph_body_, inner_configuration_,
         get_single_search_depth_, get_shell_self_contact_neighbor_);
 }
 //=================================================================================================//
@@ -117,11 +116,10 @@ void AdaptiveSplittingInnerRelation::updateConfiguration()
 {
     resetNeighborhoodCurrentSize();
     StdVec<Mesh *> &meshes = multi_level_cell_linked_list_.getMeshes();
-    StdVec<UnsignedInt> &mesh_offsets = multi_level_cell_linked_list_.getMeshOffsets();
     for (size_t l = 0; l != meshes.size(); ++l)
     {
         multi_level_cell_linked_list_.searchNeighborsByMesh(
-            *meshes[l], mesh_offsets[l], sph_body_, inner_configuration_,
+            *meshes[l], sph_body_, inner_configuration_,
             *get_multi_level_search_depth_[l], get_adaptive_splitting_inner_neighbor_);
     }
 }

--- a/src/shared/mesh_dynamics/mesh_local_dynamics.cpp
+++ b/src/shared/mesh_dynamics/mesh_local_dynamics.cpp
@@ -23,7 +23,7 @@ InitialCellTagging::InitialCellTagging(MeshWithGridDataPackagesType &data_mesh, 
 void InitialCellTagging::UpdateKernel::update(const Arrayi &cell_index)
 {
     data_mesh_->assignDataPackageIndex(cell_index, 1); // outside far field by default
-    UnsignedInt index_1d = data_mesh_->LinearCellIndexFromCellIndex(cell_index);
+    UnsignedInt index_1d = data_mesh_->LinearCellIndex(cell_index);
     cell_contain_id_[index_1d] = 2; // default value is 2, indicating not near interface
     Vecd cell_position = data_mesh_->CellPositionFromIndex(cell_index);
     Real signed_distance = shape_->findSignedDistance(cell_position);
@@ -60,7 +60,7 @@ void InitialCellTaggingFromCoarse::UpdateKernel::update(const Arrayi &cell_index
     UnsignedInt package_index = phi < 0.0 ? 0 : 1;
     data_mesh_->assignDataPackageIndex(cell_index, package_index);
 
-    UnsignedInt index_1d = data_mesh_->LinearCellIndexFromCellIndex(cell_index);
+    UnsignedInt index_1d = data_mesh_->LinearCellIndex(cell_index);
     cell_contain_id_[index_1d] = 2;
     if (ABS(phi) > far_field_distance_)
     {
@@ -100,7 +100,7 @@ void InitializeCellPackageInfo::UpdateKernel::update(const UnsignedInt &package_
     ConcurrentVec<std::pair<UnsignedInt, int>> &occupied_data_pkgs = data_mesh_->getOccupiedDataPackages();
     UnsignedInt sort_index = occupied_data_pkgs[package_index - num_singular_pkgs_].first;
     Arrayi cell_index = base_dynamics->CellIndexFromSortIndex(sort_index);
-    UnsignedInt linear_index = data_mesh_->LinearCellIndexFromCellIndex(cell_index);
+    UnsignedInt linear_index = data_mesh_->LinearCellIndex(cell_index);
     cell_pkg_index_[linear_index] = package_index;
     std::pair<Arrayi, int> &metadata = pkg_cell_info_[package_index];
     metadata.first = cell_index;

--- a/src/shared/meshes/base_mesh.cpp
+++ b/src/shared/meshes/base_mesh.cpp
@@ -3,7 +3,7 @@
 namespace SPH
 {
 //=================================================================================================//
-Mesh::Mesh(BoundingBox tentative_bounds, Real grid_spacing, size_t buffer_width)
+Mesh::Mesh(BoundingBox tentative_bounds, Real grid_spacing, UnsignedInt buffer_width)
     : grid_spacing_(grid_spacing), buffer_width_(buffer_width)
 {
     Vecd mesh_buffer = Real(buffer_width) * grid_spacing * Vecd::Ones();

--- a/src/shared/meshes/base_mesh.cpp
+++ b/src/shared/meshes/base_mesh.cpp
@@ -3,8 +3,10 @@
 namespace SPH
 {
 //=================================================================================================//
-Mesh::Mesh(BoundingBox tentative_bounds, Real grid_spacing, UnsignedInt buffer_width)
-    : grid_spacing_(grid_spacing), buffer_width_(buffer_width)
+Mesh::Mesh(BoundingBox tentative_bounds, Real grid_spacing,
+           UnsignedInt buffer_width, UnsignedInt linear_cell_index_offset)
+    : grid_spacing_(grid_spacing), buffer_width_(buffer_width),
+      linear_cell_index_offset_(linear_cell_index_offset)
 {
     Vecd mesh_buffer = Real(buffer_width) * grid_spacing * Vecd::Ones();
     mesh_lower_bound_ = tentative_bounds.first_ - mesh_buffer;
@@ -15,7 +17,8 @@ Mesh::Mesh(BoundingBox tentative_bounds, Real grid_spacing, UnsignedInt buffer_w
 //=================================================================================================//
 Mesh::Mesh(Vecd mesh_lower_bound, Real grid_spacing, Arrayi all_grid_points)
     : mesh_lower_bound_{mesh_lower_bound}, grid_spacing_{grid_spacing},
-      buffer_width_(0), all_grid_points_{all_grid_points}
+      buffer_width_(0), all_grid_points_{all_grid_points},
+      linear_cell_index_offset_(0)
 {
     all_cells_ = all_grid_points_ - Arrayi::Ones();
 }

--- a/src/shared/meshes/base_mesh.h
+++ b/src/shared/meshes/base_mesh.h
@@ -50,7 +50,8 @@ namespace SPH
 class Mesh
 {
   public:
-    Mesh(BoundingBox tentative_bounds, Real grid_spacing, UnsignedInt buffer_width);
+    Mesh(BoundingBox tentative_bounds, Real grid_spacing,
+         UnsignedInt buffer_width, UnsignedInt linear_cell_index_offset = 0);
     Mesh(Vecd mesh_lower_bound, Real grid_spacing, Arrayi all_grid_points);
     ~Mesh() {};
 
@@ -71,12 +72,13 @@ class Mesh
 
     UnsignedInt LinearCellIndexFromPosition(const Vecd &position) const
     {
-        return transferMeshIndexTo1D(all_cells_, CellIndexFromPosition(position));
+        return linear_cell_index_offset_ +
+               transferMeshIndexTo1D(all_cells_, CellIndexFromPosition(position));
     };
 
     UnsignedInt LinearCellIndex(const Arrayi &cell_index) const
     {
-        return transferMeshIndexTo1D(all_cells_, cell_index);
+        return linear_cell_index_offset_ + transferMeshIndexTo1D(all_cells_, cell_index);
     };
 
     Vecd CellPositionFromIndex(const Arrayi &cell_index) const;
@@ -134,11 +136,12 @@ class Mesh
     };
 
   protected:
-    Vecd mesh_lower_bound_;    /**< mesh lower bound as reference coordinate */
-    Real grid_spacing_;        /**< grid_spacing */
-    UnsignedInt buffer_width_; /**< buffer width to avoid bound check.*/
-    Arrayi all_grid_points_;   /**< number of grid points by dimension */
-    Arrayi all_cells_;         /**< number of cells by dimension */
+    Vecd mesh_lower_bound_;                /**< mesh lower bound as reference coordinate */
+    Real grid_spacing_;                    /**< grid_spacing */
+    UnsignedInt buffer_width_;             /**< buffer width to avoid bound check.*/
+    Arrayi all_grid_points_;               /**< number of grid points by dimension */
+    Arrayi all_cells_;                     /**< number of cells by dimension */
+    UnsignedInt linear_cell_index_offset_; /**< offset for linear cell index, used for sub-mesh */
 
     static UnsignedInt MortonCode(const UnsignedInt &i)
     {

--- a/src/shared/meshes/base_mesh.h
+++ b/src/shared/meshes/base_mesh.h
@@ -50,7 +50,7 @@ namespace SPH
 class Mesh
 {
   public:
-    Mesh(BoundingBox tentative_bounds, Real grid_spacing, size_t buffer_width);
+    Mesh(BoundingBox tentative_bounds, Real grid_spacing, UnsignedInt buffer_width);
     Mesh(Vecd mesh_lower_bound, Real grid_spacing, Arrayi all_grid_points);
     ~Mesh() {};
 
@@ -58,8 +58,8 @@ class Mesh
     Real GridSpacing() const { return grid_spacing_; };
     Arrayi AllGridPoints() const { return all_grid_points_; };
     Arrayi AllCells() const { return all_cells_; };
-    size_t NumberOfGridPoints() const { return transferMeshIndexTo1D(all_grid_points_, all_grid_points_); };
-    size_t NumberOfCells() const { return all_cells_.prod(); };
+    UnsignedInt NumberOfGridPoints() const { return all_grid_points_.prod(); };
+    UnsignedInt NumberOfCells() const { return all_cells_.prod(); };
 
     Arrayi CellIndexFromPosition(const Vecd &position) const
     {
@@ -69,12 +69,12 @@ class Mesh
             .min(all_grid_points_ - 2 * Arrayi::Ones());
     };
 
-    size_t LinearCellIndexFromPosition(const Vecd &position) const
+    UnsignedInt LinearCellIndexFromPosition(const Vecd &position) const
     {
         return transferMeshIndexTo1D(all_cells_, CellIndexFromPosition(position));
     };
 
-    size_t LinearCellIndexFromCellIndex(const Arrayi &cell_index) const
+    UnsignedInt LinearCellIndex(const Arrayi &cell_index) const
     {
         return transferMeshIndexTo1D(all_cells_, cell_index);
     };
@@ -89,59 +89,60 @@ class Mesh
     // Transferring between 1D mesh indexes.
     // Here, mesh size can be either AllGridPoints or AllCells.
     //----------------------------------------------------------------------
-    Array2i transfer1DtoMeshIndex(const Array2i &mesh_size, size_t i) const
+    static Array2i transfer1DtoMeshIndex(const Array2i &mesh_size, UnsignedInt i)
     {
-        size_t row_size = mesh_size[1];
-        size_t column = i / row_size;
+        UnsignedInt row_size = mesh_size[1];
+        UnsignedInt column = i / row_size;
         return Array2i(column, i - column * row_size);
     };
 
-    Array3i transfer1DtoMeshIndex(const Array3i &mesh_size, size_t i) const
+    static Array3i transfer1DtoMeshIndex(const Array3i &mesh_size, UnsignedInt i)
     {
-        size_t row_times_column_size = mesh_size[1] * mesh_size[2];
-        size_t page = i / row_times_column_size;
-        size_t left_over = (i - page * row_times_column_size);
-        size_t row_size = mesh_size[2];
-        size_t column = left_over / row_size;
+        UnsignedInt row_times_column_size = mesh_size[1] * mesh_size[2];
+        UnsignedInt page = i / row_times_column_size;
+        UnsignedInt left_over = (i - page * row_times_column_size);
+        UnsignedInt row_size = mesh_size[2];
+        UnsignedInt column = left_over / row_size;
         return Array3i(page, column, left_over - column * row_size);
     }
 
-    size_t transferMeshIndexTo1D(const Array2i &mesh_size, const Array2i &mesh_index) const
+    static UnsignedInt transferMeshIndexTo1D(const Array2i &mesh_size, const Array2i &mesh_index)
     {
         return mesh_index[0] * mesh_size[1] + mesh_index[1];
     };
 
-    size_t transferMeshIndexTo1D(const Array3i &mesh_size, const Array3i &mesh_index) const
+    static UnsignedInt transferMeshIndexTo1D(const Array3i &mesh_size, const Array3i &mesh_index)
     {
         return mesh_index[0] * mesh_size[1] * mesh_size[2] +
                mesh_index[1] * mesh_size[2] +
                mesh_index[2];
     };
+
     /** converts mesh index into a Morton order.
      * Interleave a 10 bit number in 32 bits, fill one bit and leave the other 2 as zeros
      * https://stackoverflow.com/questions/18529057/
      * produce-interleaving-bit-patterns-morton-keys-for-32-bit-64-bit-and-128bit
      */
-    size_t transferMeshIndexToMortonOrder(const Array2i &mesh_index) const
+    static UnsignedInt transferMeshIndexToMortonOrder(const Array2i &mesh_index)
     {
         return MortonCode(mesh_index[0]) | (MortonCode(mesh_index[1]) << 1);
     };
 
-    size_t transferMeshIndexToMortonOrder(const Array3i &mesh_index) const
+    static UnsignedInt transferMeshIndexToMortonOrder(const Array3i &mesh_index)
     {
         return MortonCode(mesh_index[0]) | (MortonCode(mesh_index[1]) << 1) | (MortonCode(mesh_index[2]) << 2);
     };
 
   protected:
-    Vecd mesh_lower_bound_;  /**< mesh lower bound as reference coordinate */
-    Real grid_spacing_;      /**< grid_spacing */
-    size_t buffer_width_;    /**< buffer width to avoid bound check.*/
-    Arrayi all_grid_points_; /**< number of grid points by dimension */
-    Arrayi all_cells_;       /**< number of cells by dimension */
+    Vecd mesh_lower_bound_;    /**< mesh lower bound as reference coordinate */
+    Real grid_spacing_;        /**< grid_spacing */
+    UnsignedInt buffer_width_; /**< buffer width to avoid bound check.*/
+    Arrayi all_grid_points_;   /**< number of grid points by dimension */
+    Arrayi all_cells_;         /**< number of cells by dimension */
 
-    size_t MortonCode(const size_t &i) const
+    static UnsignedInt MortonCode(const UnsignedInt &i)
     {
-        size_t x = i;
+        UnsignedInt x = i;
         x &= 0x3ff;
         x = (x | x << 16) & 0x30000ff;
         x = (x | x << 8) & 0x300f00f;

--- a/src/shared/meshes/cell_linked_list.cpp
+++ b/src/shared/meshes/cell_linked_list.cpp
@@ -89,7 +89,7 @@ void BaseCellLinkedList::tagBodyPartByCellByMesh(Mesh &mesh, UnsignedInt mesh_of
                 });
             if (is_included == true)
             {
-                UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndexFromCellIndex(cell_index);
+                UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(cell_index);
                 cell_lists.push_back(&cell_index_lists_[linear_index]);
                 cell_indexes.push_back(linear_index);
             }
@@ -125,7 +125,7 @@ void BaseCellLinkedList::findNearestListDataEntryByMesh(Mesh &mesh, UnsignedInt 
         mesh.AllCells().min(cell + 2 * Arrayi::Ones()),
         [&](const Arrayi &cell_index)
         {
-            UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndexFromCellIndex(cell_index);
+            UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(cell_index);
             ListDataVector &target_particles = cell_data_lists_[linear_index];
             for (const ListData &list_data : target_particles)
             {
@@ -180,7 +180,7 @@ ListData CellLinkedList::findNearestListDataEntry(const Vecd &position)
 //=================================================================================================//
 UnsignedInt CellLinkedList::computingSequence(Vecd &position, UnsignedInt index_i)
 {
-    return mesh_->transferMeshIndexToMortonOrder(mesh_->CellIndexFromPosition(position));
+    return Mesh::transferMeshIndexToMortonOrder(mesh_->CellIndexFromPosition(position));
 }
 //=================================================================================================//
 void CellLinkedList::tagBodyPartByCell(ConcurrentCellLists &cell_lists,
@@ -258,8 +258,7 @@ void MultilevelCellLinkedList::InsertListDataEntry(UnsignedInt particle_index, c
 UnsignedInt MultilevelCellLinkedList::computingSequence(Vecd &position, UnsignedInt index_i)
 {
     UnsignedInt level = getMeshLevel(kernel_.CutOffRadius(h_ratio_[index_i]));
-    return meshes_[level]->transferMeshIndexToMortonOrder(
-        meshes_[level]->CellIndexFromPosition(position));
+    return Mesh::transferMeshIndexToMortonOrder(meshes_[level]->CellIndexFromPosition(position));
 }
 //=================================================================================================//
 void MultilevelCellLinkedList::tagBodyPartByCell(ConcurrentCellLists &cell_lists,

--- a/src/shared/meshes/cell_linked_list.cpp
+++ b/src/shared/meshes/cell_linked_list.cpp
@@ -67,8 +67,7 @@ void BaseCellLinkedList::UpdateCellListData(BaseParticles &base_particles)
         ap);
 }
 //=================================================================================================//
-void BaseCellLinkedList::tagBodyPartByCellByMesh(Mesh &mesh, UnsignedInt mesh_offset,
-                                                 ConcurrentCellLists &cell_lists,
+void BaseCellLinkedList::tagBodyPartByCellByMesh(Mesh &mesh, ConcurrentCellLists &cell_lists,
                                                  ConcurrentIndexVector &cell_indexes,
                                                  std::function<bool(Vecd, Real)> &check_included)
 {
@@ -89,7 +88,7 @@ void BaseCellLinkedList::tagBodyPartByCellByMesh(Mesh &mesh, UnsignedInt mesh_of
                 });
             if (is_included == true)
             {
-                UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(cell_index);
+                UnsignedInt linear_index = +mesh.LinearCellIndex(cell_index);
                 cell_lists.push_back(&cell_index_lists_[linear_index]);
                 cell_indexes.push_back(linear_index);
             }
@@ -115,8 +114,7 @@ void BaseCellLinkedList::UpdateCellLists(BaseParticles &base_particles)
     UpdateCellListData(base_particles);
 }
 //=================================================================================================//
-void BaseCellLinkedList::findNearestListDataEntryByMesh(Mesh &mesh, UnsignedInt mesh_offset,
-                                                        Real &min_distance_sqr, ListData &nearest_entry,
+void BaseCellLinkedList::findNearestListDataEntryByMesh(Mesh &mesh, Real &min_distance_sqr, ListData &nearest_entry,
                                                         const Vecd &position)
 {
     Arrayi cell = mesh.CellIndexFromPosition(position);
@@ -125,7 +123,7 @@ void BaseCellLinkedList::findNearestListDataEntryByMesh(Mesh &mesh, UnsignedInt 
         mesh.AllCells().min(cell + 2 * Arrayi::Ones()),
         [&](const Arrayi &cell_index)
         {
-            UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(cell_index);
+            UnsignedInt linear_index = mesh.LinearCellIndex(cell_index);
             ListDataVector &target_particles = cell_data_lists_[linear_index];
             for (const ListData &list_data : target_particles)
             {
@@ -147,7 +145,6 @@ CellLinkedList::CellLinkedList(BoundingBox tentative_bounds, Real grid_spacing,
         "BackgroundMesh", tentative_bounds, grid_spacing, 2);
     mesh_ = sv_mesh_->Data();
     meshes_.push_back(mesh_);
-    mesh_offsets_.push_back(0);
     total_number_of_cells_ = mesh_->NumberOfCells();
     initialize(base_particles);
 }
@@ -167,14 +164,14 @@ void CellLinkedList ::InsertListDataEntry(UnsignedInt particle_index, const Vecd
 void CellLinkedList::tagBoundingCells(StdVec<CellLists> &cell_data_lists,
                                       const BoundingBox &bounding_bounds, int axis)
 {
-    tagBoundingCellsByMesh(*mesh_, 0, cell_data_lists, bounding_bounds, axis);
+    tagBoundingCellsByMesh(*mesh_, cell_data_lists, bounding_bounds, axis);
 }
 //=================================================================================================//
 ListData CellLinkedList::findNearestListDataEntry(const Vecd &position)
 {
     Real min_distance_sqr = MaxReal;
     ListData nearest_entry = std::make_pair(MaxSize_t, MaxReal * Vecd::Ones());
-    findNearestListDataEntryByMesh(*mesh_, 0, min_distance_sqr, nearest_entry, position);
+    findNearestListDataEntryByMesh(*mesh_, min_distance_sqr, nearest_entry, position);
     return nearest_entry;
 }
 //=================================================================================================//
@@ -187,14 +184,14 @@ void CellLinkedList::tagBodyPartByCell(ConcurrentCellLists &cell_lists,
                                        ConcurrentIndexVector &cell_indexes,
                                        std::function<bool(Vecd, Real)> &check_included)
 {
-    tagBodyPartByCellByMesh(*mesh_, 0, cell_lists, cell_indexes, check_included);
+    tagBodyPartByCellByMesh(*mesh_, cell_lists, cell_indexes, check_included);
 }
 //=================================================================================================//
 void CellLinkedList::writeMeshFieldToPlt(const std::string &partial_file_name)
 {
     std::string full_file_name = partial_file_name + ".dat";
     std::ofstream out_file(full_file_name.c_str(), std::ios::app);
-    writeMeshFieldToPltByMesh(*mesh_, 0, out_file);
+    writeMeshFieldToPltByMesh(*mesh_, out_file);
     out_file.close();
 }
 //=================================================================================================//
@@ -207,9 +204,8 @@ MultilevelCellLinkedList::MultilevelCellLinkedList(
 {
     meshes_.push_back(mesh_ptrs_keeper_
                           .createPtr<SingularVariable<Mesh>>(
-                              "BackgroundMesh0", tentative_bounds, reference_grid_spacing, 2)
+                              "BackgroundMesh0", tentative_bounds, reference_grid_spacing, 2, 0)
                           ->Data());
-    mesh_offsets_.push_back(0);
     total_number_of_cells_ = meshes_[0]->NumberOfCells();
     for (UnsignedInt level = 1; level != total_levels; ++level)
     {
@@ -217,9 +213,9 @@ MultilevelCellLinkedList::MultilevelCellLinkedList(
         Real refined_spacing = meshes_[level - 1]->GridSpacing() / 2.0;
         meshes_.push_back(mesh_ptrs_keeper_
                               .createPtr<SingularVariable<Mesh>>(
-                                  "BackgroundMesh" + std::to_string(level), tentative_bounds, refined_spacing, 2)
+                                  "BackgroundMesh" + std::to_string(level),
+                                  tentative_bounds, refined_spacing, 2, total_number_of_cells_)
                               ->Data());
-        mesh_offsets_.push_back(total_number_of_cells_);
         total_number_of_cells_ += meshes_[level]->NumberOfCells();
     }
     initialize(base_particles);
@@ -243,14 +239,14 @@ void MultilevelCellLinkedList::insertParticleIndex(UnsignedInt particle_index, c
 {
     UnsignedInt level = getMeshLevel(kernel_.CutOffRadius(h_ratio_[particle_index]));
     level_[particle_index] = level;
-    UnsignedInt linear_index = mesh_offsets_[level] + meshes_[level]->LinearCellIndexFromPosition(particle_position);
+    UnsignedInt linear_index = meshes_[level]->LinearCellIndexFromPosition(particle_position);
     cell_index_lists_[linear_index].emplace_back(particle_index);
 }
 //=================================================================================================//
 void MultilevelCellLinkedList::InsertListDataEntry(UnsignedInt particle_index, const Vecd &particle_position)
 {
     UnsignedInt level = getMeshLevel(kernel_.CutOffRadius(h_ratio_[particle_index]));
-    UnsignedInt linear_index = mesh_offsets_[level] + meshes_[level]->LinearCellIndexFromPosition(particle_position);
+    UnsignedInt linear_index = meshes_[level]->LinearCellIndexFromPosition(particle_position);
     cell_data_lists_[linear_index]
         .emplace_back(std::make_pair(particle_index, particle_position));
 }
@@ -267,7 +263,7 @@ void MultilevelCellLinkedList::tagBodyPartByCell(ConcurrentCellLists &cell_lists
 {
     for (UnsignedInt l = 0; l != meshes_.size(); ++l)
     {
-        tagBodyPartByCellByMesh(*meshes_[l], mesh_offsets_[l], cell_lists, cell_indexes, check_included);
+        tagBodyPartByCellByMesh(*meshes_[l], cell_lists, cell_indexes, check_included);
     }
 }
 //=================================================================================================//
@@ -276,7 +272,7 @@ void MultilevelCellLinkedList::tagBoundingCells(StdVec<CellLists> &cell_data_lis
 {
     for (UnsignedInt l = 0; l != meshes_.size(); ++l)
     {
-        tagBoundingCellsByMesh(*meshes_[l], mesh_offsets_[l], cell_data_lists, bounding_bounds, axis);
+        tagBoundingCellsByMesh(*meshes_[l], cell_data_lists, bounding_bounds, axis);
     }
 }
 //=================================================================================================//
@@ -286,7 +282,7 @@ void MultilevelCellLinkedList::writeMeshFieldToPlt(const std::string &partial_fi
     {
         std::string full_file_name = partial_file_name + "_" + std::to_string(l) + ".dat";
         std::ofstream out_file(full_file_name.c_str(), std::ios::app);
-        writeMeshFieldToPltByMesh(*meshes_[l], mesh_offsets_[l], out_file);
+        writeMeshFieldToPltByMesh(*meshes_[l], out_file);
         out_file.close();
     }
 }

--- a/src/shared/meshes/cell_linked_list.h
+++ b/src/shared/meshes/cell_linked_list.h
@@ -56,13 +56,11 @@ class BaseCellLinkedList : public BaseMeshField
     UniquePtrsKeeper<Entity> unique_variable_ptrs_;
     UniquePtrsKeeper<SingularVariable<Mesh>> mesh_ptrs_keeper_;
     StdVec<Mesh *> meshes_;
-    StdVec<UnsignedInt> mesh_offsets_; // off sets linear index for each mesh
 
   public:
     BaseCellLinkedList(BaseParticles &base_particles, SPHAdaptation &sph_adaptation);
     virtual ~BaseCellLinkedList();
     StdVec<Mesh *> &getMeshes() { return meshes_; };
-    StdVec<UnsignedInt> &getMeshOffsets() { return mesh_offsets_; };
     BaseParticles &getBaseParticles() { return base_particles_; };
     void UpdateCellLists(BaseParticles &base_particles);
     /** Insert a cell-linked_list entry to the concurrent index list. */
@@ -81,8 +79,7 @@ class BaseCellLinkedList : public BaseMeshField
     virtual void tagBoundingCells(StdVec<CellLists> &cell_data_lists, const BoundingBox &bounding_bounds, int axis) = 0;
     /** generalized particle search algorithm */
     template <class DynamicsRange, typename GetSearchDepth, typename GetNeighborRelation>
-    void searchNeighborsByMesh(Mesh &mesh, UnsignedInt mesh_offset,
-                               DynamicsRange &dynamics_range, ParticleConfiguration &particle_configuration,
+    void searchNeighborsByMesh(Mesh &mesh, DynamicsRange &dynamics_range, ParticleConfiguration &particle_configuration,
                                GetSearchDepth &get_search_depth, GetNeighborRelation &get_neighbor_relation);
     DiscreteVariable<UnsignedInt> *dvParticleIndex() { return dv_particle_index_; };
     DiscreteVariable<UnsignedInt> *dvCellOffset() { return dv_cell_offset_; };
@@ -109,22 +106,20 @@ class BaseCellLinkedList : public BaseMeshField
     void initialize(BaseParticles &base_particles);
     void clearCellLists();
     void UpdateCellListData(BaseParticles &base_particles);
-    void tagBodyPartByCellByMesh(Mesh &mesh, UnsignedInt mesh_offset,
-                                 ConcurrentCellLists &cell_lists,
+    void tagBodyPartByCellByMesh(Mesh &mesh, ConcurrentCellLists &cell_lists,
                                  ConcurrentIndexVector &cell_indexes,
                                  std::function<bool(Vecd, Real)> &check_included);
-    void writeMeshFieldToPltByMesh(Mesh &mesh, UnsignedInt mesh_offset, std::ofstream &output_file);
-    void tagBoundingCellsByMesh(Mesh &mesh, UnsignedInt mesh_offset,
-                                StdVec<CellLists> &cell_data_lists, const BoundingBox &bounding_bounds, int axis);
-    void findNearestListDataEntryByMesh(Mesh &mesh, UnsignedInt mesh_offset,
-                                        Real &min_distance_sqr, ListData &nearest_entry,
+    void writeMeshFieldToPltByMesh(Mesh &mesh, std::ofstream &output_file);
+    void tagBoundingCellsByMesh(Mesh &mesh, StdVec<CellLists> &cell_data_lists,
+                                const BoundingBox &bounding_bounds, int axis);
+    void findNearestListDataEntryByMesh(Mesh &mesh, Real &min_distance_sqr, ListData &nearest_entry,
                                         const Vecd &position);
     /** split algorithm */;
     template <class LocalDynamicsFunction>
-    void particle_for_split_by_mesh(const execution::SequencedPolicy &, Mesh &mesh, UnsignedInt mesh_offset,
+    void particle_for_split_by_mesh(const execution::SequencedPolicy &, Mesh &mesh,
                                     const LocalDynamicsFunction &local_dynamics_function);
     template <class LocalDynamicsFunction>
-    void particle_for_split_by_mesh(const execution::ParallelPolicy &, Mesh &mesh, UnsignedInt mesh_offset,
+    void particle_for_split_by_mesh(const execution::ParallelPolicy &, Mesh &mesh,
                                     const LocalDynamicsFunction &local_dynamics_function);
 };
 
@@ -157,7 +152,7 @@ class CellLinkedList : public BaseCellLinkedList
   public:
     CellLinkedList(BoundingBox tentative_bounds, Real grid_spacing,
                    BaseParticles &base_particles, SPHAdaptation &sph_adaptation);
-    ~CellLinkedList(){};
+    ~CellLinkedList() {};
     Mesh &getMesh() { return *mesh_; };
     SingularVariable<Mesh> *svMesh() { return sv_mesh_; };
     void insertParticleIndex(UnsignedInt particle_index, const Vecd &particle_position) override;
@@ -199,7 +194,7 @@ class MultilevelCellLinkedList : public BaseCellLinkedList
     MultilevelCellLinkedList(BoundingBox tentative_bounds,
                              Real reference_grid_spacing, UnsignedInt total_levels,
                              BaseParticles &base_particles, SPHAdaptation &sph_adaptation);
-    virtual ~MultilevelCellLinkedList(){};
+    virtual ~MultilevelCellLinkedList() {};
     void insertParticleIndex(UnsignedInt particle_index, const Vecd &particle_position) override;
     void InsertListDataEntry(UnsignedInt particle_index, const Vecd &particle_position) override;
     virtual ListData findNearestListDataEntry(const Vecd &position) override { return ListData(0, Vecd::Zero()); }; // mocking, not implemented

--- a/src/shared/meshes/cell_linked_list.hpp
+++ b/src/shared/meshes/cell_linked_list.hpp
@@ -36,7 +36,7 @@ void BaseCellLinkedList::searchNeighborsByMesh(
                          mesh.AllCells().min(target_cell_index + (search_depth + 1) * Arrayi::Ones()),
                          [&](const Arrayi &cell_index)
                          {
-                             UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndexFromCellIndex(cell_index);
+                             UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(cell_index);
                              ListDataVector &target_particles = cell_data_lists_[linear_index];
                              for (const ListData &data_list : target_particles)
                              {
@@ -59,7 +59,7 @@ void BaseCellLinkedList::particle_for_split_by_mesh(
 
         // get the corresponding 2D/3D split cell index (m, n)
         // e.g., for k = 0, split_cell_index = (0,0), for k = 3, split_cell_index = (1,0), etc.
-        const Arrayi split_cell_index = mesh.transfer1DtoMeshIndex(array3s, k);
+        const Arrayi split_cell_index = Mesh::transfer1DtoMeshIndex(array3s, k);
         // get the number of cells belonging to the split cell k
         // i_max = (M - m - 1) / 3 + 1, j_max = (N - n - 1) / 3 + 1
         // e.g. all_cells = (M,N) = (6, 9), (m, n) = (1, 1), then i_max = 2, j_max = 3
@@ -73,8 +73,8 @@ void BaseCellLinkedList::particle_for_split_by_mesh(
             // (i , j) = (m + 3 * (l / j_max), n + 3 * l % i_max)
             // e.g. all_cells = (M,N) = (6, 9), (m, n) = (1, 1), l = 0, then (i, j) = (1, 1)
             // l = 1, then (i, j) = (1, 4), l = 3, then (i, j) = (4, 1), etc.
-            const Arrayi cell_index = split_cell_index + 3 * mesh.transfer1DtoMeshIndex(all_cells_k, l);
-            UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndexFromCellIndex(cell_index);
+            const Arrayi cell_index = split_cell_index + 3 * Mesh::transfer1DtoMeshIndex(all_cells_k, l);
+            UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(cell_index);
             // get the list of particles in the cell (i, j)
             const ConcurrentIndexVector &cell_list = cell_index_lists_[linear_index];
             // looping over all particles in the cell (i, j)
@@ -88,14 +88,14 @@ void BaseCellLinkedList::particle_for_split_by_mesh(
     // backward sweeping
     for (int k = array3s.prod(); k != 0; --k)
     {
-        const Arrayi split_cell_index = mesh.transfer1DtoMeshIndex(array3s, k - 1);
+        const Arrayi split_cell_index = Mesh::transfer1DtoMeshIndex(array3s, k - 1);
         const Arrayi all_cells_k = (mesh.AllCells() - split_cell_index - Arrayi::Ones()) / 3 + Arrayi::Ones();
         const UnsignedInt number_of_cells = all_cells_k.prod();
 
         for (UnsignedInt l = 0; l < number_of_cells; l++)
         {
-            const Arrayi cell_index = split_cell_index + 3 * mesh.transfer1DtoMeshIndex(all_cells_k, l);
-            UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndexFromCellIndex(cell_index);
+            const Arrayi cell_index = split_cell_index + 3 * Mesh::transfer1DtoMeshIndex(all_cells_k, l);
+            UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(cell_index);
             const ConcurrentIndexVector &cell_list = cell_index_lists_[linear_index];
             for (UnsignedInt i = cell_list.size(); i != 0; --i)
             {
@@ -115,7 +115,7 @@ void BaseCellLinkedList::particle_for_split_by_mesh(
     // forward sweeping
     for (int k = 0; k < array3s.prod(); k++)
     {
-        const Arrayi split_cell_index = mesh.transfer1DtoMeshIndex(array3s, k);
+        const Arrayi split_cell_index = Mesh::transfer1DtoMeshIndex(array3s, k);
         const Arrayi all_cells_k = (mesh.AllCells() - split_cell_index - Arrayi::Ones()) / 3 + Arrayi::Ones();
         const UnsignedInt number_of_cells = all_cells_k.prod();
 
@@ -125,8 +125,8 @@ void BaseCellLinkedList::particle_for_split_by_mesh(
             {
                 for (UnsignedInt l = r.begin(); l < r.end(); ++l)
                 {
-                    const Arrayi cell_index = split_cell_index + 3 * mesh.transfer1DtoMeshIndex(all_cells_k, l);
-                    UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndexFromCellIndex(cell_index);
+                    const Arrayi cell_index = split_cell_index + 3 * Mesh::transfer1DtoMeshIndex(all_cells_k, l);
+                    UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(cell_index);
                     const ConcurrentIndexVector &cell_list = cell_index_lists_[linear_index];
                     for (const UnsignedInt index_i : cell_list)
                     {
@@ -140,7 +140,7 @@ void BaseCellLinkedList::particle_for_split_by_mesh(
     // backward sweeping
     for (int k = array3s.prod(); k != 0; --k)
     {
-        const Arrayi split_cell_index = mesh.transfer1DtoMeshIndex(array3s, k - 1);
+        const Arrayi split_cell_index = Mesh::transfer1DtoMeshIndex(array3s, k - 1);
         const Arrayi all_cells_k = (mesh.AllCells() - split_cell_index - Arrayi::Ones()) / 3 + Arrayi::Ones();
         const UnsignedInt number_of_cells = all_cells_k.prod();
 
@@ -150,8 +150,8 @@ void BaseCellLinkedList::particle_for_split_by_mesh(
             {
                 for (UnsignedInt l = r.begin(); l < r.end(); ++l)
                 {
-                    const Arrayi cell_index = split_cell_index + 3 * mesh.transfer1DtoMeshIndex(all_cells_k, l);
-                    UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndexFromCellIndex(cell_index);
+                    const Arrayi cell_index = split_cell_index + 3 * Mesh::transfer1DtoMeshIndex(all_cells_k, l);
+                    UnsignedInt linear_index = mesh_offset + mesh.LinearCellIndex(cell_index);
                     const ConcurrentIndexVector &cell_list = cell_index_lists_[linear_index];
                     for (UnsignedInt i = cell_list.size(); i != 0; --i)
                     {
@@ -204,7 +204,7 @@ void NeighborSearch::forEachSearch(UnsignedInt source_index, const Vecd *source_
         all_cells_.min(target_cell_index + (depth + 1) * Arrayi::Ones()),
         [&](const Arrayi &cell_index)
         {
-            const UnsignedInt linear_index = LinearCellIndexFromCellIndex(cell_index);
+            const UnsignedInt linear_index = LinearCellIndex(cell_index);
             // Since offset_cell_size_ has linear_cell_size_+1 elements, no boundary checks are needed.
             // offset_cell_size_[0] == 0 && offset_cell_size_[linear_cell_size_] == total_real_particles_
             for (UnsignedInt n = cell_offset_[linear_index]; n < cell_offset_[linear_index + 1]; ++n)

--- a/src/shared/meshes/cell_linked_list.hpp
+++ b/src/shared/meshes/cell_linked_list.hpp
@@ -185,6 +185,24 @@ DiscreteVariable<DataType> *BaseCellLinkedList::registerDiscreteVariable(
     return variable;
 }
 //=================================================================================================//
+template <class LocalDynamicsFunction>
+void BaseCellLinkedList::particle_for_split(const execution::SequencedPolicy &seq,
+                                            const LocalDynamicsFunction &local_dynamics_function)
+{
+    for (UnsignedInt level = 0; level != meshes_.size(); ++level)
+        particle_for_split_by_mesh(execution::SequencedPolicy(),
+                                   *meshes_[level], local_dynamics_function);
+}
+//=================================================================================================//
+template <class LocalDynamicsFunction>
+void BaseCellLinkedList::particle_for_split(const execution::ParallelPolicy &par_host,
+                                            const LocalDynamicsFunction &local_dynamics_function)
+{
+    for (UnsignedInt level = 0; level != meshes_.size(); ++level)
+        particle_for_split_by_mesh(execution::ParallelPolicy(),
+                                   *meshes_[level], local_dynamics_function);
+}
+//=================================================================================================//
 template <class ExecutionPolicy>
 NeighborSearch::NeighborSearch(const ExecutionPolicy &ex_policy, CellLinkedList &cell_linked_list)
     : Mesh(cell_linked_list.getMesh()),
@@ -215,38 +233,6 @@ template <class ExecutionPolicy>
 NeighborSearch CellLinkedList::createNeighborSearch(const ExecutionPolicy &ex_policy)
 {
     return NeighborSearch(ex_policy, *this);
-}
-//=================================================================================================//
-template <class LocalDynamicsFunction>
-void CellLinkedList::particle_for_split(const execution::SequencedPolicy &,
-                                        const LocalDynamicsFunction &local_dynamics_function)
-{
-    particle_for_split_by_mesh(execution::SequencedPolicy(), *mesh_, local_dynamics_function);
-}
-//=================================================================================================//
-template <class LocalDynamicsFunction>
-void CellLinkedList::particle_for_split(const execution::ParallelPolicy &,
-                                        const LocalDynamicsFunction &local_dynamics_function)
-{
-    particle_for_split_by_mesh(execution::ParallelPolicy(), *mesh_, local_dynamics_function);
-}
-//=================================================================================================//
-template <class LocalDynamicsFunction>
-void MultilevelCellLinkedList::particle_for_split(const execution::SequencedPolicy &seq,
-                                                  const LocalDynamicsFunction &local_dynamics_function)
-{
-    for (UnsignedInt level = 0; level != meshes_.size(); ++level)
-        particle_for_split_by_mesh(execution::SequencedPolicy(),
-                                   *meshes_[level], local_dynamics_function);
-}
-//=================================================================================================//
-template <class LocalDynamicsFunction>
-void MultilevelCellLinkedList::particle_for_split(const execution::ParallelPolicy &par_host,
-                                                  const LocalDynamicsFunction &local_dynamics_function)
-{
-    for (UnsignedInt level = 0; level != meshes_.size(); ++level)
-        particle_for_split_by_mesh(execution::ParallelPolicy(),
-                                   *meshes_[level], local_dynamics_function);
 }
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/meshes/sparse_storage_mesh/mesh_with_data_packages.hxx
+++ b/src/shared/meshes/sparse_storage_mesh/mesh_with_data_packages.hxx
@@ -156,7 +156,7 @@ template <UnsignedInt PKG_SIZE>
 UnsignedInt MeshWithGridDataPackages<PKG_SIZE>::
     IndexHandler::PackageIndexFromCellIndex(UnsignedInt *cell_package_index, const Arrayi &cell_index)
 {
-    UnsignedInt index_1d = mesh_.transferMeshIndexTo1D(all_cells_, cell_index);
+    UnsignedInt index_1d = mesh_.LinearCellIndex(cell_index);
     return cell_package_index[index_1d];
 }
 //=============================================================================================//
@@ -279,7 +279,7 @@ void MeshWithGridDataPackages<PKG_SIZE>::organizeOccupiedPackages()
 template <UnsignedInt PKG_SIZE>
 bool MeshWithGridDataPackages<PKG_SIZE>::isInnerDataPackage(const Arrayi &cell_index)
 {
-    UnsignedInt index_1d = transferMeshIndexTo1D(all_cells_, cell_index);
+    UnsignedInt index_1d = LinearCellIndex(cell_index);
     /**
      * NOTE currently this func is only used in non-device mode;
      *      use the `DelegatedData` version when needed.
@@ -316,7 +316,7 @@ template <UnsignedInt PKG_SIZE>
 UnsignedInt MeshWithGridDataPackages<PKG_SIZE>::
     PackageIndexFromCellIndex(UnsignedInt *cell_package_index, const Arrayi &cell_index)
 {
-    UnsignedInt index_1d = transferMeshIndexTo1D(all_cells_, boundCellIndex(cell_index));
+    UnsignedInt index_1d = LinearCellIndex(boundCellIndex(cell_index));
     return cell_package_index[index_1d];
 }
 //=============================================================================================//
@@ -324,7 +324,7 @@ template <UnsignedInt PKG_SIZE>
 void MeshWithGridDataPackages<PKG_SIZE>::
     assignDataPackageIndex(const Arrayi &cell_index, const UnsignedInt package_index)
 {
-    UnsignedInt index_1d = transferMeshIndexTo1D(all_cells_, cell_index);
+    UnsignedInt index_1d = LinearCellIndex(cell_index);
     /**
      * NOTE currently the `bmv_cell_pkg_index_` is only assigned in the host;
      *      use the `DelegatedData` version when needed.

--- a/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.hpp
@@ -100,7 +100,7 @@ template <class ExecutionPolicy>
 void ParticleSortCK<ExecutionPolicy>::ComputingKernel::
     prepareSequence(UnsignedInt index_i)
 {
-    sequence_[index_i] = mesh_.transferMeshIndexToMortonOrder(mesh_.CellIndexFromPosition(pos_[index_i]));
+    sequence_[index_i] = Mesh::transferMeshIndexToMortonOrder(mesh_.CellIndexFromPosition(pos_[index_i]));
     index_permutation_[index_i] = index_i;
 }
 //=================================================================================================//


### PR DESCRIPTION
This pull request refactors how linear cell indices are computed and simplifies several method signatures throughout the mesh and body relation code. The main focus is on consolidating and simplifying the interface for cell index calculations and neighbor search routines, removing redundant parameters and standardizing function calls.

**Refactoring of cell index calculation methods:**

* Replaced all calls to `LinearCellIndexFromCellIndex`, `transferMeshIndexTo1D`, and similar methods with the unified `LinearCellIndex` method in both 2D and 3D mesh dynamics and mesh data package files. This change standardizes how linear indices are computed from cell indices across the codebase. [[1]](diffhunk://#diff-b251b5bc5bae2e17deb142197b7fd0525c402cc1317cb30f83d75ac67a61ac41L14-R14) [[2]](diffhunk://#diff-b251b5bc5bae2e17deb142197b7fd0525c402cc1317cb30f83d75ac67a61ac41L30-R38) [[3]](diffhunk://#diff-b251b5bc5bae2e17deb142197b7fd0525c402cc1317cb30f83d75ac67a61ac41L52-R52) [[4]](diffhunk://#diff-af318efa4e8834c4f2cbc0ec6d320ac2778b1b245f1c812fde05ab697a02438aL14-R14) [[5]](diffhunk://#diff-af318efa4e8834c4f2cbc0ec6d320ac2778b1b245f1c812fde05ab697a02438aL30-R38) [[6]](diffhunk://#diff-af318efa4e8834c4f2cbc0ec6d320ac2778b1b245f1c812fde05ab697a02438aL52-R52) [[7]](diffhunk://#diff-c0c6e0cf5186afcf5b723eceb916239d4216b9be0ad15fd7fb9ef67adabb2f28L47-R54) [[8]](diffhunk://#diff-c0c6e0cf5186afcf5b723eceb916239d4216b9be0ad15fd7fb9ef67adabb2f28L71-R70) [[9]](diffhunk://#diff-c0c6e0cf5186afcf5b723eceb916239d4216b9be0ad15fd7fb9ef67adabb2f28L85-R84) [[10]](diffhunk://#diff-3e9298adf3697c18795222af7a431d5320418df37ab7fb891d057019e9a6476fL67-R74) [[11]](diffhunk://#diff-3e9298adf3697c18795222af7a431d5320418df37ab7fb891d057019e9a6476fL98-R97) [[12]](diffhunk://#diff-3e9298adf3697c18795222af7a431d5320418df37ab7fb891d057019e9a6476fL119-R118) [[13]](diffhunk://#diff-2e764cc65773f90a3367066d9166b3acef34c2614f0126ba3d814db2b46e3100L126-R126) [[14]](diffhunk://#diff-b7966a0f2dac13b9d6e6760011eb9b31cab6cc3cc14a058c51f8e09a09cb5e20L146-R146)

**Simplification of mesh neighbor search interfaces:**

* Removed the `mesh_offset` parameter from `writeMeshFieldToPltByMesh`, `tagBoundingCellsByMesh`, and all related calls, as well as from neighbor search routines in both 2D and 3D mesh linked list implementations. Function signatures and internal logic were updated accordingly. [[1]](diffhunk://#diff-c0c6e0cf5186afcf5b723eceb916239d4216b9be0ad15fd7fb9ef67adabb2f28L8-R8) [[2]](diffhunk://#diff-c0c6e0cf5186afcf5b723eceb916239d4216b9be0ad15fd7fb9ef67adabb2f28L47-R54) [[3]](diffhunk://#diff-c0c6e0cf5186afcf5b723eceb916239d4216b9be0ad15fd7fb9ef67adabb2f28L71-R70) [[4]](diffhunk://#diff-c0c6e0cf5186afcf5b723eceb916239d4216b9be0ad15fd7fb9ef67adabb2f28L85-R84) [[5]](diffhunk://#diff-3e9298adf3697c18795222af7a431d5320418df37ab7fb891d057019e9a6476fL13-R13) [[6]](diffhunk://#diff-3e9298adf3697c18795222af7a431d5320418df37ab7fb891d057019e9a6476fL67-R74) [[7]](diffhunk://#diff-3e9298adf3697c18795222af7a431d5320418df37ab7fb891d057019e9a6476fL98-R97) [[8]](diffhunk://#diff-3e9298adf3697c18795222af7a431d5320418df37ab7fb891d057019e9a6476fL119-R118)

* Updated all calls to `searchNeighborsByMesh` in body relation classes to remove the now-unnecessary `mesh_offset` argument, simplifying the interface for neighbor searches in contact and inner relations. [[1]](diffhunk://#diff-6701a25b1b5a661dd4ed53a25239010e0da1c157daca5cecbbf6f588e30cd443L29-R29) [[2]](diffhunk://#diff-6701a25b1b5a661dd4ed53a25239010e0da1c157daca5cecbbf6f588e30cd443L66-R66) [[3]](diffhunk://#diff-6701a25b1b5a661dd4ed53a25239010e0da1c157daca5cecbbf6f588e30cd443L90-R90) [[4]](diffhunk://#diff-6701a25b1b5a661dd4ed53a25239010e0da1c157daca5cecbbf6f588e30cd443L125-R128) [[5]](diffhunk://#diff-6701a25b1b5a661dd4ed53a25239010e0da1c157daca5cecbbf6f588e30cd443L159-R158) [[6]](diffhunk://#diff-6701a25b1b5a661dd4ed53a25239010e0da1c157daca5cecbbf6f588e30cd443L188-R187) [[7]](diffhunk://#diff-6701a25b1b5a661dd4ed53a25239010e0da1c157daca5cecbbf6f588e30cd443L248-R247) [[8]](diffhunk://#diff-d5e29b099638c0a100b5b002ac83eee03543f40ac7f0c799f9fa13a238f738b7L18-R18) [[9]](diffhunk://#diff-d5e29b099638c0a100b5b002ac83eee03543f40ac7f0c799f9fa13a238f738b7L42-R45) [[10]](diffhunk://#diff-d5e29b099638c0a100b5b002ac83eee03543f40ac7f0c799f9fa13a238f738b7L73-R72) [[11]](diffhunk://#diff-d5e29b099638c0a100b5b002ac83eee03543f40ac7f0c799f9fa13a238f738b7L97-R96)

These changes collectively improve code maintainability and reduce the likelihood of errors by enforcing a consistent approach to cell indexing and mesh neighbor search operations.