### PR TITLE
unused level deleted

### DIFF
--- a/src/shared/adaptations/adaptation.cpp
+++ b/src/shared/adaptations/adaptation.cpp
@@ -139,27 +139,18 @@ void ParticleWithLocalRefinement::initializeAdaptationVariables(BaseParticles &b
     base_particles.addEvolvingVariable<Real>("SmoothingLengthRatio");
 }
 //=================================================================================================//
-size_t ParticleWithLocalRefinement::getCellLinkedListTotalLevel()
-{
-    return size_t(local_refinement_level_) + 1;
-}
-//=================================================================================================//
-size_t ParticleWithLocalRefinement::getLevelSetTotalLevel()
-{
-    return getCellLinkedListTotalLevel();
-}
-//=================================================================================================//
 UniquePtr<BaseCellLinkedList> ParticleWithLocalRefinement::
     createCellLinkedList(const BoundingBox &domain_bounds, BaseParticles &base_particles)
 {
     return makeUnique<MultilevelCellLinkedList>(domain_bounds, kernel_ptr_->CutOffRadius(),
-                                                getCellLinkedListTotalLevel(), base_particles, *this);
+                                                local_refinement_level_, base_particles, *this);
 }
 //=================================================================================================//
 UniquePtr<MultilevelLevelSet> ParticleWithLocalRefinement::createLevelSet(Shape &shape, Real refinement_ratio)
 {
+    // one more level for interpolation
     return makeUnique<MultilevelLevelSet>(shape.getBounds(), ReferenceSpacing() / refinement_ratio,
-                                          getLevelSetTotalLevel(), shape, *this, refinement_ratio);
+                                          local_refinement_level_ + 1, shape, *this, refinement_ratio);
 }
 //=================================================================================================//
 Real ParticleRefinementByShape::smoothedSpacing(const Real &measure, const Real &transition_thickness)

--- a/src/shared/adaptations/adaptation.h
+++ b/src/shared/adaptations/adaptation.h
@@ -122,8 +122,6 @@ class ParticleWithLocalRefinement : public SPHAdaptation
     ParticleWithLocalRefinement(SPHSystem &sph_system, Real h_spacing_ratio_, Real system_refinement_ratio, int local_refinement_level);
     virtual ~ParticleWithLocalRefinement() {};
 
-    virtual size_t getCellLinkedListTotalLevel();
-    size_t getLevelSetTotalLevel();
     virtual Real SmoothingLengthRatio(size_t particle_index_i) override
     {
         return h_ratio_[particle_index_i];


### PR DESCRIPTION
This pull request refactors how the total number of refinement levels is handled in the `ParticleWithLocalRefinement` class. The main change is the removal of the `getCellLinkedListTotalLevel` and `getLevelSetTotalLevel` methods, with their logic now being used directly where needed. This simplifies the code and makes the usage of refinement levels more explicit.

Refactoring and simplification of refinement level handling:

* Removed the `getCellLinkedListTotalLevel` and `getLevelSetTotalLevel` methods from the `ParticleWithLocalRefinement` class, and replaced their usage with direct calculations based on `local_refinement_level_` in both `adaptation.cpp` and `adaptation.h`. [[1]](diffhunk://#diff-24087ea204da9086043f74a2f59fefa2e1acea5282e1d4acf844b3cd5c807cb0L142-R153) [[2]](diffhunk://#diff-c9b190e1f93461a105e2b2683207e517cde617a1c9d985f651ff871ff5eab243L125-L126)
* Updated the construction of `MultilevelCellLinkedList` and `MultilevelLevelSet` to use `local_refinement_level_` and `local_refinement_level_ + 1` directly, clarifying the intent and reducing indirection.