### PR TITLE
Fix typos of filenames and comments, improve naming

### DIFF
--- a/src/for_2D_build/meshes/sparse_mesh/sparse_mesh_field.hpp
+++ b/src/for_2D_build/meshes/sparse_mesh/sparse_mesh_field.hpp
@@ -1,7 +1,7 @@
 #ifndef SPARSE_MESH_FIELD_2D_HPP
 #define SPARSE_MESH_FIELD_2D_HPP
 
-#include "spares_mesh_field.hxx"
+#include "sparse_mesh_field.hxx"
 
 namespace SPH
 {

--- a/src/for_2D_build/particle_generator/all_particle_generators.h
+++ b/src/for_2D_build/particle_generator/all_particle_generators.h
@@ -21,7 +21,7 @@
  *                                                                           *
  * ------------------------------------------------------------------------- */
 /**
- * @file 	all_particle_generator.h
+ * @file 	all_particle_generators.h
  * @brief 	Head file for all particle generator.
  * @author	Chi Zhang and Xiangyu Hu
  */

--- a/src/for_3D_build/meshes/cell_linked_list_3d.cpp
+++ b/src/for_3D_build/meshes/cell_linked_list_3d.cpp
@@ -1,5 +1,5 @@
 /**
- * @file 	cell_linked_list_supplementary.cpp
+ * @file 	cell_linked_list_3d.cpp
  * @author	Luhui Han, Chi Zhang and Xiangyu Hu
  */
 

--- a/src/for_3D_build/meshes/sparse_mesh/sparse_mesh_field.hpp
+++ b/src/for_3D_build/meshes/sparse_mesh/sparse_mesh_field.hpp
@@ -1,7 +1,7 @@
 #ifndef SPARSE_MESH_FIELD_3D_HPP
 #define SPARSE_MESH_FIELD_3D_HPP
 
-#include "spares_mesh_field.hxx"
+#include "sparse_mesh_field.hxx"
 
 #include "block_cluster_3d.h"
 

--- a/src/for_3D_build/particle_dynamics/solid_dynamics/slender_structure_math.h
+++ b/src/for_3D_build/particle_dynamics/solid_dynamics/slender_structure_math.h
@@ -21,7 +21,7 @@
  *                                                                           *
  * ------------------------------------------------------------------------- */
 /**
- * @file 	slender_structure_dynamics.h
+ * @file 	slender_structure_math.h
  * @brief 	Here, we define the math operation for slender structure dynamics.
  * @details We consider here a weakly compressible solids.
  * @author	Dong Wu, Chi Zhang and Xiangyu Hu

--- a/src/for_3D_build/particle_generator/all_particle_generators.h
+++ b/src/for_3D_build/particle_generator/all_particle_generators.h
@@ -21,7 +21,7 @@
  *                                                                           *
  * ------------------------------------------------------------------------- */
 /**
- * @file 	all_particle_generator.h
+ * @file 	all_particle_generators.h
  * @brief 	Head file for all particle generator.
  * @author	Chi Zhang and Xiangyu Hu
  */

--- a/src/shared/mesh_dynamics/base_local_mesh_dynamics.h
+++ b/src/shared/mesh_dynamics/base_local_mesh_dynamics.h
@@ -31,7 +31,7 @@
 
 #include "base_dynamics.h"
 #include "base_implementation.h"
-#include "spares_mesh_field.hpp"
+#include "sparse_mesh_field.hpp"
 
 namespace SPH
 {

--- a/src/shared/mesh_dynamics/mesh_dynamics_algorithm.h
+++ b/src/shared/mesh_dynamics/mesh_dynamics_algorithm.h
@@ -34,7 +34,7 @@
 #include "base_local_mesh_dynamics.h"
 #include "implementation.h"
 #include "mesh_iterators.hpp"
-#include "spares_mesh_field.h"
+#include "sparse_mesh_field.h"
 
 namespace SPH
 {

--- a/src/shared/meshes/sparse_mesh/sparse_mesh_field.h
+++ b/src/shared/meshes/sparse_mesh/sparse_mesh_field.h
@@ -21,7 +21,7 @@
  *                                                                           *
  * ------------------------------------------------------------------------- */
 /**
- * @file    spares_mesh_field.h
+ * @file    sparse_mesh_field.h
  * @brief   This class is designed to save memory and increase computational efficiency on mesh.
  * @author  Chi Zhang and Xiangyu Hu
  */

--- a/src/shared/meshes/sparse_mesh/sparse_mesh_field.hxx
+++ b/src/shared/meshes/sparse_mesh/sparse_mesh_field.hxx
@@ -1,7 +1,7 @@
 #ifndef SPARSE_MESH_FIELD_HXX
 #define SPARSE_MESH_FIELD_HXX
 
-#include "spares_mesh_field.h"
+#include "sparse_mesh_field.h"
 
 namespace SPH
 {

--- a/src/shared/particle_dynamics/general_dynamics/general_reduce.h
+++ b/src/shared/particle_dynamics/general_dynamics/general_reduce.h
@@ -38,12 +38,12 @@ namespace SPH
  * @class VariableNorm
  * @brief  obtains the norm of a variable for reduce
  */
-template <typename DataType, typename NormType, class DynamicsIdentifier = SPHBody>
-class VariableNorm : public BaseLocalDynamicsReduce<NormType, DynamicsIdentifier>
+template <typename DataType, typename Operation, class DynamicsIdentifier = SPHBody>
+class VariableNorm : public BaseLocalDynamicsReduce<Operation, DynamicsIdentifier>
 {
   public:
     VariableNorm(DynamicsIdentifier &identifier, const std::string &variable_name)
-        : BaseLocalDynamicsReduce<NormType, DynamicsIdentifier>(identifier),
+        : BaseLocalDynamicsReduce<Operation, DynamicsIdentifier>(identifier),
           variable_(this->particles_->template getVariableDataByName<DataType>(variable_name)) {};
     virtual ~VariableNorm() {};
     virtual Real outputResult(Real reduced_value) override { return std::sqrt(reduced_value); }

--- a/src/shared/particle_dynamics/general_dynamics/general_reduce.h
+++ b/src/shared/particle_dynamics/general_dynamics/general_reduce.h
@@ -36,7 +36,7 @@ namespace SPH
 {
 /**
  * @class VariableNorm
- * @brief  obtained the maximum norm of a variable
+ * @brief  obtains the norm of a variable for reduce
  */
 template <typename DataType, typename NormType, class DynamicsIdentifier = SPHBody>
 class VariableNorm : public BaseLocalDynamicsReduce<NormType, DynamicsIdentifier>

--- a/src/shared/physical_closure/materials/riemann_solver.h
+++ b/src/shared/physical_closure/materials/riemann_solver.h
@@ -21,7 +21,7 @@
  *                                                                           *
  * ------------------------------------------------------------------------- */
 /**
- * @file 	riemann_solvers.h
+ * @file 	riemann_solver.h
  * @brief 	This is the collection of Riemann solvers.
  * @author	Chi Zhang and Xiangyu Hu
  */

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/geometric_dynamics.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/geometric_dynamics.h
@@ -39,7 +39,7 @@ class HostKernel
     template <class ExecutionPolicy, class EncloserType>
     HostKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
     {
-        // not implemented for device policy due to virtual function call in inital_shape_,
+        // not implemented for device policy due to virtual function call in initial_shape_,
         // which is not allowed in device code
         static_assert(!std::is_base_of<execution::DeviceExecution<>, ExecutionPolicy>::value,
                       "This compute kernel is not designed for execution on device!");

--- a/src/shared/shared_ck/particle_dynamics/particle_functors_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/particle_functors_ck.h
@@ -22,7 +22,7 @@
  * ------------------------------------------------------------------------- */
 
 /**
- * @file    particle_functors.h
+ * @file    particle_functors_ck.h
  * @brief 	TBD.
  * @author	Xiangyu Hu
  */

--- a/tests/extra_source_and_tests/2d_examples/test_2d_T_pipe_VIPO_shell/T_pipe_VIPO_shell.cpp
+++ b/tests/extra_source_and_tests/2d_examples/test_2d_T_pipe_VIPO_shell/T_pipe_VIPO_shell.cpp
@@ -6,8 +6,8 @@
  */
 
 #include "bidirectional_buffer.h"
-#include "density_correciton.h"
-#include "density_correciton.hpp"
+#include "density_correction.h"
+#include "density_correction.hpp"
 #include "kernel_summation.h"
 #include "kernel_summation.hpp"
 #include "pressure_boundary.h"

--- a/tests/extra_source_and_tests/2d_examples/test_2d_channel_windkessel_rigid_shell/channel_windkessel_rigid_shell.cpp
+++ b/tests/extra_source_and_tests/2d_examples/test_2d_channel_windkessel_rigid_shell/channel_windkessel_rigid_shell.cpp
@@ -6,8 +6,8 @@
  */
 #include "sphinxsys.h"
 #include "bidirectional_buffer.h"
-#include "density_correciton.h"
-#include "density_correciton.hpp"
+#include "density_correction.h"
+#include "density_correction.hpp"
 #include "kernel_summation.h"
 #include "kernel_summation.hpp"
 #include "pressure_boundary.h"

--- a/tests/extra_source_and_tests/2d_examples/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/2d_examples/test_2d_mixed_poiseuille_flow/mixed_poiseuille_flow.cpp
@@ -5,8 +5,8 @@
  * @author 	Shuoguo Zhang and Xiangyu Hu
  */
 #include "bidirectional_buffer.h"
-#include "density_correciton.h"
-#include "density_correciton.hpp"
+#include "density_correction.h"
+#include "density_correction.hpp"
 #include "kernel_summation.h"
 #include "kernel_summation.hpp"
 #include "pressure_boundary.h"

--- a/tests/extra_source_and_tests/2d_examples/test_2d_modified_T_flow/modified_T_flow.cpp
+++ b/tests/extra_source_and_tests/2d_examples/test_2d_modified_T_flow/modified_T_flow.cpp
@@ -6,8 +6,8 @@
  */
 
 #include "bidirectional_buffer.h"
-#include "density_correciton.h"
-#include "density_correciton.hpp"
+#include "density_correction.h"
+#include "density_correction.hpp"
 #include "kernel_summation.h"
 #include "kernel_summation.hpp"
 #include "pressure_boundary.h"

--- a/tests/extra_source_and_tests/2d_examples/test_2d_pulsatile_poiseuille_flow/pulsatile_poiseuille_flow.cpp
+++ b/tests/extra_source_and_tests/2d_examples/test_2d_pulsatile_poiseuille_flow/pulsatile_poiseuille_flow.cpp
@@ -8,8 +8,8 @@
  * @brief 	SPHinXsys Library.
  */
 #include "bidirectional_buffer.h"
-#include "density_correciton.h"
-#include "density_correciton.hpp"
+#include "density_correction.h"
+#include "density_correction.hpp"
 #include "kernel_summation.h"
 #include "kernel_summation.hpp"
 #include "pressure_boundary.h"

--- a/tests/extra_source_and_tests/2d_examples/test_2d_turbulent_channel/test_2d_turbulent_channel.h
+++ b/tests/extra_source_and_tests/2d_examples/test_2d_turbulent_channel/test_2d_turbulent_channel.h
@@ -6,8 +6,8 @@
  */
 
 #include "bidirectional_buffer.h"
-#include "density_correciton.h"
-#include "density_correciton.hpp"
+#include "density_correction.h"
+#include "density_correction.hpp"
 #include "k-epsilon_turbulent_model.cpp"
 #include "kernel_summation.h"
 #include "kernel_summation.hpp"

--- a/tests/extra_source_and_tests/2d_examples/test_2d_vessel_stenosis_womersley/test_2d_vessel_stenosis_womersley.cpp
+++ b/tests/extra_source_and_tests/2d_examples/test_2d_vessel_stenosis_womersley/test_2d_vessel_stenosis_womersley.cpp
@@ -5,8 +5,8 @@
  * @author 	Minhui Zhou, Dong Wu
  */
 #include "bidirectional_buffer.h"
-#include "density_correciton.h"
-#include "density_correciton.hpp"
+#include "density_correction.h"
+#include "density_correction.hpp"
 #include "kernel_summation.h"
 #include "kernel_summation.hpp"
 #include "pressure_boundary.h"

--- a/tests/extra_source_and_tests/extra_src/shared/extended_eulerian_riemann_solver.h
+++ b/tests/extra_source_and_tests/extra_src/shared/extended_eulerian_riemann_solver.h
@@ -21,9 +21,9 @@
  *                                                                           *
  * ------------------------------------------------------------------------- */
 /**
- * @file extended_eulerian_riemann_solvers.h
- * @brief This file make changes to the eulerian_riemann_solver.h in order to
-    accomodate the turbulence variables in riemann solver .
+ * @file extended_eulerian_riemann_solver.h
+ * @brief This file makes changes to the eulerian_riemann_solver.h in order to
+    accommodate the turbulence variables in riemann solver.
  */
 
 #ifndef EXTENDED_EULERIAN_RIEMANN_SOLVER_H

--- a/tests/extra_source_and_tests/extra_src/shared/particle_momentum_dissipation.h
+++ b/tests/extra_source_and_tests/extra_src/shared/particle_momentum_dissipation.h
@@ -21,11 +21,11 @@
  *                                                                           *
  * ------------------------------------------------------------------------- */
 /**
- * @file 	particle_dynamics_dissipation.h
+ * @file 	particle_momentum_dissipation.h
  * @brief 	Here are the classes for damping the magnitude of
  * 			any variables.
- * 			Note that, currently, these classes works only in single resolution.
- * @author	Chi ZHang and Xiangyu Hu
+ * 			Note that, currently, these classes work only in single resolution.
+ * @author	Chi Zhang and Xiangyu Hu
  */
 
 #ifndef PARTICLE_MOMENTUM_DISSIPATION_H

--- a/tests/extra_source_and_tests/extra_src/shared/porous_media_dynamics.h
+++ b/tests/extra_source_and_tests/extra_src/shared/porous_media_dynamics.h
@@ -21,10 +21,10 @@
  *                                                                           *
  * ------------------------------------------------------------------------- */
 /**
- * @file 	POROUS_ELASTIC_DYNAMICS_H.h
- * @brief 	Here, we define the algorithm classes for elastic solid dynamics.
+ * @file 	porous_media_dynamics.h
+ * @brief 	Here, we define the algorithm classes for porous media dynamics.
  * @details 	We consider here a weakly compressible solids.
- * @author	Chi ZHang and Xiangyu Hu
+ * @author	Chi Zhang and Xiangyu Hu
  */
 
 #ifndef POROUS_ELASTIC_DYNAMICS_H

--- a/tests/extra_source_and_tests/extra_src/shared/porous_media_solid.h
+++ b/tests/extra_source_and_tests/extra_src/shared/porous_media_solid.h
@@ -22,11 +22,11 @@
  * ------------------------------------------------------------------------- */
 /**
  * @file 	porous_media_solid.h
- * @brief 	These are classes for define properties of elastic solid materials.
+ * @brief 	These are classes for defining properties of elastic solid materials.
  *			These classes are based on isotropic linear elastic solid.
  * 			Several more complex materials, including neo-Hookean, FENE neo-Hookean
  *			and anisotropic muscle, are derived from the basic elastic solid class.
- * @author	Chi ZHang and Xiangyu Hu
+ * @author	Chi Zhang and Xiangyu Hu
  */
 
 #ifndef POROUS_SOLID_H

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/bidirectional_buffer.h
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/bidirectional_buffer.h
@@ -22,7 +22,7 @@
  * ------------------------------------------------------------------------- */
 /**
  * @file 	bidirectional_buffer.h
- * @brief 	Here, we define the algorithm classes for bidirectiontal buffer.
+ * @brief 	Here, we define the algorithm classes for bidirectional buffer.
  * @details The buffer particle index is periodically updated at each time step.
             The bidirectional buffer can serve for unidirectional, bidirectional and mixed flows.
  * @author	Shuoguo Zhang and Xiangyu Hu

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/density_correction.cpp
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/density_correction.cpp
@@ -1,4 +1,4 @@
-#include "density_correciton.hpp"
+#include "density_correction.hpp"
 
 namespace SPH
 {

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/density_correction.h
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/density_correction.h
@@ -113,4 +113,4 @@ using DensitySummationPressureComplex = BaseDensitySummationPressureComplex<Inne
 
 } // namespace fluid_dynamics
 } // namespace SPH
-#endif // DENSITY_SUMMATION_INNER_H
+#endif // DENSITY_CORRECTION_H

--- a/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/density_correction.hpp
+++ b/tests/extra_source_and_tests/extra_src/shared/pressure_boundary/density_correction.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "density_correciton.h"
+#include "density_correction.h"
 
 namespace SPH
 {


### PR DESCRIPTION
This pull request primarily addresses a series of naming corrections and file renames throughout the codebase to improve consistency and clarity. The changes focus on fixing typos in file names and include statements, as well as updating documentation comments to match the corrected file names. Additionally, minor improvements to comments and documentation are included.

# File and Include Name Corrections

* Renamed files and updated include statements from `spares_mesh_field` to `sparse_mesh_field` across both 2D and 3D mesh directories, including `.h`, `.hpp`, and `.hxx` variants.
* Corrected include and file names from `density_correciton` to `density_correction` in multiple test files.

# Documentation and Comment Updates

* Updated file documentation comments to match corrected file names, such as changing `all_particle_generator.h` to `all_particle_generators.h` and `riemann_solvers.h` to `riemann_solver.h`.
* Fixed comment typo in `HostKernel` constructor from `inital_shape_` to `initial_shape_`.
* Improved the description in the `VariableNorm` class comment for clarity.
* Corrected file name and documentation for slender structure dynamics math operations.
* Updated file name and documentation for 3D cell linked list implementation.

# Better naming

* In the `VariableNorm` class, the template parameter `NormType` actually means `Operation` (sum/max/min/AND/OR/...). The original name is unsuitable, I suggest using `Operation`, consistent with `BaseLocalDynamicsReduce`.

These changes collectively enhance code readability and maintainability by ensuring accurate naming and documentation throughout the project.