### PR TITLE
Check f determinant

### DIFF
--- a/src/shared/common/vector_functions.h
+++ b/src/shared/common/vector_functions.h
@@ -213,7 +213,10 @@ inline Matd polarRotation(const Matd &F)
 {
     Eigen::JacobiSVD<Matd> svd(F, Eigen::ComputeFullU | Eigen::ComputeFullV);
     Matd R = svd.matrixU() * svd.matrixV().transpose();
-    assert(R.determinant() > 0.0);
+    if (R.determinant() <= 0.0)
+    {
+        throw std::runtime_error("polarDecomposition failed: det(R) <= 0 from SVD-based polar decomposition.");
+    }
     return R;
 };
 
@@ -223,7 +226,10 @@ inline void polarDecomposition(const Matd &F, Matd &R, Matd &S)
     const Matd &U = svd.matrixU();
     const Matd &V = svd.matrixV();
     R = U * V.transpose();
-    assert(R.determinant() > 0.0);
+    if (R.determinant() <= 0.0)
+    {
+        throw std::runtime_error("polarDecomposition failed: det(R) <= 0 from SVD-based polar decomposition.");
+    }
     S = V * svd.singularValues().asDiagonal() * V.transpose();
 }
 } // namespace SPH

--- a/src/shared/common/vector_functions.h
+++ b/src/shared/common/vector_functions.h
@@ -213,10 +213,6 @@ inline Matd polarRotation(const Matd &F)
 {
     Eigen::JacobiSVD<Matd> svd(F, Eigen::ComputeFullU | Eigen::ComputeFullV);
     Matd R = svd.matrixU() * svd.matrixV().transpose();
-    if (R.determinant() <= 0.0)
-    {
-        throw std::runtime_error("polarDecomposition failed: det(R) <= 0 from SVD-based polar decomposition.");
-    }
     return R;
 };
 
@@ -226,10 +222,6 @@ inline void polarDecomposition(const Matd &F, Matd &R, Matd &S)
     const Matd &U = svd.matrixU();
     const Matd &V = svd.matrixV();
     R = U * V.transpose();
-    if (R.determinant() <= 0.0)
-    {
-        throw std::runtime_error("polarDecomposition failed: det(R) <= 0 from SVD-based polar decomposition.");
-    }
     S = V * svd.singularValues().asDiagonal() * V.transpose();
 }
 } // namespace SPH

--- a/src/shared/particle_dynamics/solid_dynamics/elastic_dynamics.cpp
+++ b/src/shared/particle_dynamics/solid_dynamics/elastic_dynamics.cpp
@@ -1,6 +1,8 @@
 #include "elastic_dynamics.h"
 #include "base_general_dynamics.h"
 
+#include <cmath>
+
 namespace SPH
 {
 //=========================================================================================================//
@@ -66,7 +68,13 @@ BaseElasticIntegration::
       force_(particles_->registerStateVariableData<Vecd>("Force")),
       B_(particles_->getVariableDataByName<Matd>("LinearGradientCorrectionMatrix")),
       F_(particles_->registerStateVariableData<Matd>("DeformationGradient", IdentityMatrix<Matd>::value)),
-      dF_dt_(particles_->registerStateVariableData<Matd>("DeformationRate")) {}
+      dF_dt_(particles_->registerStateVariableData<Matd>("DeformationRate")),
+      deformation_gradient_determinant_check_(inner_relation.getSPHBody()) {}
+//=================================================================================================//
+void BaseElasticIntegration::setupDynamics(Real dt)
+{
+    deformation_gradient_determinant_check_.exec(dt);
+}
 //=================================================================================================//
 BaseIntegration1stHalf::
     BaseIntegration1stHalf(BaseInnerRelation &inner_relation)
@@ -138,7 +146,7 @@ void Integration1stHalfCauchy::initialization(size_t index_i, Real dt)
     rho_[index_i] = rho0_ / J;
     Matd inverse_F_T = F_T.inverse();
     Matd almansi_strain = 0.5 * (Matd::Identity() - (F_[index_i] * F_T).inverse());
-    // obtain the first Piola-Kirchhoff stress from the  Cauchy stress
+    // obtain the first Piola-Kirchhoff stress from the Cauchy stress
     stress_PK1_B_[index_i] = J * elastic_solid_.StressCauchy(almansi_strain, index_i) *
                              inverse_F_T * B_[index_i];
 }
@@ -183,6 +191,46 @@ void Integration1stHalfPK2RightCauchy::initialization(size_t index_i, Real dt)
     // add damping stress
     const Matd numerical_damping_stress = elastic_solid_.NumericalDampingRightCauchy(F_[index_i], dF_dt_[index_i], smoothing_length_ / h_ratio_[index_i], index_i);
     stress_PK1_B_[index_i] += F_[index_i] * 0.5 * numerical_dissipation_factor_ * numerical_damping_stress;
+}
+//=================================================================================================//
+DeformationGradientDeterminantCheck::
+    DeformationGradientDeterminantCheck(SPHBody &sph_body, Real lower_bound)
+    : LocalDynamicsReduce<ReduceOR>(sph_body),
+      F_(particles_->getVariableDataByName<Matd>("DeformationGradient")),
+      lower_bound_(lower_bound)
+{
+    quantity_name_ = "DeformationGradientDeterminantCheck";
+}
+//=================================================================================================//
+bool DeformationGradientDeterminantCheck::reduce(size_t index_i, Real dt)
+{
+    Real determinant = F_[index_i].determinant();
+    return !std::isfinite(determinant) || determinant <= lower_bound_;
+}
+//=================================================================================================//
+bool DeformationGradientDeterminantCheck::outputResult(bool reduced_value)
+{
+    if (!reduced_value)
+    {
+        return false;
+    }
+
+    UnsignedInt total_real_particles = particles_->TotalRealParticles();
+    UnsignedInt first_bad_particle = total_real_particles;
+    UnsignedInt worst_particle = 0;
+    Real first_bad_det = Real(0);
+    Real min_det = MaxReal;
+
+    for (UnsignedInt i = 0; i < total_real_particles; ++i)
+    {
+        Real J = F_[i].determinant();
+        if (!std::isfinite(J) || J <= lower_bound_)
+        {
+            std::cerr << "Deformation gradient determinant check failed at particle " << i 
+                      << " with determinant " << J << std::endl;
+            return true;
+        }
+    }
 }
 //=================================================================================================//
 } // namespace solid_dynamics

--- a/src/shared/particle_dynamics/solid_dynamics/elastic_dynamics.h
+++ b/src/shared/particle_dynamics/solid_dynamics/elastic_dynamics.h
@@ -129,6 +129,25 @@ class DeformationGradientBySummation : public LocalDynamics, public DataDelegate
 };
 
 /**
+ * @class DeformationGradientDeterminantCheck
+ * @brief Check whether deformation gradient determinant remains above a lower bound.
+ * The class is designed as a standalone monitor and can also be used internally.
+ */
+class DeformationGradientDeterminantCheck : public LocalDynamicsReduce<ReduceOR>
+{
+  public:
+    explicit DeformationGradientDeterminantCheck(SPHBody &sph_body, Real lower_bound = 0.0);
+    virtual ~DeformationGradientDeterminantCheck() {};
+
+    bool reduce(size_t index_i, Real dt = 0.0);
+    virtual bool outputResult(bool reduced_value) override;
+
+  protected:
+    Matd *F_;
+    Real lower_bound_;
+};
+
+/**
  * @class BaseElasticIntegration
  * @brief base class for elastic relaxation
  */
@@ -137,11 +156,13 @@ class BaseElasticIntegration : public LocalDynamics, public DataDelegateInner
   public:
     explicit BaseElasticIntegration(BaseInnerRelation &inner_relation);
     virtual ~BaseElasticIntegration() {};
+    virtual void setupDynamics(Real dt = 0.0) override;
 
   protected:
     Real *Vol_;
     Vecd *pos_, *vel_, *force_;
     Matd *B_, *F_, *dF_dt_;
+    ReduceDynamics<DeformationGradientDeterminantCheck> deformation_gradient_determinant_check_;
 };
 
 /**
@@ -350,6 +371,7 @@ class Integration2ndHalf : public BaseElasticIntegration
 
     void update(size_t index_i, Real dt = 0.0);
 };
+
 } // namespace solid_dynamics
 } // namespace SPH
 #endif // ELASTIC_DYNAMICS_H


### PR DESCRIPTION
This PR is a continuation of PR #1034 . In PR #1034 , @Xiangyu-Hu suggested that a separate method class should be added to monitor the physical behavior of a variable rather than if-else check in the computing kernel. I introduced unrelated commit histories by mistake there. In this PR, I implemented this feature with `DeformationGradientDeterminantCheck` in `elastic_dynamics.*`. This class checks whether each particle has a positive & finite determinant of the deformation gradient, and reduce this value with `ReduceOR`. If the reduced value is `false`, nothing will happen; else, a message will be printed on the screen showing which particle has invalid determinant, by `std::cerr`.

This dynamics will be called in `BaseElasticIntegration::setupDynamics` so that the positive definiteness will be checked automatically when elastic dynamics is used.

Also, I removed the assertions in `polarRotation/Decomposition` since they are invalid in the release mode, and the positive definteness has been ensured in `BaseElasticIntegration::setupDynamics`.

Hope this will be satisfactory.