### PR TITLE
slightly less core cells

### DIFF
--- a/src/shared/mesh_dynamics/mesh_local_dynamics.cpp
+++ b/src/shared/mesh_dynamics/mesh_local_dynamics.cpp
@@ -24,10 +24,7 @@ void InitialCellTagging::UpdateKernel::update(const Arrayi &cell_index)
     cell_pkg_index_[index_1d] = 1;  // outside far field by default
     cell_contain_id_[index_1d] = 2; // default value is 2, indicating not near interface
     Vecd cell_position = index_handler_.CellPositionFromIndex(cell_index);
-    Real signed_distance = shape_->findSignedDistance(cell_position);
-    Vecd normal_direction = shape_->findNormalDirection(cell_position);
-    Real measure = (signed_distance * normal_direction).cwiseAbs().maxCoeff();
-    if (measure < grid_spacing_)
+    if (ABS(shape_->findSignedDistance(cell_position)) < grid_spacing_)
     {
         cell_pkg_index_[index_1d] = 2;                               // indicate initially tagged temporarily
         occupied_data_pkgs_->push_back(std::make_pair(index_1d, 1)); // core package
@@ -65,10 +62,7 @@ void InitialCellTaggingFromCoarse::UpdateKernel::update(const Arrayi &cell_index
 
     if (coarse_index_handler_.isWithinCorePackage(cell_pkg_index_coarse_, pkg_type_coarse_, cell_position))
     {
-        Real signed_distance = shape_->findSignedDistance(cell_position);
-        Vecd normal_direction = shape_->findNormalDirection(cell_position);
-        Real measure = (signed_distance * normal_direction).cwiseAbs().maxCoeff();
-        if (measure < grid_spacing_)
+        if (ABS(shape_->findSignedDistance(cell_position)) < grid_spacing_)
         {
             cell_pkg_index_[index_1d] = 2;                               // indicate initially tagged temporarily
             occupied_data_pkgs_->push_back(std::make_pair(index_1d, 1)); // core package


### PR DESCRIPTION
This pull request simplifies the logic for tagging cells near an interface in the mesh dynamics code. The main change is to use the absolute value of the signed distance to the interface, instead of a more complex calculation involving the normal direction, to determine if a cell is near the interface.

**Cell tagging logic simplification:**

* In both `InitialCellTagging::UpdateKernel::update` and `InitialCellTaggingFromCoarse::UpdateKernel::update` (in `mesh_local_dynamics.cpp`), replaced the calculation that combined signed distance and normal direction with a simpler check using only the absolute value of the signed distance to determine if a cell is within one grid spacing of the interface. [[1]](diffhunk://#diff-870d6496416e6b29cd5d940d4cdf3e61a9bc48601e17018e4dacc7a44da871edL27-R27) [[2]](diffhunk://#diff-870d6496416e6b29cd5d940d4cdf3e61a9bc48601e17018e4dacc7a44da871edL68-R65)