### PR TITLE
Xiangyu/own sorting algorithm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option(SPHINXSYS_USE_FLOAT "Build using float (single-precision floating-point f
 option(SPHINXSYS_USE_SIMD "Build using SIMD instructions" OFF)
 option(SPHINXSYS_MODULE_OPENCASCADE "Build extension relying on OpenCASCADE" OFF)
 option(SPHINXSYS_USE_SYCL "Build using SYCL acceleration or not" OFF)
+option(SPHINXSYS_USE_ONEDPL_SORTING "Build One DPL for particle sorting" ON)
 
 # ------ Global properties (Some cannot be set on INTERFACE targets)
 set(CMAKE_VERBOSE_MAKEFILE OFF CACHE BOOL "Enable verbose compilation commands for Makefile and Ninja" FORCE) # Extra fluff needed for Ninja: https://github.com/ninja-build/ninja/issues/900
@@ -65,6 +66,7 @@ endif()
 
 target_compile_definitions(sphinxsys_core INTERFACE SPHINXSYS_USE_SYCL=$<BOOL:${SPHINXSYS_USE_SYCL}>)
 target_compile_definitions(sphinxsys_core INTERFACE SPHINXSYS_USE_FLOAT=$<BOOL:${SPHINXSYS_USE_FLOAT}>)
+target_compile_definitions(sphinxsys_core INTERFACE SPHINXSYS_USE_ONEDPL_SORTING=$<BOOL:${SPHINXSYS_USE_ONEDPL_SORTING}>)
 
 # ------ Dependencies
 # ## SIMD flags

--- a/src/src_sycl/shared/common/algorithm_primitive_sycl.h
+++ b/src/src_sycl/shared/common/algorithm_primitive_sycl.h
@@ -35,22 +35,6 @@
 namespace SPH
 {
 using namespace execution;
-
-class RadixSort
-{
-  public:
-    template <class ExecutionPolicy>
-    explicit RadixSort(const ExecutionPolicy &ex_policy,
-                       DiscreteVariable<UnsignedInt> *dv_sequence,
-                       DiscreteVariable<UnsignedInt> *dv_index_permutation)
-        : dv_sequence_(dv_sequence), dv_index_permutation_(dv_index_permutation){};
-    void sort(const ParallelDevicePolicy &ex_policy, UnsignedInt size, UnsignedInt start_index = 0);
-
-  protected:
-    DiscreteVariable<UnsignedInt> *dv_sequence_;
-    DiscreteVariable<UnsignedInt> *dv_index_permutation_;
-};
-
 template <class DataType>
 class DeviceRadixSort
 {
@@ -79,12 +63,28 @@ class DeviceRadixSort
 
   private:
     bool uniform_case_masking_;
-    UnsignedInt data_size_ = 0, radix_bits_, workgroup_size_,
-                uniform_global_size_, workgroups_, radix_;
+    UnsignedInt data_size_ = 0;
+    UnsignedInt radix_bits_, workgroup_size_, uniform_global_size_, workgroups_, radix_;
     sycl::nd_range<1> kernel_range_{0, 0};
     std::unique_ptr<sycl::buffer<UnsignedInt, 2>> global_buckets_, global_buckets_offsets_;
     std::unique_ptr<sycl::buffer<UnsignedInt, 1>> local_buckets_offsets_buffer_;
     std::unique_ptr<sycl::buffer<SortablePair>> data_swap_buffer_, uniform_extra_swap_buffer_;
+};
+
+class RadixSort
+{
+  public:
+    template <class ExecutionPolicy>
+    explicit RadixSort(const ExecutionPolicy &ex_policy,
+                       DiscreteVariable<UnsignedInt> *dv_sequence,
+                       DiscreteVariable<UnsignedInt> *dv_index_permutation)
+        : dv_sequence_(dv_sequence), dv_index_permutation_(dv_index_permutation){};
+    void sort(const ParallelDevicePolicy &ex_policy, UnsignedInt size, UnsignedInt start_index = 0);
+
+  protected:
+    DiscreteVariable<UnsignedInt> *dv_sequence_;
+    DiscreteVariable<UnsignedInt> *dv_index_permutation_;
+    DeviceRadixSort<UnsignedInt> device_radix_sorting;
 };
 
 template <typename T, typename Op>

--- a/src/src_sycl/shared/common/algorithm_primitive_sycl.hpp
+++ b/src/src_sycl/shared/common/algorithm_primitive_sycl.hpp
@@ -113,8 +113,7 @@ sycl::event DeviceRadixSort<DataType>::sort_by_key(
                 auto local_buckets = sycl::local_accessor<UnsignedInt>(radix_, cgh);
                 auto local_output = sycl::local_accessor<SortablePair>(kernel_range_.get_local_range(), cgh);
                 auto global_buckets_accessor = global_buckets_->get_access(cgh, sycl::read_write, sycl::no_init);
-                auto local_buckets_offsets_accessor = local_buckets_offsets_buffer_->get_access(cgh, sycl::write_only,
-                                                                                                                              sycl::no_init);
+                auto local_buckets_offsets_accessor = local_buckets_offsets_buffer_->get_access(cgh, sycl::write_only, sycl::no_init);
 
                 cgh.parallel_for(
                     kernel_range_, 


### PR DESCRIPTION
This pull request introduces an optional build-time feature for particle sorting using OneDPL, improves the sorting algorithm infrastructure in the SYCL backend, and refactors related code for better maintainability and performance. The main changes are grouped below:

**Build System & Feature Toggle**

* Added the `SPHINXSYS_USE_ONEDPL_SORTING` CMake option (default ON) to allow switching between a custom SYCL radix sort and OneDPL's `sort_by_key` for particle sorting. The option is propagated as a compile definition for conditional compilation. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR18) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR69)

**Algorithm Infrastructure & Implementation**

* Introduced the new `DeviceRadixSort` template class in `algorithm_primitive_sycl.h` and implemented its methods in the new `algorithm_primitive_sycl.hpp` file. This class encapsulates a custom radix sort implementation for SYCL, with support for efficient parallel sorting and flexible configuration. [[1]](diffhunk://#diff-b1ebaea1a5cb4cd1d9fd5b1b0f74742355680427e690c9cb4b8cc6c9be790ff9R38-R72) [[2]](diffhunk://#diff-925dfe538d0ac13bad2516171d49672c4ca3ccb0881371e1fb10e0f7ee003767R1-R241)
* Refactored the `RadixSort` class to use `DeviceRadixSort` for custom sorting, improving encapsulation and code clarity.

**Conditional Sorting Logic**

* Updated the sorting logic in `algorithm_primitive_sycl.cpp` to use either OneDPL's `sort_by_key` or the custom radix sort based on the `SPHINXSYS_USE_ONEDPL_SORTING` flag, enabling flexible performance tuning and portability.

**Code Hygiene & Consistency**

* Changed the include from `algorithm_primitive_sycl.h` to `algorithm_primitive_sycl.hpp` in `algorithm_primitive_sycl.cpp` to match the new implementation structure and prevent potential compilation issues.

These changes collectively make the particle sorting infrastructure more modular and configurable, and allow for easy switching between vendor-optimized and custom implementations.