### PR TITLE
add VS Code section

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,135 +1,165 @@
 {
-    "version": 8,
-    "configurePresets": [
-        {
-            "name": "Windows ck release",
-            "displayName": "Windows ck Release",
-            "description": "Sets Ninja generator, build and install directory",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            },
-            "cacheVariables": {
-                "CMAKE_MAKE_PROGRAM": "ninja",
-                "CMAKE_BUILD_TYPE": "Release",
-                "CMAKE_C_COMPILER": "cl",
-                "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_TOOLCHAIN_FILE": "'${sourceDir}/../vcpkg/scripts/buildsystems/vcpkg.cmake'",
-                "CMAKE_C_COMPILER_LAUNCHER": "ccache",
-                "CMAKE_CXX_COMPILER_LAUNCHER": "ccache"
-            }
-        },
-        {
-            "name": "Windows sycl_cpu release",
-            "displayName": "Windows sycl_cpu Release",
-            "description": "Sets Ninja generator, build and install directory",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            },
-            "cacheVariables": {
-                "CMAKE_MAKE_PROGRAM": "ninja",
-                "CMAKE_BUILD_TYPE": "Release",
-                "CMAKE_C_COMPILER": "icx-cl",
-                "CMAKE_CXX_COMPILER": "icx-cl",
-                "CMAKE_TOOLCHAIN_FILE": "'${sourceDir}/../vcpkg/scripts/buildsystems/vcpkg.cmake'",
-                "CMAKE_C_COMPILER_LAUNCHER": "ccache",
-                "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
-                "SPHINXSYS_USE_SYCL": "ON",
-                "SPHINXSYS_2D": "OFF",
-                "SPHINXSYS_BUILD_2D_EXAMPLES": "OFF",
-                "SPHINXSYS_BUILD_OPTIMIZATION_EXAMPLES": "OFF",
-                "SPHINXSYS_BUILD_PYTHON_INTERFACE": "OFF"
-            }
-        },
-        {
-            "name": "Linux sycl_cpu release",
-            "displayName": "Linux sycl_cpu Release",
-            "description": "Sets Ninja generator, build and install directory",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            },
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release",
-                "CMAKE_C_COMPILER": "icx",
-                "CMAKE_CXX_COMPILER": "icpx",
-                "SPHINXSYS_USE_SYCL": "ON",
-                "CMAKE_TOOLCHAIN_FILE": "'${sourceDir}/../vcpkg/scripts/buildsystems/vcpkg.cmake'",
-                "CMAKE_C_COMPILER_LAUNCHER": "ccache",
-                "CMAKE_CXX_COMPILER_LAUNCHER": "ccache"
-            }
-        },
-        {
-            "name": "Linux sycl_gpu release",
-            "displayName": "Linux sycl_gpu Release",
-            "description": "Sets Ninja generator, build and install directory",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            },
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release",
-                "CMAKE_C_COMPILER": "icx",
-                "CMAKE_CXX_COMPILER": "icpx",
-                "SPHINXSYS_USE_SYCL": "ON",
-                "CMAKE_TOOLCHAIN_FILE": "'${sourceDir}/../vcpkg/scripts/buildsystems/vcpkg.cmake'",
-                "CMAKE_C_COMPILER_LAUNCHER": "ccache",
-                "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
-                "SPHINXSYS_SYCL_TARGETS": "nvptx64-nvidia-cuda"
-            }
-        },
-        {
-            "name": "Linux GNU debug",
-            "displayName": "SPHinXsys GNU Debug",
-            "description": "Sets Ninja generator, build and install directory",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            },
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug",
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++",
-                "CMAKE_TOOLCHAIN_FILE": "'${sourceDir}/../vcpkg/scripts/buildsystems/vcpkg.cmake'",
-                "CMAKE_C_COMPILER_LAUNCHER": "ccache",
-                "CMAKE_CXX_COMPILER_LAUNCHER": "ccache"
-            }
-        },
-        {
-            "name": "Linux GNU Release",
-            "displayName": "SPHinXsys GNU Release",
-            "description": "Sets Ninja generator, build and install directory",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Linux"
-            },
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release",
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++",
-                "CMAKE_TOOLCHAIN_FILE": "'${sourceDir}/../vcpkg/scripts/buildsystems/vcpkg.cmake'",
-                "CMAKE_C_COMPILER_LAUNCHER": "ccache",
-                "CMAKE_CXX_COMPILER_LAUNCHER": "ccache"
-            }
-        }
-    ]
+  "version": 8,
+  "configurePresets": [
+    {
+      "name": "Windows ck release",
+      "displayName": "Windows ck Release",
+      "description": "Sets Ninja generator, build and install directory",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "cacheVariables": {
+        "CMAKE_MAKE_PROGRAM": "ninja",
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_COMPILER": "cl",
+        "CMAKE_CXX_COMPILER": "cl",
+        "CMAKE_TOOLCHAIN_FILE": "'${sourceDir}/../vcpkg/scripts/buildsystems/vcpkg.cmake'",
+        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache"
+      }
+    },
+    {
+      "name": "Windows sycl_cpu release",
+      "displayName": "Windows sycl_cpu Release",
+      "description": "Sets Ninja generator, build and install directory",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "cacheVariables": {
+        "CMAKE_MAKE_PROGRAM": "ninja",
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_COMPILER": "icx-cl",
+        "CMAKE_CXX_COMPILER": "icx-cl",
+        "CMAKE_TOOLCHAIN_FILE": "'${sourceDir}/../vcpkg/scripts/buildsystems/vcpkg.cmake'",
+        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
+        "SPHINXSYS_USE_SYCL": "ON",
+        "SPHINXSYS_2D": "OFF",
+        "SPHINXSYS_BUILD_2D_EXAMPLES": "OFF",
+        "SPHINXSYS_BUILD_OPTIMIZATION_EXAMPLES": "OFF",
+        "SPHINXSYS_BUILD_PYTHON_INTERFACE": "OFF"
+      }
+    },
+    {
+      "name": "Linux sycl_cpu release",
+      "displayName": "Linux sycl_cpu Release",
+      "description": "Sets Ninja generator, build and install directory",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_COMPILER": "icx",
+        "CMAKE_CXX_COMPILER": "icpx",
+        "SPHINXSYS_USE_SYCL": "ON",
+        "CMAKE_TOOLCHAIN_FILE": "'${sourceDir}/../vcpkg/scripts/buildsystems/vcpkg.cmake'",
+        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache"
+      }
+    },
+    {
+      "name": "Linux sycl_gpu release",
+      "displayName": "Linux sycl_gpu Release",
+      "description": "Sets Ninja generator, build and install directory",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_COMPILER": "icx",
+        "CMAKE_CXX_COMPILER": "icpx",
+        "SPHINXSYS_USE_SYCL": "ON",
+        "CMAKE_TOOLCHAIN_FILE": "'${sourceDir}/../vcpkg/scripts/buildsystems/vcpkg.cmake'",
+        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
+        "SPHINXSYS_SYCL_TARGETS": "nvptx64-nvidia-cuda"
+      }
+    },
+    {
+      "name": "Linux GNU debug",
+      "displayName": "SPHinXsys GNU Debug",
+      "description": "Sets Ninja generator, build and install directory",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++",
+        "CMAKE_TOOLCHAIN_FILE": "'${sourceDir}/../vcpkg/scripts/buildsystems/vcpkg.cmake'",
+        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache"
+      }
+    },
+    {
+      "name": "Linux GNU Release",
+      "displayName": "SPHinXsys GNU Release",
+      "description": "Sets Ninja generator, build and install directory",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_COMPILER": "gcc",
+        "CMAKE_CXX_COMPILER": "g++",
+        "CMAKE_TOOLCHAIN_FILE": "'${sourceDir}/../vcpkg/scripts/buildsystems/vcpkg.cmake'",
+        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache"
+      }
+    },
+    {
+      "name": "Multi-platform Clang Release",
+      "displayName": "Multi-platform SPHinXsys Clang Release",
+      "description": "Sets Ninja generator, build and install directory",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_TOOLCHAIN_FILE": "'${sourceDir}/../vcpkg/scripts/buildsystems/vcpkg.cmake'",
+        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache"
+      }
+    },
+    {
+      "name": "Multi-platform Clang Debug",
+      "displayName": "Multi-platform SPHinXsys Clang Debug",
+      "description": "Sets Ninja generator, build and install directory",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_TOOLCHAIN_FILE": "'${sourceDir}/../vcpkg/scripts/buildsystems/vcpkg.cmake'",
+        "CMAKE_C_COMPILER_LAUNCHER": "ccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "ccache"
+      }
+    }
+  ]
 }

--- a/tutorials/sphinx/installation.rst
+++ b/tutorials/sphinx/installation.rst
@@ -287,7 +287,7 @@ Pre-requisites
 * Windows 7 or newer
 * `Git <https://git-scm.com/download/win>`_
 * `Visual Studio 2017 or newer <https://visualstudio.microsoft.com/vs/community/>`_ with C++ environment installed
-* `CMake <https://cmake.org/>`_
+* `CMake <https://cmake.org/>`_ version 3.16 or later but before 4.0
 * `Python3 <https://www.python.org/>`_
 
 Installing dependencies
@@ -382,6 +382,12 @@ Installing on macOS (latest)
 The procedure is given for MAC OS 13.0.1  and clang 14.0.0 (clang-1400.0.29.202).
 With the assumption that you have installed Command Line Tools and python3. 
 
+Pre-requisites
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+* `CMake <https://cmake.org/>`_ version 3.16 or later but before 4.0
+* `Python3 <https://www.python.org/>`_
+
 Installing dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -393,7 +399,6 @@ Note that gfortran is essential for lapack_reference, which is needed for simbod
 
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         brew update 
-        brew install cmake
         brew install pkg-config
         brew install ccache
         brew install gfortran
@@ -444,3 +449,40 @@ Running the tests and examples
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 They are the same as in Ubuntu Linux (See above).  
+
+
+Using VS Code as the development environment
+----------------------------------------------
+
+If you are using VS Code as your development platform, 
+please make sure the CMake Tool plugin is installed 
+and the corresponding icon shown in the GUI.
+You may also need to install the C++ extension for better code editing experience.
+
+SPHinXsys provides CMake presets for both Linux and Windows platforms, 
+which can be used directly in VS Code. For macOS, you may use the clang presets. 
+To do so, you can open the Command Palette (Ctrl+Shift+P) and select "CMake: Select a Configure Preset". 
+Then, you can choose the preset that matches your platform and build configuration.
+
+To use the presets, you ensure the SPHinXsys repository is opened (using open folder) in VS Code.
+Please also make sure that vcpkg is installed in another folder parallel to SPHinXsys, 
+and the CMAKE_TOOLCHAIN_FILE variable is set correctly in the presets.
+
+When CMake icon is clicked, you can see the build and debug options.
+In Configuration option, you can choose Debug or Release presets by click the modification icon.
+In Build option, you can choose build the entire library or just a specific test case, such as test_2d_dambreak.
+After option is chosen, the building process will begin if you click
+the building icon beside target name, or the building icon at the VS Code status bar, 
+which is at bottom of the frame.
+
+SPHinXsys requires quite some memory and time to build, especially for the first time.
+So, it is recommended to build the library in Release mode and only build the test cases you
+are interested in. Also, please make sure that you are not using the full number of cores for building,
+otherwise, the building process may fail due to out of memory. 
+You can set the number of parallel compilation processes by changing the "parallel Jobs" 
+variable in the presets, or modify the VS Code settings on CMake parallel jobs.
+
+
+
+
+


### PR DESCRIPTION
This pull request updates the build configuration and documentation to improve multi-platform support and clarify installation steps, especially for users on macOS and those using Visual Studio Code (VS Code) as their development environment.

**Build configuration improvements:**

* Added new CMake presets for multi-platform Clang builds (both Release and Debug) to `CMakePresets.json`, enabling easier setup for macOS and other Clang-based environments.

**Documentation updates:**

* Specified required CMake version (3.16 or later, but before 4.0) in the prerequisites for both general and macOS installation instructions in `tutorials/sphinx/installation.rst`. [[1]](diffhunk://#diff-d770b08b9090a5badc971a265bb82ce7b76f8c97a6f2eb600a3c3e9199840bb2L290-R290) [[2]](diffhunk://#diff-d770b08b9090a5badc971a265bb82ce7b76f8c97a6f2eb600a3c3e9199840bb2R385-R390)
* Added a dedicated section with step-by-step guidance on using VS Code as the development environment, including instructions for selecting CMake presets, installing necessary extensions, and optimizing build performance.
* Removed redundant `brew install cmake` instruction for macOS, since CMake is now covered in the prerequisites.