### PR TITLE
Remove redundant codes

### DIFF
--- a/src/for_2D_build/geometries/multi_polygon_shape.cpp
+++ b/src/for_2D_build/geometries/multi_polygon_shape.cpp
@@ -264,7 +264,7 @@ BoundingBoxd MultiPolygon::findBounds()
 //=================================================================================================//
 bool MultiPolygonShape::isValid()
 {
-    return !(multi_polygon_.getBoostMultiPoly().size() == 0);
+    return !multi_polygon_.getBoostMultiPoly().empty();
 }
 //=================================================================================================//
 bool MultiPolygonShape::checkContain(const Vecd &probe_point, bool BOUNDARY_INCLUDED)

--- a/src/for_2D_build/geometries/multi_polygon_shape.cpp
+++ b/src/for_2D_build/geometries/multi_polygon_shape.cpp
@@ -264,7 +264,7 @@ BoundingBoxd MultiPolygon::findBounds()
 //=================================================================================================//
 bool MultiPolygonShape::isValid()
 {
-    return multi_polygon_.getBoostMultiPoly().size() == 0 ? false : true;
+    return !(multi_polygon_.getBoostMultiPoly().size() == 0);
 }
 //=================================================================================================//
 bool MultiPolygonShape::checkContain(const Vecd &probe_point, bool BOUNDARY_INCLUDED)

--- a/src/for_2D_build/particle_generator/particle_generator_lattice_2d.cpp
+++ b/src/for_2D_build/particle_generator/particle_generator_lattice_2d.cpp
@@ -18,13 +18,8 @@ void ParticleGenerator<BaseParticles, Lattice>::prepareGeometricData()
         for (int j = 0; j < number_of_lattices[1]; ++j)
         {
             Vecd particle_position = mesh.CellPositionFromIndex(Arrayi(i, j));
-            if (initial_shape_.checkNotFar(particle_position, lattice_spacing_))
-            {
-                if (initial_shape_.checkContain(particle_position))
-                {
-                    addPositionAndVolumetricMeasure(particle_position, particle_volume);
-                }
-            }
+            if (initial_shape_.checkContain(particle_position))
+                addPositionAndVolumetricMeasure(particle_position, particle_volume);
         }
 }
 //=================================================================================================//
@@ -38,13 +33,10 @@ void ParticleGenerator<SurfaceParticles, Lattice>::prepareGeometricData()
         for (int j = 0; j < number_of_lattices[1]; ++j)
         {
             Vecd particle_position = mesh.CellPositionFromIndex(Arrayi(i, j));
-            if (initial_shape_.checkNotFar(particle_position, lattice_spacing_))
+            if (initial_shape_.checkContain(particle_position))
             {
-                if (initial_shape_.checkContain(particle_position))
-                {
-                    all_cells_++;
-                    total_volume_ += lattice_spacing_ * lattice_spacing_;
-                }
+                all_cells_++;
+                total_volume_ += lattice_spacing_ * lattice_spacing_;
             }
         }
     Real number_of_particles = total_volume_ / avg_particle_volume_ + 0.5;
@@ -64,17 +56,14 @@ void ParticleGenerator<SurfaceParticles, Lattice>::prepareGeometricData()
         for (int j = 0; j < number_of_lattices[1]; ++j)
         {
             Vecd particle_position = mesh.CellPositionFromIndex(Arrayi(i, j));
-            if (initial_shape_.checkNotFar(particle_position, lattice_spacing_))
+            if (initial_shape_.checkContain(particle_position))
             {
-                if (initial_shape_.checkContain(particle_position))
+                Real random_real = unif(rng);
+                // If the random_real is smaller than the interval, add a particle, only if we haven't reached the max. number of particles
+                if (random_real <= interval && base_particles_.TotalRealParticles() < planned_number_of_particles_)
                 {
-                    Real random_real = unif(rng);
-                    // If the random_real is smaller than the interval, add a particle, only if we haven't reached the max. number of particles
-                    if (random_real <= interval && base_particles_.TotalRealParticles() < planned_number_of_particles_)
-                    {
-                        addPositionAndVolumetricMeasure(particle_position, avg_particle_volume_ / thickness_);
-                        addSurfaceProperties(initial_shape_.findNormalDirection(particle_position), thickness_);
-                    }
+                    addPositionAndVolumetricMeasure(particle_position, avg_particle_volume_ / thickness_);
+                    addSurfaceProperties(initial_shape_.findNormalDirection(particle_position), thickness_);
                 }
             }
         }

--- a/src/for_3D_build/geometries/triangle_mesh_shape.cpp
+++ b/src/for_3D_build/geometries/triangle_mesh_shape.cpp
@@ -135,7 +135,7 @@ bool TriangleMeshShape::checkContain(const Vec3d &probe_point, bool BOUNDARY_INC
 {
     Real distance = triangle_mesh_distance_.signed_distance(probe_point).distance;
 
-    return distance < 0.0 ? true : false;
+    return distance < 0.0;
 }
 //=================================================================================================//
 Vecd TriangleMeshShape::findClosestPoint(const Vecd &probe_point)

--- a/src/for_3D_build/particle_generator/particle_generator_lattice_3d.cpp
+++ b/src/for_3D_build/particle_generator/particle_generator_lattice_3d.cpp
@@ -19,13 +19,8 @@ void ParticleGenerator<BaseParticles, Lattice>::prepareGeometricData()
             for (int k = 0; k < number_of_lattices[2]; ++k)
             {
                 Vecd particle_position = mesh.CellPositionFromIndex(Arrayi(i, j, k));
-                if (initial_shape_.checkNotFar(particle_position, lattice_spacing_))
-                {
-                    if (initial_shape_.checkContain(particle_position))
-                    {
-                        addPositionAndVolumetricMeasure(particle_position, particle_volume);
-                    }
-                }
+                if (initial_shape_.checkContain(particle_position))
+                    addPositionAndVolumetricMeasure(particle_position, particle_volume);
             }
 }
 //=================================================================================================//
@@ -40,13 +35,10 @@ void ParticleGenerator<SurfaceParticles, Lattice>::prepareGeometricData()
             for (int k = 0; k < number_of_lattices[2]; ++k)
             {
                 Vecd particle_position = mesh.CellPositionFromIndex(Arrayi(i, j, k));
-                if (initial_shape_.checkNotFar(particle_position, lattice_spacing_))
+                if (initial_shape_.checkContain(particle_position))
                 {
-                    if (initial_shape_.checkContain(particle_position))
-                    {
-                        all_cells_++;
-                        total_volume_ += lattice_spacing_ * lattice_spacing_ * lattice_spacing_;
-                    }
+                    all_cells_++;
+                    total_volume_ += lattice_spacing_ * lattice_spacing_ * lattice_spacing_;
                 }
             }
     Real number_of_particles = total_volume_ / avg_particle_volume_ + 0.5;
@@ -67,17 +59,14 @@ void ParticleGenerator<SurfaceParticles, Lattice>::prepareGeometricData()
             for (int k = 0; k < number_of_lattices[2]; ++k)
             {
                 Vecd particle_position = mesh.CellPositionFromIndex(Arrayi(i, j, k));
-                if (initial_shape_.checkNotFar(particle_position, lattice_spacing_))
+                if (initial_shape_.checkContain(particle_position))
                 {
-                    if (initial_shape_.checkContain(particle_position))
+                    Real random_real = uniform_distr(rng);
+                    // If the random_real is smaller than the interval, add a particle, only if we haven't reached the max. number of particles.
+                    if (random_real <= interval && base_particles_.TotalRealParticles() < planned_number_of_particles_)
                     {
-                        Real random_real = uniform_distr(rng);
-                        // If the random_real is smaller than the interval, add a particle, only if we haven't reached the max. number of particles.
-                        if (random_real <= interval && base_particles_.TotalRealParticles() < planned_number_of_particles_)
-                        {
-                            addPositionAndVolumetricMeasure(particle_position, avg_particle_volume_ / thickness_);
-                            addSurfaceProperties(initial_shape_.findNormalDirection(particle_position), thickness_);
-                        }
+                        addPositionAndVolumetricMeasure(particle_position, avg_particle_volume_ / thickness_);
+                        addSurfaceProperties(initial_shape_.findNormalDirection(particle_position), thickness_);
                     }
                 }
             }

--- a/src/shared/common/geometric_primitive.h
+++ b/src/shared/common/geometric_primitive.h
@@ -128,7 +128,7 @@ class BoundingBox
 template <template <int> typename BoundType, int N>
 bool operator==(const BoundingBox<BoundType, N> &bb1, const BoundingBox<BoundType, N> &bb2)
 {
-    return bb1.lower_ == bb2.lower_ && bb1.upper_ == bb2.upper_ ? true : false;
+    return bb1.lower_ == bb2.lower_ && bb1.upper_ == bb2.upper_;
 };
 
 using Rotation2d = Eigen::Rotation2D<Real>;

--- a/src/shared/common/scalar_functions.h
+++ b/src/shared/common/scalar_functions.h
@@ -144,7 +144,7 @@ inline T clamp(T a, T lower, T upper)
 template <class T>
 inline bool Not_a_number(T a)
 {
-    return (std::isnan(a) || !(std::isfinite(a))) ? true : false;
+    return (std::isnan(a) || !(std::isfinite(a)));
 }
 
 inline Real harmonic_average(const Real &a, const Real &b)

--- a/src/shared/common/scalar_functions.h
+++ b/src/shared/common/scalar_functions.h
@@ -144,7 +144,7 @@ inline T clamp(T a, T lower, T upper)
 template <class T>
 inline bool Not_a_number(T a)
 {
-    return (std::isnan(a) || !(std::isfinite(a)));
+    return !std::isfinite(a);
 }
 
 inline Real harmonic_average(const Real &a, const Real &b)

--- a/src/shared/geometries/base_geometry.cpp
+++ b/src/shared/geometries/base_geometry.cpp
@@ -60,7 +60,7 @@ Vecd Shape::findNormalDirection(const Vecd &probe_point)
 //=================================================================================================//
 bool BinaryShapes::isValid()
 {
-    return !(sub_shapes_and_ops_.size() == 0);
+    return !sub_shapes_and_ops_.empty();
 }
 //=================================================================================================//
 BoundingBoxd BinaryShapes::findBounds()

--- a/src/shared/geometries/base_geometry.cpp
+++ b/src/shared/geometries/base_geometry.cpp
@@ -27,13 +27,13 @@ BoundingBoxd Shape::getBounds()
 //=================================================================================================//
 bool Shape::checkNotFar(const Vecd &probe_point, Real threshold)
 {
-    return checkContain(probe_point) || checkNearSurface(probe_point, threshold) ? true : false;
+    return checkContain(probe_point) || checkNearSurface(probe_point, threshold);
 }
 //=================================================================================================//
 bool Shape::checkNearSurface(const Vecd &probe_point, Real threshold)
 {
     Vecd distance = probe_point - findClosestPoint(probe_point);
-    return distance.cwiseAbs().maxCoeff() < threshold ? true : false;
+    return distance.cwiseAbs().maxCoeff() < threshold;
 }
 //=================================================================================================//
 Real Shape::findSignedDistance(const Vecd &probe_point)
@@ -60,7 +60,7 @@ Vecd Shape::findNormalDirection(const Vecd &probe_point)
 //=================================================================================================//
 bool BinaryShapes::isValid()
 {
-    return sub_shapes_and_ops_.size() == 0 ? false : true;
+    return !(sub_shapes_and_ops_.size() == 0);
 }
 //=================================================================================================//
 BoundingBoxd BinaryShapes::findBounds()

--- a/src/shared/geometries/complex_geometry.cpp
+++ b/src/shared/geometries/complex_geometry.cpp
@@ -5,25 +5,25 @@ namespace SPH
 //=================================================================================================//
 bool AlignedBox::checkNotFar(const Vecd &probe_point, Real threshold)
 {
-    return checkContain(probe_point) || checkNearSurface(probe_point, threshold) ? true : false;
+    return checkContain(probe_point) || checkNearSurface(probe_point, threshold);
 }
 //=================================================================================================//
 bool AlignedBox::checkNearSurface(const Vecd &probe_point, Real threshold)
 {
     Vecd distance = probe_point - findClosestPoint(probe_point);
-    return distance.cwiseAbs().maxCoeff() < threshold ? true : false;
+    return distance.cwiseAbs().maxCoeff() < threshold;
 }
 //=================================================================================================//
 bool AlignedBox::checkNearUpperBound(const Vecd &probe_point, Real threshold)
 {
     Vecd position_in_frame = transform_.shiftBaseStationToFrame(probe_point);
-    return ABS(position_in_frame[alignment_axis_] - halfsize_[alignment_axis_]) <= threshold ? true : false;
+    return ABS(position_in_frame[alignment_axis_] - halfsize_[alignment_axis_]) <= threshold;
 }
 //=================================================================================================//
 bool AlignedBox::checkNearLowerBound(const Vecd &probe_point, Real threshold)
 {
     Vecd position_in_frame = transform_.shiftBaseStationToFrame(probe_point);
-    return ABS(position_in_frame[alignment_axis_] + halfsize_[alignment_axis_]) <= threshold ? true : false;
+    return ABS(position_in_frame[alignment_axis_] + halfsize_[alignment_axis_]) <= threshold;
 }
 //=================================================================================================//
 Vecd AlignedBox::getLowerPeriodic(const Vecd &probe_point)

--- a/src/shared/geometries/complex_geometry.h
+++ b/src/shared/geometries/complex_geometry.h
@@ -106,12 +106,12 @@ class AlignedBox : public TransformGeometry<GeometricBox>
     bool checkUpperBound(const Vecd &probe_point, Real upper_bound_fringe = 0.0)
     {
         Vecd position_in_frame = transform_.shiftBaseStationToFrame(probe_point);
-        return position_in_frame[alignment_axis_] > halfsize_[alignment_axis_] + upper_bound_fringe ? true : false;
+        return position_in_frame[alignment_axis_] > halfsize_[alignment_axis_] + upper_bound_fringe;
     };
     bool checkLowerBound(const Vecd &probe_point, Real lower_bound_fringe = 0.0)
     {
         Vecd position_in_frame = transform_.shiftBaseStationToFrame(probe_point);
-        return position_in_frame[alignment_axis_] < -halfsize_[alignment_axis_] - lower_bound_fringe ? true : false;
+        return position_in_frame[alignment_axis_] < -halfsize_[alignment_axis_] - lower_bound_fringe;
     }
     bool checkNearUpperBound(const Vecd &probe_point, Real threshold);
     bool checkNearLowerBound(const Vecd &probe_point, Real threshold);

--- a/src/shared/geometries/level_set_shape.cpp
+++ b/src/shared/geometries/level_set_shape.cpp
@@ -44,7 +44,7 @@ LevelSetShape *LevelSetShape::correctLevelSetSign()
 //=================================================================================================//
 bool LevelSetShape::checkContain(const Vecd &probe_point, bool BOUNDARY_INCLUDED)
 {
-    return level_set_.probeSignedDistance(probe_point) < 0.0 ? true : false;
+    return level_set_.probeSignedDistance(probe_point) < 0.0;
 }
 //=================================================================================================//
 Vecd LevelSetShape::findClosestPoint(const Vecd &probe_point)

--- a/src/shared/io_system/io_base.cpp
+++ b/src/shared/io_system/io_base.cpp
@@ -20,7 +20,7 @@ bool BaseIO::isBodyIncluded(const SPHBodyVector &bodies, SPHBody *sph_body)
     auto result = std::find_if(bodies.begin(), bodies.end(),
                                [&](auto &body) -> bool
                                { return body == sph_body; });
-    return result != bodies.end() ? true : false;
+    return result != bodies.end();
 }
 //=============================================================================================//
 BodyStatesRecording::BodyStatesRecording(SPHSystem &sph_system)

--- a/src/shared/kernels/anisotropic_kernel.hpp
+++ b/src/shared/kernels/anisotropic_kernel.hpp
@@ -49,10 +49,7 @@ bool AnisotropicKernel<KernelType>::checkIfWithinCutOffRadius(Vec2d displacement
 {
     Vec2d transformed_displacement = this->h_ * transformed_tensor_2d_ * displacement;
     Real distance_metric = transformed_displacement.squaredNorm();
-    if (distance_metric < this->CutOffRadiusSqr())
-        return true;
-    else
-        return false;
+    return distance_metric < this->CutOffRadiusSqr();
 }
 //=========================================================================================//
 template <class KernelType>
@@ -60,10 +57,7 @@ bool AnisotropicKernel<KernelType>::checkIfWithinCutOffRadius(Vec3d displacement
 {
     Vec3d transformed_displacement = this->h_ * transformed_tensor_3d_ * displacement;
     Real distance_metric = transformed_displacement.squaredNorm();
-    if (distance_metric < this->CutOffRadiusSqr())
-        return true;
-    else
-        return false;
+    return distance_metric < this->CutOffRadiusSqr()
 }
 //=========================================================================================//
 template <class KernelType>

--- a/src/shared/kernels/anisotropic_kernel.hpp
+++ b/src/shared/kernels/anisotropic_kernel.hpp
@@ -57,7 +57,7 @@ bool AnisotropicKernel<KernelType>::checkIfWithinCutOffRadius(Vec3d displacement
 {
     Vec3d transformed_displacement = this->h_ * transformed_tensor_3d_ * displacement;
     Real distance_metric = transformed_displacement.squaredNorm();
-    return distance_metric < this->CutOffRadiusSqr()
+    return distance_metric < this->CutOffRadiusSqr();
 }
 //=========================================================================================//
 template <class KernelType>

--- a/src/shared/kernels/base_kernel.h
+++ b/src/shared/kernels/base_kernel.h
@@ -105,18 +105,12 @@ class Kernel
     virtual bool checkIfWithinCutOffRadius(Vec2d displacement)
     {
         Real distance_metric = displacement.squaredNorm();
-        if (distance_metric < CutOffRadiusSqr())
-            return true;
-        else
-            return false;
+        return distance_metric < CutOffRadiusSqr();
     };
     virtual bool checkIfWithinCutOffRadius(Vec3d displacement)
     {
         Real distance_metric = displacement.squaredNorm();
-        if (distance_metric < CutOffRadiusSqr())
-            return true;
-        else
-            return false;
+        return distance_metric < CutOffRadiusSqr();
     };
 
     /**

--- a/src/shared/particle_dynamics/dissipation_dynamics/particle_dynamics_dissipation.hpp
+++ b/src/shared/particle_dynamics/dissipation_dynamics/particle_dynamics_dissipation.hpp
@@ -167,7 +167,7 @@ DampingWithRandomChoice<DampingAlgorithmType>::
 template <class DampingAlgorithmType>
 bool DampingWithRandomChoice<DampingAlgorithmType>::RandomChoice()
 {
-    return rand_uniform(0.0, 1.0) < random_ratio_ ? true : false;
+    return rand_uniform(0.0, 1.0) < random_ratio_;
 }
 //=================================================================================================//
 template <class DampingAlgorithmType>

--- a/src/shared/particle_dynamics/fluid_dynamics/density_summation.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/density_summation.h
@@ -142,7 +142,7 @@ struct NearFreeStream
 {
     Real operator()(Real rho_sum, Real rho0, Real rho)
     {
-      return rho_sum + SMAX(Real(0), (rho - rho_sum)) * rho0 / rho;
+      return (rho_sum < rho) ? (rho_sum + (rho - rho_sum) * rho0 / rho) : rho_sum;
     };
 };
 

--- a/src/shared/particle_dynamics/fluid_dynamics/density_summation.h
+++ b/src/shared/particle_dynamics/fluid_dynamics/density_summation.h
@@ -142,11 +142,7 @@ struct NearFreeStream
 {
     Real operator()(Real rho_sum, Real rho0, Real rho)
     {
-        if (rho_sum < rho)
-        {
-            return rho_sum + SMAX(Real(0), (rho - rho_sum)) * rho0 / rho;
-        }
-        return rho_sum;
+      return rho_sum + SMAX(Real(0), (rho - rho_sum)) * rho0 / rho;
     };
 };
 

--- a/src/shared/shared_ck/particle_dynamics/sph_solver.cpp
+++ b/src/shared/shared_ck/particle_dynamics/sph_solver.cpp
@@ -19,11 +19,7 @@ TimeStepper::TriggerByPhysicalTime::
 //=================================================================================================//
 bool TimeStepper::TriggerByPhysicalTime::operator()()
 {
-    if (sv_physical_time_->getValue() > trigger_time_)
-    {
-        return true;
-    }
-    return false;
+    return sv_physical_time_->getValue() > trigger_time_;
 }
 //=================================================================================================//
 TimeStepper::TriggerByInterval::TriggerByInterval(Real initial_interval)

--- a/tests/3d_examples/test_3d_load_image/image_shape.cpp
+++ b/tests/3d_examples/test_3d_load_image/image_shape.cpp
@@ -8,20 +8,7 @@ namespace SPH
 bool ImageShape::checkContain(const Vecd &probe_point, bool BOUNDARY_INCLUDED)
 {
     Real value = image_->findValueAtPoint(probe_point);
-    if (BOUNDARY_INCLUDED == true)
-    {
-        if (value > 0.0)
-            return false;
-        else
-            return true;
-    }
-    else
-    {
-        if (value >= 0.0)
-            return false;
-        else
-            return true;
-    }
+    return BOUNDARY_INCLUDED ? value <= 0.0 : value < 0.0;
 }
 //=================================================================================================//
 Vecd ImageShape::findClosestPoint(const Vecd &probe_point)

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/bidirectional_buffer.h
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/bidirectional_buffer.h
@@ -108,26 +108,23 @@ class BidirectionalBuffer
 
         void update(size_t index_i, Real dt = 0.0)
         {
-            if (!aligned_box_.checkInBounds(pos_[index_i]))
-            {
-                if (aligned_box_.checkUpperBound(pos_[index_i], upper_bound_fringe_) &&
-                    buffer_indicator_[index_i] == part_id_ &&
-                    index_i < particles_->TotalRealParticles())
-                {
-                    mutex_switch.lock();
-                    particle_buffer_.checkEnoughBuffer(*particles_);
-                    size_t new_particle_index = particles_->createRealParticleFrom(index_i);
-                    buffer_indicator_[new_particle_index] = 0;
+          if (aligned_box_.checkUpperBound(pos_[index_i], upper_bound_fringe_) &&
+              buffer_indicator_[index_i] == part_id_ &&
+              index_i < particles_->TotalRealParticles())
+          {
+              mutex_switch.lock();
+              particle_buffer_.checkEnoughBuffer(*particles_);
+              size_t new_particle_index = particles_->createRealParticleFrom(index_i);
+              buffer_indicator_[new_particle_index] = 0;
 
-                    /** Periodic bounding. */
-                    pos_[index_i] = aligned_box_.getUpperPeriodic(pos_[index_i]);
-                    Real sound_speed = fluid_.getSoundSpeed(rho_[index_i]);
-                    p_[index_i] = target_pressure_(p_[index_i], *physical_time_);
-                    rho_[index_i] = p_[index_i] / pow(sound_speed, 2.0) + fluid_.ReferenceDensity();
-                    previous_surface_indicator_[index_i] = 1;
-                    mutex_switch.unlock();
-                }
-            }
+              /** Periodic bounding. */
+              pos_[index_i] = aligned_box_.getUpperPeriodic(pos_[index_i]);
+              Real sound_speed = fluid_.getSoundSpeed(rho_[index_i]);
+              p_[index_i] = target_pressure_(p_[index_i], *physical_time_);
+              rho_[index_i] = p_[index_i] / pow(sound_speed, 2.0) + fluid_.ReferenceDensity();
+              previous_surface_indicator_[index_i] = 1;
+              mutex_switch.unlock();
+          }
         }
 
       protected:

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/windkessel_bc.h
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/windkessel_bc.h
@@ -168,29 +168,26 @@ class BidirectionalBufferWindkessel
 
         void update(size_t index_i, Real dt = 0.0)
         {
-            if (!aligned_box_.checkInBounds(pos_[index_i]))
-            {
-                if (aligned_box_.checkUpperBound(pos_[index_i], upper_bound_fringe_) &&
-                    buffer_indicator_[index_i] == part_id_ &&
-                    index_i < particles_->TotalRealParticles())
-                {
-                    mutex_switch.lock();
-                    particle_buffer_.checkEnoughBuffer(*particles_);
-                    size_t new_particle_index = particles_->createRealParticleFrom(index_i);
-                    buffer_indicator_[new_particle_index] = 0;
+          if (aligned_box_.checkUpperBound(pos_[index_i], upper_bound_fringe_) &&
+              buffer_indicator_[index_i] == part_id_ &&
+              index_i < particles_->TotalRealParticles())
+          {
+              mutex_switch.lock();
+              particle_buffer_.checkEnoughBuffer(*particles_);
+              size_t new_particle_index = particles_->createRealParticleFrom(index_i);
+              buffer_indicator_[new_particle_index] = 0;
 
-                    /** Periodic bounding. */
-                    pos_[index_i] = aligned_box_.getUpperPeriodic(pos_[index_i]);
-                    Real sound_speed = fluid_.getSoundSpeed(rho_[index_i]);
-                    p_[index_i] = target_pressure_(p_[index_i], *physical_time_);
-                    rho_[index_i] = p_[index_i] / pow(sound_speed, 2.0) + fluid_.ReferenceDensity();
-                    previous_surface_indicator_[index_i] = 1;
-                    mutex_switch.unlock();
+              /** Periodic bounding. */
+              pos_[index_i] = aligned_box_.getUpperPeriodic(pos_[index_i]);
+              Real sound_speed = fluid_.getSoundSpeed(rho_[index_i]);
+              p_[index_i] = target_pressure_(p_[index_i], *physical_time_);
+              rho_[index_i] = p_[index_i] / pow(sound_speed, 2.0) + fluid_.ReferenceDensity();
+              previous_surface_indicator_[index_i] = 1;
+              mutex_switch.unlock();
 
-                    flow_rate_ -= Vol_[index_i];
-                    acc_mass_flow_rate_ -= Vol_[index_i] * rho_[index_i];
-                }
-            }
+              flow_rate_ -= Vol_[index_i];
+              acc_mass_flow_rate_ -= Vol_[index_i] * rho_[index_i];
+          }
         }
 
       protected:


### PR DESCRIPTION
Some codes, esp. conditional expressions and statements, are redundant and can be written more concisely.

# Unnecessary use of the ternary operator

1. `xxx ? true : false` can be simplified as `xxx`.
2. `xxx ? false : true` can be simplified as `!(xxx)`.

# Redundant if-else in return statements

```cpp
        if (distance_metric < CutOffRadiusSqr())
            return true;
        else
            return false;
```
The above can be simplified as `return distance_metric < CutOffRadiusSqr()`.

```cpp
    Real operator()(Real rho_sum, Real rho0, Real rho)
    {
        if (rho_sum < rho)
        {
            return rho_sum + SMAX(Real(0), (rho - rho_sum)) * rho0 / rho;
        }
        return rho_sum;
    };
``` 
If `rho_sum >= rho`, `rho_sum + SMAX(Real(0), (rho - rho_sum)) * rho0 / rho` will be reduced to `rho_sum`. So this judgement is unnecessary.

# Redundant checks

```cpp
            if (initial_shape_.checkNotFar(particle_position, lattice_spacing_))
            {
                if (initial_shape_.checkContain(particle_position))
                   ...
            }
```
`checkNotFar` can be expanded as `checkContain(probe_point) || checkNearSurface(probe_point, threshold)`. Because `(A OR B) AND A` is equal to `A`, the above codes can be simplified as `if (initial_shape_.checkContain(particle_position))` and `checkNotFar` is unnecessary.

```cpp
            if (!aligned_box_.checkInBounds(pos_[index_i]))
            {
                if (aligned_box_.checkUpperBound(pos_[index_i], upper_bound_fringe_) &&
                    buffer_indicator_[index_i] == part_id_ &&
                    index_i < particles_->TotalRealParticles())
                ...
            }
```
`!aligned_box_.checkInBounds(pos_[index_i])` can be expanded as $x<x_{min}\ \mathrm{OR}\ x>x_{max}$, `aligned_box_.checkUpperBound(pos_[index_i], upper_bound_fringe_` can be expanded as $x > x_{max} + \Delta x$. If these two conditions are to be both satisfied, it is equal to $x > x_{max} + \Delta x$. As a result, `!checkInBounds` is not necessary.