### PR TITLE
to ci test

### DIFF
--- a/src/shared/common/sphinxsys_constant.h
+++ b/src/shared/common/sphinxsys_constant.h
@@ -34,24 +34,23 @@
 
 namespace SPH
 {
-template <typename GeneratorType, typename DataType>
+template <typename DataType>
 class ConstantArray : public Entity
 {
     UniquePtrKeeper<Entity> device_only_constant_array_keeper_;
 
   public:
+    template <typename GeneratorType>
     ConstantArray(StdVec<GeneratorType *> generators)
-        : Entity("ConstantArray"), generators_(generators),
-          data_size_(generators.size()),
+        : Entity("ConstantArray"), data_size_(generators.size()),
           data_(new DataType[data_size_]), delegated_(data_)
     {
         for (size_t i = 0; i != data_size_; ++i)
         {
-            data_[i] = DataType(*generators_[i]);
+            data_[i] = DataType(*generators[i]);
         }
     };
     ~ConstantArray() { delete[] data_; };
-    StdVec<GeneratorType *> getGenerators() { return generators_; }
     size_t getDataSize() { return data_size_; }
     DataType *Data() { return data_; };
     template <class ExecutionPolicy>
@@ -64,19 +63,18 @@ class ConstantArray : public Entity
     void setDelegateData(DataType *new_delegated) { delegated_ = new_delegated; };
 
   protected:
-    StdVec<GeneratorType *> generators_;
     size_t data_size_;
     DataType *data_;
     DataType *delegated_;
 };
 
-template <typename GeneratorType, typename DataType>
+template <typename DataType>
 class DeviceOnlyConstantArray : public Entity
 {
   public:
     template <class PolicyType>
     DeviceOnlyConstantArray(const DeviceExecution<PolicyType> &ex_policy,
-                            ConstantArray<GeneratorType, DataType> *host_constant);
+                            ConstantArray<DataType> *host_constant);
     ~DeviceOnlyConstantArray();
 
   protected:

--- a/src/shared/common/sphinxsys_variable.h
+++ b/src/shared/common/sphinxsys_variable.h
@@ -135,10 +135,9 @@ class DiscreteVariable : public Entity
     template <class InitializationFunction>
     DiscreteVariable(const std::string &name, size_t data_size,
                      const InitializationFunction &initialization)
-        : Entity(name), data_size_(data_size), data_field_(nullptr),
+        : Entity(name), data_size_(data_size), data_field_(new DataType[data_size]),
           device_only_variable_(nullptr), device_data_field_(nullptr)
     {
-        data_field_ = new DataType[data_size];
         for (size_t i = 0; i < data_size; ++i)
         {
             data_field_[i] = initialization(i);

--- a/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.h
@@ -90,7 +90,7 @@ class DiffusionRelaxationCK<DiffusionType, BaseInteractionType>
     DiscreteVariableArray<Real> dv_diffusion_species_array_;
     DiscreteVariableArray<Real> dv_gradient_species_array_;
     DiscreteVariableArray<Real> dv_diffusion_dt_array_;
-    ConstantArray<DiffusionType, InverseVolumetricCapacity> ca_inverse_volume_capacity_;
+    ConstantArray<InverseVolumetricCapacity> ca_inverse_volume_capacity_;
 };
 
 template <class DiffusionType, class KernelCorrectionType, class... Parameters>
@@ -122,7 +122,7 @@ class DiffusionRelaxationCK<Inner<InteractionOnly, DiffusionType, KernelCorrecti
 
   protected:
     KernelCorrectionType kernel_correction_method_;
-    ConstantArray<DiffusionType, InterParticleDiffusionCoeff> ca_inter_particle_diffusion_coeff_;
+    ConstantArray<InterParticleDiffusionCoeff> ca_inter_particle_diffusion_coeff_;
     Real smoothing_length_sq_;
 };
 
@@ -278,7 +278,7 @@ class Dirichlet<DiffusionType>
     Real smoothing_length_sq_;
     DiscreteVariableArray<Real> &dv_gradient_species_array_;
     DiscreteVariableArray<Real> contact_dv_gradient_species_array_;
-    ConstantArray<DiffusionType, InterParticleDiffusionCoeff> ca_inter_particle_diffusion_coeff_;
+    ConstantArray<InterParticleDiffusionCoeff> ca_inter_particle_diffusion_coeff_;
 };
 
 template <class DiffusionType>

--- a/src/src_sycl/shared/common/sphinxsys_constant_sycl.hpp
+++ b/src/src_sycl/shared/common/sphinxsys_constant_sycl.hpp
@@ -7,40 +7,33 @@
 namespace SPH
 {
 //=================================================================================================//
-template <typename GeneratorType, typename DataType>
+template <typename DataType>
 template <class PolicyType>
-DataType *ConstantArray<GeneratorType, DataType>::
-    DelegatedOnDevice(const DeviceExecution<PolicyType> &ex_policy)
+DataType *ConstantArray<DataType>::DelegatedOnDevice(const DeviceExecution<PolicyType> &ex_policy)
 {
     if (!isDataDelegated())
     {
         device_only_constant_array_keeper_
-            .createPtr<DeviceOnlyConstantArray<GeneratorType, DataType>>(DeviceExecution<PolicyType>{}, this);
+            .createPtr<DeviceOnlyConstantArray<DataType>>(DeviceExecution<PolicyType>{}, this);
     }
     return delegated_;
 };
 //=================================================================================================//
-template <typename GeneratorType, typename DataType>
+template <typename DataType>
 template <class PolicyType>
-DeviceOnlyConstantArray<GeneratorType, DataType>::
-    DeviceOnlyConstantArray(const DeviceExecution<PolicyType> &ex_policy,
-                            ConstantArray<GeneratorType, DataType> *host_constant)
+DeviceOnlyConstantArray<DataType>::DeviceOnlyConstantArray(
+    const DeviceExecution<PolicyType> &ex_policy, ConstantArray<DataType> *host_constant)
     : Entity(host_constant->Name()), device_only_data_(nullptr)
 {
-    StdVec<GeneratorType *> generators = host_constant->getGenerators();
     size_t data_size = host_constant->getDataSize();
     DataType *host_data = host_constant->Data();
-    for (size_t i = 0; i != data_size; ++i)
-    {
-        host_data[i] = DataType(ex_policy, *generators[i]);
-    }
     device_only_data_ = allocateDeviceOnly<DataType>(data_size);
     copyToDevice(host_data, device_only_data_, data_size);
     host_constant->setDelegateData(device_only_data_);
 }
 //=================================================================================================//
-template <typename GeneratorType, typename DataType>
-DeviceOnlyConstantArray<GeneratorType, DataType>::~DeviceOnlyConstantArray()
+template <typename DataType>
+DeviceOnlyConstantArray<DataType>::~DeviceOnlyConstantArray()
 {
     freeDeviceData(device_only_data_);
 }


### PR DESCRIPTION
This pull request simplifies the `ConstantArray` and `DeviceOnlyConstantArray` templates by removing the `GeneratorType` template parameter, making the codebase cleaner and easier to maintain. It also updates related classes and device code to reflect this change, and includes a small fix in the initialization of `DiscreteVariable`. 

The most important changes are:

### Template Simplification and Refactoring

* Refactored `ConstantArray` and `DeviceOnlyConstantArray` in `sphinxsys_constant.h` and `sphinxsys_constant_sycl.hpp` to remove the `GeneratorType` template parameter, making these classes templated only on `DataType`. Constructors and internal logic were updated accordingly. [[1]](diffhunk://#diff-626afb5c87620384b2b0db239c529ef4925994c70f74191dee1a9d01a4a38da6L37-L54) [[2]](diffhunk://#diff-626afb5c87620384b2b0db239c529ef4925994c70f74191dee1a9d01a4a38da6L67-R77) [[3]](diffhunk://#diff-9ff84d22241b1b694c3e855079cb6c99c7db7dfac227ab4af87f295ef07a88e5L10-R36)
* Updated all usages of `ConstantArray` in `diffusion_dynamics_ck.h` to use the new single-parameter template, removing references to `GeneratorType` throughout the codebase. [[1]](diffhunk://#diff-a4b262bf02d6d07d62e3656c70201511a56118a2acd8948e40d536c12c8040f8L93-R93) [[2]](diffhunk://#diff-a4b262bf02d6d07d62e3656c70201511a56118a2acd8948e40d536c12c8040f8L125-R125) [[3]](diffhunk://#diff-a4b262bf02d6d07d62e3656c70201511a56118a2acd8948e40d536c12c8040f8L281-R281)

### Code Cleanup and Initialization Fix

* Fixed the initialization of `DiscreteVariable` in `sphinxsys_variable.h` by allocating the data array directly in the initializer list, ensuring proper memory allocation and avoiding redundant assignment.