### PR TITLE
i move the force criterion into accoustic step limit

### DIFF
--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/fluid_time_step_ck.cpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/fluid_time_step_ck.cpp
@@ -12,10 +12,7 @@ AdvectionTimeStepCK::
     : LocalDynamicsReduce<ReduceMax>(sph_body),
       h_min_(sph_body.getSPHAdaptation().MinimumSmoothingLength()),
       speed_ref_(U_ref), advectionCFL_(advectionCFL),
-      dv_mass_(particles_->getVariableByName<Real>("Mass")),
-      dv_vel_(particles_->getVariableByName<Vecd>("Velocity")),
-      dv_force_(particles_->getVariableByName<Vecd>("Force")),
-      dv_force_prior_(particles_->getVariableByName<Vecd>("ForcePrior"))
+      dv_vel_(particles_->getVariableByName<Vecd>("Velocity"))
 {
     std::cout << sph_body.getName() << ": AdvectionTimeStepCK::speed_ref_ = " << speed_ref_ << std::endl;
 }

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/fluid_time_step_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/fluid_time_step_ck.hpp
@@ -12,9 +12,12 @@ template <class FluidType>
 AcousticTimeStepCK<FluidType>::AcousticTimeStepCK(SPHBody &sph_body, Real acousticCFL)
     : LocalDynamicsReduce<ReduceMax>(sph_body),
       fluid_(DynamicCast<FluidType>(this, particles_->getBaseMaterial())),
+      dv_mass_(particles_->getVariableByName<Real>("Mass")),
       dv_rho_(particles_->getVariableByName<Real>("Density")),
       dv_p_(particles_->getVariableByName<Real>("Pressure")),
       dv_vel_(particles_->getVariableByName<Vecd>("Velocity")),
+      dv_force_(particles_->getVariableByName<Vecd>("Force")),
+      dv_force_prior_(particles_->getVariableByName<Vecd>("ForcePrior")),
       h_min_(sph_body.getSPHAdaptation().MinimumSmoothingLength()),
       acousticCFL_(acousticCFL) {}
 //=================================================================================================//
@@ -36,10 +39,27 @@ template <class ExecutionPolicy>
 AcousticTimeStepCK<FluidType>::ReduceKernel::ReduceKernel(
     const ExecutionPolicy &ex_policy, AcousticTimeStepCK<FluidType> &encloser)
     : eos_(encloser.fluid_),
+      mass_(encloser.dv_mass_->DelegatedData(ex_policy)),
       rho_(encloser.dv_rho_->DelegatedData(ex_policy)),
       p_(encloser.dv_p_->DelegatedData(ex_policy)),
       vel_(encloser.dv_vel_->DelegatedData(ex_policy)),
+      force_(encloser.dv_force_->DelegatedData(ex_policy)),
+      force_prior_(encloser.dv_force_prior_->DelegatedData(ex_policy)),
       h_min_(encloser.h_min_) {}
+//=================================================================================================//
+template <class FluidType>
+Real AcousticTimeStepCK<FluidType>::ReduceKernel::reduce(size_t index_i, Real dt)
+{
+    Real force_norm = (force_[index_i] + force_prior_[index_i]).norm();
+    Real acc_scale = math::sqrt(4.0 * h_min_ * force_norm / mass_[index_i]);
+    return SMAX(eos_.getSoundSpeed(p_[index_i], rho_[index_i]) + vel_[index_i].norm(), acc_scale);
+}
+//=================================================================================================//
+template <class ExecutionPolicy>
+AdvectionTimeStepCK::ReduceKernel::ReduceKernel(
+    const ExecutionPolicy &ex_policy, AdvectionTimeStepCK &encloser)
+    : h_min_(encloser.h_min_),
+      vel_(encloser.dv_vel_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <class ExecutionPolicy>
 AdvectionStepSetup::UpdateKernel::


### PR DESCRIPTION
This pull request refactors the time step calculation logic for fluid dynamics by clarifying and separating the responsibilities of the `AcousticTimeStepCK` and `AdvectionTimeStepCK` classes. The changes ensure that only relevant variables are used in each time step calculation, improving code clarity and maintainability. The most significant updates are the addition of force and mass variables to the acoustic time step, and the removal of unnecessary variables from the advection time step.

**Refactoring of time step calculation kernels:**

* `AcousticTimeStepCK` now explicitly includes mass, force, and force_prior variables for its calculations, and its `ReduceKernel::reduce` method has been updated to use these variables for a more accurate time step estimation. [[1]](diffhunk://#diff-fb995b49d2e9f15358a013f4d1b88da301f66da29be1b20ab29041caaa0a9d5dR15-R20) [[2]](diffhunk://#diff-fb995b49d2e9f15358a013f4d1b88da301f66da29be1b20ab29041caaa0a9d5dR42-R63) [[3]](diffhunk://#diff-f4f1c1f15e0002b59a8ade23a61fdbeba05cfb388cbe28f323de42dbe088dfceL66-R78)
* `AdvectionTimeStepCK` has been simplified to only use velocity for its time step calculation, removing mass, force, and force_prior from both its member variables and its `ReduceKernel`. [[1]](diffhunk://#diff-f29d3cd846cd9ed971a841eca46d4bdb3dae0fc7c5159db21b6f622dee708309L15-R15) [[2]](diffhunk://#diff-f4f1c1f15e0002b59a8ade23a61fdbeba05cfb388cbe28f323de42dbe088dfceL108-R119) [[3]](diffhunk://#diff-fb995b49d2e9f15358a013f4d1b88da301f66da29be1b20ab29041caaa0a9d5dR42-R63)

**API and implementation adjustments:**

* Constructors and member variable lists in both `.h` and `.cpp` files have been updated to reflect the new variable usage, ensuring consistency across the codebase. [[1]](diffhunk://#diff-f29d3cd846cd9ed971a841eca46d4bdb3dae0fc7c5159db21b6f622dee708309L15-R15) [[2]](diffhunk://#diff-f4f1c1f15e0002b59a8ade23a61fdbeba05cfb388cbe28f323de42dbe088dfceL66-R78) [[3]](diffhunk://#diff-f4f1c1f15e0002b59a8ade23a61fdbeba05cfb388cbe28f323de42dbe088dfceL108-R119) [[4]](diffhunk://#diff-fb995b49d2e9f15358a013f4d1b88da301f66da29be1b20ab29041caaa0a9d5dR15-R20)
* The `ReduceKernel` constructors and method signatures have been updated to match the new requirements for each time step kernel. [[1]](diffhunk://#diff-f4f1c1f15e0002b59a8ade23a61fdbeba05cfb388cbe28f323de42dbe088dfceL108-R119) [[2]](diffhunk://#diff-fb995b49d2e9f15358a013f4d1b88da301f66da29be1b20ab29041caaa0a9d5dR42-R63)

These changes streamline the code for each time step calculation, making it clearer which physical quantities are relevant for each kernel and reducing the risk of errors from unused or unnecessary variables.