### PR TITLE
simplified the particle generation

### DIFF
--- a/src/shared/adaptations/adaptation.h
+++ b/src/shared/adaptations/adaptation.h
@@ -89,9 +89,10 @@ class SPHAdaptation
     virtual UniquePtr<BaseCellLinkedList> createCellLinkedList(const BoundingBoxd &domain_bounds, BaseParticles &base_particles);
     UniquePtr<BaseCellLinkedList> createRefinedCellLinkedList(int level, const BoundingBoxd &domain_bounds, BaseParticles &base_particles);
     virtual UniquePtr<LevelSet> createLevelSet(Shape &shape, Real refinement) const;
+    virtual Real getLocalSpacing(Shape &shape, const Vecd &position) {return spacing_ref_;}
 
     template <class KernelType, typename... Args>
-    void resetKernel(Args &&...args)
+        void resetKernel(Args &&...args)
     {
         kernel_ptr_.reset(new KernelType(h_ref_, std::forward<Args>(args)...));
         sigma0_ref_ = computeLatticeNumberDensity(Vecd());
@@ -134,6 +135,7 @@ class AdaptiveSmoothingLength : public SPHAdaptation
     virtual UniquePtr<LevelSet> createLevelSet(Shape &shape, Real refinement) const override;
     DiscreteVariable<Real> *dvSmoothingLengthRatio() { return dv_h_ratio_; };
     DiscreteVariable<int> *dvSmoothingLengthLevel() { return dv_h_level_; };
+    virtual Real getLocalSpacing(Shape &shape, const Vecd &position) = 0;
 
     class ContinuousSmoothingLengthRatio
     {
@@ -168,7 +170,6 @@ class AdaptiveByShape : public AdaptiveSmoothingLength
         : AdaptiveSmoothingLength(std::forward<Args>(args)...){};
 
     virtual ~AdaptiveByShape() {};
-    virtual Real getLocalSpacing(Shape &shape, const Vecd &position) = 0;
 
   protected:
     Real smoothedSpacing(const Real &measure, const Real &transition_thickness);

--- a/src/shared/particle_generator/particle_generator_lattice.cpp
+++ b/src/shared/particle_generator/particle_generator_lattice.cpp
@@ -8,9 +8,8 @@ namespace SPH
 {
 //=================================================================================================//
 GeneratingMethod<Lattice>::GeneratingMethod(SPHBody &sph_body)
-    : lattice_spacing_(sph_body.getSPHAdaptation().ReferenceSpacing()),
-      domain_bounds_(sph_body.getSPHSystemBounds()),
-      initial_shape_(sph_body.getInitialShape())
+    : sph_adaptation_(sph_body.getSPHAdaptation()), lattice_spacing_(sph_adaptation_.MinimumSpacing()),
+      domain_bounds_(sph_body.getSPHSystemBounds()), initial_shape_(sph_body.getInitialShape())
 {
     if (!initial_shape_.isValid())
     {
@@ -21,28 +20,18 @@ GeneratingMethod<Lattice>::GeneratingMethod(SPHBody &sph_body)
 }
 //=================================================================================================//
 ParticleGenerator<BaseParticles, Lattice>::
-    ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles)
-    : ParticleGenerator<BaseParticles>(sph_body, base_particles),
-      GeneratingMethod<Lattice>(sph_body) {}
-//=================================================================================================//
-ParticleGenerator<BaseParticles, Lattice, AdaptiveByShape>::
     ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles, Shape &target_shape)
-    : ParticleGenerator<BaseParticles, Lattice>(sph_body, base_particles),
-      target_shape_(target_shape),
-      particle_adaptation_(DynamicCast<AdaptiveByShape>(this, &sph_body.getSPHAdaptation()))
-{
-    lattice_spacing_ = particle_adaptation_->MinimumSpacing();
-}
+    : ParticleGenerator<BaseParticles>(sph_body, base_particles),
+      GeneratingMethod<Lattice>(sph_body), target_shape_(target_shape) {}
 //=================================================================================================//
-ParticleGenerator<BaseParticles, Lattice, AdaptiveByShape>::
+ParticleGenerator<BaseParticles, Lattice>::
     ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles)
-    : ParticleGenerator<BaseParticles, Lattice, AdaptiveByShape>(
-          sph_body, base_particles, sph_body.getInitialShape()) {}
+    : ParticleGenerator(sph_body, base_particles, sph_body.getInitialShape()) {}
 //=================================================================================================//
-void ParticleGenerator<BaseParticles, Lattice, AdaptiveByShape>::
+void ParticleGenerator<BaseParticles, Lattice>::
     addPositionAndVolumetricMeasure(const Vecd &position, Real volume)
 {
-    Real local_particle_spacing = particle_adaptation_->getLocalSpacing(target_shape_, position);
+    Real local_particle_spacing = sph_adaptation_.getLocalSpacing(target_shape_, position);
     Real local_particle_volume_ratio = pow(lattice_spacing_ / local_particle_spacing, Dimensions);
     if (rand_uniform(0.0, 1.0) < local_particle_volume_ratio)
     {

--- a/src/shared/particle_generator/particle_generator_lattice.h
+++ b/src/shared/particle_generator/particle_generator_lattice.h
@@ -47,9 +47,10 @@ class GeneratingMethod<Lattice>
     virtual ~GeneratingMethod() {};
 
   protected:
-    Real lattice_spacing_;      /**< Initial particle spacing. */
+    SPHAdaptation &sph_adaptation_;
+    Real lattice_spacing_;       /**< Define minimum particle spacing. */
     BoundingBoxd domain_bounds_; /**< Domain bounds. */
-    Shape &initial_shape_;      /**< Geometry shape for body. */
+    Shape &initial_shape_;       /**< Geometry shape for body. */
 };
 
 template <>
@@ -57,22 +58,13 @@ class ParticleGenerator<BaseParticles, Lattice>
     : public ParticleGenerator<BaseParticles>, public GeneratingMethod<Lattice>
 {
   public:
-    explicit ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles);
-    virtual ~ParticleGenerator() {};
-    virtual void prepareGeometricData() override;
-};
-
-template <> // For generating particles with adaptive resolution from lattice positions
-class ParticleGenerator<BaseParticles, Lattice, AdaptiveByShape> : public ParticleGenerator<BaseParticles, Lattice>
-{
-  public:
     ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles, Shape &target_shape);
     explicit ParticleGenerator(SPHBody &sph_body, BaseParticles &base_particles);
     virtual ~ParticleGenerator() {};
+    virtual void prepareGeometricData() override;
 
   protected:
     Shape &target_shape_;
-    AdaptiveByShape *particle_adaptation_;
     virtual void addPositionAndVolumetricMeasure(const Vecd &position, Real volume) override;
 };
 

--- a/tests/2d_examples/test_2d_airfoil/airfoil_2d.cpp
+++ b/tests/2d_examples/test_2d_airfoil/airfoil_2d.cpp
@@ -16,9 +16,9 @@ std::string airfoil_flap_rear = "./input/airfoil_flap_rear.dat";
 //----------------------------------------------------------------------
 //	Basic geometry parameters and numerical setup.
 //----------------------------------------------------------------------
-Real DL = 1.25;             /**< airfoil length rear part. */
-Real DL1 = 0.25;            /**< airfoil length front part. */
-Real DH = 0.25;             /**< airfoil height. */
+Real DL = 1.25;                /**< airfoil length rear part. */
+Real DL1 = 0.25;               /**< airfoil length front part. */
+Real DH = 0.25;                /**< airfoil height. */
 Real global_resolution = 0.02; /**< Reference resolution. */
 BoundingBoxd system_domain_bounds(Vec2d(-DL1, -DH), Vec2d(DL, DH));
 //----------------------------------------------------------------------
@@ -54,7 +54,7 @@ int main(int ac, char *av[])
         ->cleanLevelSet()
         ->addCellVariableToWrite<UnsignedInt>("CellPackageIndex")
         ->writeLevelSet();
-    airfoil.generateParticles<BaseParticles, Lattice, AdaptiveByShape>();
+    airfoil.generateParticles<BaseParticles, Lattice>();
     //----------------------------------------------------------------------
     //	Define outputs functions.
     //----------------------------------------------------------------------

--- a/tests/2d_examples/test_2d_free_stream_around_cylinder_mr/mr_free_stream_around_cylinder.cpp
+++ b/tests/2d_examples/test_2d_free_stream_around_cylinder_mr/mr_free_stream_around_cylinder.cpp
@@ -32,7 +32,7 @@ int main(int ac, char *av[])
     ParticleBuffer<ReserveSizeFactor> inlet_particle_buffer(0.5);
     (!sph_system.RunParticleRelaxation() && sph_system.ReloadParticles())
         ? water_block.generateParticlesWithReserve<BaseParticles, Reload>(inlet_particle_buffer, water_block.getName())
-        : water_block.generateParticles<BaseParticles, Lattice, AdaptiveByShape>(refinement_region);
+        : water_block.generateParticles<BaseParticles, Lattice>(refinement_region);
 
     SolidBody cylinder(sph_system, makeShared<Cylinder>("Cylinder"));
     cylinder.defineAdaptationRatios(1.15, 4.0);

--- a/tests/2d_examples/test_2d_mr_cantilever_beam/test_2d_mr_cantilever_beam.cpp
+++ b/tests/2d_examples/test_2d_mr_cantilever_beam/test_2d_mr_cantilever_beam.cpp
@@ -197,7 +197,7 @@ return_data beam_multi_resolution(Real dp_factor, bool damping_on, int refinemen
     beam_body.defineBodyLevelSetShape();
     beam_body.defineMaterial<NeoHookeanSolid>(*material.get());
     if (refinement_level > 0)
-        beam_body.generateParticles<BaseParticles, Lattice, AdaptiveByShape>(refinement_region);
+        beam_body.generateParticles<BaseParticles, Lattice>(refinement_region);
     else
         beam_body.generateParticles<BaseParticles, Lattice>();
 

--- a/tests/3d_examples/test_3d_load_image/load_image.cpp
+++ b/tests/3d_examples/test_3d_load_image/load_image.cpp
@@ -48,7 +48,7 @@ int main(int ac, char *av[])
     RealBody imported_model(sph_system, makeShared<SolidBodyFromMesh>("SolidBodyFromMesh"));
     imported_model.defineAdaptation<AdaptiveNearSurface>(1.15, 1.0, 2);
     imported_model.defineBodyLevelSetShape()->writeLevelSet();
-    imported_model.generateParticles<BaseParticles, Lattice, AdaptiveByShape>();
+    imported_model.generateParticles<BaseParticles, Lattice>();
     //----------------------------------------------------------------------
     //	Define simple file input and outputs functions.
     //----------------------------------------------------------------------

--- a/tests/3d_examples/test_3d_mr_cantilever_beam/test_3d_mr_cantilever_beam.cpp
+++ b/tests/3d_examples/test_3d_mr_cantilever_beam/test_3d_mr_cantilever_beam.cpp
@@ -188,7 +188,7 @@ return_data beam_multi_resolution(Real dp_factor, bool damping_on, int refinemen
     beam_body.defineBodyLevelSetShape();
     beam_body.defineMaterial<NeoHookeanSolid>(*material.get());
     if (refinement_level > 0)
-        beam_body.generateParticles<BaseParticles, Lattice, AdaptiveByShape>(*refinement_region);
+        beam_body.generateParticles<BaseParticles, Lattice>(*refinement_region);
     else
         beam_body.generateParticles<BaseParticles, Lattice>();
 

--- a/tests/3d_examples/test_3d_nonlinear_wave_fsi/nonlinear_wave_fsi.cpp
+++ b/tests/3d_examples/test_3d_nonlinear_wave_fsi/nonlinear_wave_fsi.cpp
@@ -20,7 +20,7 @@ int main(int ac, char *av[])
     structure_fit.defineAdaptation<AdaptiveNearSurface>(1.3, 0.7, 3);
     structure_fit.defineBodyLevelSetShape()->correctLevelSetSign()->writeLevelSet();
     structure_fit.defineMaterial<Solid>(StructureDensity);
-    structure_fit.generateParticles<BaseParticles, Lattice, AdaptiveByShape>();
+    structure_fit.generateParticles<BaseParticles, Lattice>();
 
     //----------------------------------------------------------------------
     //	Define body relation map.

--- a/tests/3d_examples/test_3d_particle_relaxation/particle_relaxation.cpp
+++ b/tests/3d_examples/test_3d_particle_relaxation/particle_relaxation.cpp
@@ -49,7 +49,7 @@ int main(int ac, char *av[])
     RealBody imported_model(sph_system, makeShared<SolidBodyFromMesh>("SolidBodyFromMesh"));
     imported_model.defineAdaptation<AdaptiveNearSurface>(1.15, 1.0, 3);
     imported_model.defineBodyLevelSetShape()->correctLevelSetSign()->writeLevelSet();
-    imported_model.generateParticles<BaseParticles, Lattice, AdaptiveByShape>();
+    imported_model.generateParticles<BaseParticles, Lattice>();
     //----------------------------------------------------------------------
     //	Define simple file input and outputs functions.
     //----------------------------------------------------------------------


### PR DESCRIPTION
This pull request refactors the particle generation system to simplify the usage of lattice-based particle generators and to generalize adaptive spacing logic. The main focus is to remove the explicit dependency on the `AdaptiveByShape` template parameter in particle generators, instead relying on the adaptation interface for local spacing. This results in a cleaner interface for particle generation and improved maintainability.

**Core Refactoring and Interface Simplification:**

* The `ParticleGenerator<BaseParticles, Lattice, AdaptiveByShape>` specialization and its usages have been removed. Now, `ParticleGenerator<BaseParticles, Lattice>` is used for both uniform and adaptive lattice particle generation, with adaptive behavior handled through the `SPHAdaptation` interface. [[1]](diffhunk://#diff-f142a3be1c028f753166a9e8e4000c459cc2723e6e9190c01b7eefa5860e0fecL24-R34) [[2]](diffhunk://#diff-5a3d21203b4a8d4f2da48d87453353f3e70f9fd6ae8028540a4c387dc78fa09aL50-L75)

* All calls to `generateParticles<BaseParticles, Lattice, AdaptiveByShape>` in test and example files have been replaced with `generateParticles<BaseParticles, Lattice>`, simplifying code and usage. [[1]](diffhunk://#diff-0729cc9a9e4ab15a07776e39c9eca0fe7cd728b17355af1466760bdcfae65a07L57-R57) [[2]](diffhunk://#diff-045a8a0d33b61fa75b5ce3b96be77cd0975e65685bfa5d9d855ff4a80078bd58L35-R35) [[3]](diffhunk://#diff-cd456788d0166308ee9776911fd9c83309c74aefcde91a65d5f6ae3a55ce392eL200-R200) [[4]](diffhunk://#diff-3ee8c5e833a512159adb5237886a1285ad0a7ec3ecc43e09cdde18a1f94b30d0L51-R51) [[5]](diffhunk://#diff-fdc9fe0ebfd2d3e0ac63679a88bd9f54559c1ffd6e34846e13203b1875364167L191-R191) [[6]](diffhunk://#diff-eb4233de022f582d65d8d42265d286ed99bbfaa72036714b3309f00c8a55e3d2L23-R23) [[7]](diffhunk://#diff-269f852a1a83db5daeee2fdb9c1edacf20c246d2b7666606ae20550534279ab3L52-R52)

**Adaptation and Spacing Logic Improvements:**

* The method `getLocalSpacing` is now part of the base `SPHAdaptation` interface, with a default implementation, and is overridden as needed in derived classes. This allows particle generators to query local spacing directly from the adaptation object, regardless of its specific type. [[1]](diffhunk://#diff-c9b190e1f93461a105e2b2683207e517cde617a1c9d985f651ff871ff5eab243R92) [[2]](diffhunk://#diff-c9b190e1f93461a105e2b2683207e517cde617a1c9d985f651ff871ff5eab243R138) [[3]](diffhunk://#diff-c9b190e1f93461a105e2b2683207e517cde617a1c9d985f651ff871ff5eab243L171)

* The `GeneratingMethod<Lattice>` class now stores a reference to `SPHAdaptation` and uses its `MinimumSpacing()` and `getLocalSpacing()` methods, further decoupling particle generation from specific adaptation implementations. [[1]](diffhunk://#diff-f142a3be1c028f753166a9e8e4000c459cc2723e6e9190c01b7eefa5860e0fecL11-R12) [[2]](diffhunk://#diff-5a3d21203b4a8d4f2da48d87453353f3e70f9fd6ae8028540a4c387dc78fa09aL50-L75)

These changes collectively make the particle generation system more modular, easier to use, and more maintainable by unifying the interface for adaptive and non-adaptive lattice generation.