### PR TITLE
Fix normal direction in CPU

### DIFF
--- a/src/shared/particle_dynamics/fluid_dynamics/fluid_integration.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/fluid_integration.hpp
@@ -218,10 +218,12 @@ void Integration2ndHalf<Contact<Wall>, RiemannSolverType>::interaction(size_t in
             Vecd &e_ij = wall_neighborhood.e_ij_[n];
             Real dW_ijV_j = wall_neighborhood.dW_ij_[n] * wall_Vol_k[index_j];
 
+            Vecd face_to_fluid_n = SGN(e_ij.dot(n_k[index_j])) * n_k[index_j];
+
             Vecd vel_j_in_wall = 2.0 * vel_ave_k[index_j] - vel_[index_i];
             density_change_rate += (vel_[index_i] - vel_j_in_wall).dot(e_ij) * dW_ijV_j;
-            Real u_jump = 2.0 * (vel_[index_i] - vel_ave_k[index_j]).dot(n_k[index_j]);
-            p_dissipation += riemann_solver_.DissipativePJump(u_jump) * dW_ijV_j * n_k[index_j];
+            Real u_jump = 2.0 * (vel_[index_i] - vel_ave_k[index_j]).dot(face_to_fluid_n);
+            p_dissipation += riemann_solver_.DissipativePJump(u_jump) * dW_ijV_j * face_to_fluid_n;
         }
     }
     drho_dt_[index_i] += density_change_rate * this->rho_[index_i];

--- a/src/shared/particle_dynamics/solid_dynamics/fluid_structure_interaction.hpp
+++ b/src/shared/particle_dynamics/solid_dynamics/fluid_structure_interaction.hpp
@@ -50,8 +50,9 @@ void PressureForceFromFluid<FluidIntegration2ndHalfType>::interaction(size_t ind
             Real face_wall_external_acceleration =
                 (force_prior_k[index_j] / mass_k[index_j] - acc_ave_[index_i]).dot(e_ij);
             Real p_j_in_wall = p_k[index_j] + rho_k[index_j] * r_ij * SMAX(Real(0), face_wall_external_acceleration);
-            Real u_jump = 2.0 * (vel_k[index_j] - vel_ave_[index_i]).dot(n_[index_i]);
-            force -= (riemann_solvers_k.DissipativePJump(u_jump) * n_[index_i] + (p_j_in_wall + p_k[index_j]) * e_ij) *
+            Vecd face_to_fluid_n = -SGN(e_ij.dot(n_[index_i])) * n_[index_i];
+            Real u_jump = 2.0 * (vel_k[index_j] - vel_ave_[index_i]).dot(face_to_fluid_n);
+            force -= (riemann_solvers_k.DissipativePJump(u_jump) * face_to_fluid_n + (p_j_in_wall + p_k[index_j]) * e_ij) *
                      contact_neighborhood.dW_ij_[n] * Vol_k[index_j];
         }
     }


### PR DESCRIPTION
Following the ck version [878](https://github.com/Xiangyu-Hu/SPHinXsys/pull/878), select the normal direction of wall particles automatically in cpu version as well.