### PR TITLE
to CI test

### DIFF
--- a/src/for_3D_build/particles/linear_particles.cpp
+++ b/src/for_3D_build/particles/linear_particles.cpp
@@ -12,8 +12,8 @@ void LinearParticles::registerLineProperties(StdVec<Vecd> &b_n, StdVec<Real> &wi
 {
     b_n_ = registerStateVariableDataFrom<Vecd>("BinormalDirection", b_n);
     width_ = registerStateVariableDataFrom<Real>("Width", width);
-    addEvolvingVariable<Vecd>("BinormalDirection");
-    addEvolvingVariable<Real>("Width");
+    addVariableToReload<Vecd>("BinormalDirection");
+    addVariableToReload<Real>("Width");
     addVariableToWrite<Vecd>("BinormalDirection");
 }
 //=================================================================================================//

--- a/src/shared/io_system/io_base.cpp
+++ b/src/shared/io_system/io_base.cpp
@@ -94,7 +94,8 @@ void RestartIO::writeToFile(size_t iteration_step)
         restart_xml.setAttributeToElement(body_element, "name", body_name);
 
         // Write particles to this body element
-        base_particles.writeParticlesToXmlForRestart(restart_xml, body_element);
+        base_particles.writeParticlesToXml(
+            base_particles.EvolvingVariables(), restart_xml, body_element);
     }
 
     // Write the consolidated XML file
@@ -158,7 +159,8 @@ void RestartIO::readFromFile(size_t restart_step)
             if (name_attr != nullptr && std::string(name_attr) == body_name)
             {
                 found = true;
-                base_particles.readParticlesFromXmlForRestart(restart_xml, body_element);
+                base_particles.readParticlesFromXml(
+                    base_particles.EvolvingVariables(), restart_xml, body_element);
                 std::cout << "\n Total real particles of body " << body_name
                           << " read from restart: " << base_particles.TotalRealParticles() << "\n";
                 break;
@@ -214,7 +216,8 @@ void ReloadParticleIO::writeToFile(size_t iteration_step)
         tinyxml2::XMLElement *body_element = reload_xml.first_element_->LastChildElement("body");
         reload_xml.setAttributeToElement(body_element, "name", body_name);
 
-        base_particles.writeParticlesToXmlForRestart(reload_xml, body_element);
+        base_particles.writeParticlesToXml(
+            base_particles.VariablesToReload(), reload_xml, body_element);
     }
 
     reload_xml.writeToXmlFile(overall_file_path_);

--- a/src/shared/io_system/io_base.hpp
+++ b/src/shared/io_system/io_base.hpp
@@ -52,7 +52,7 @@ void ReloadParticleIO::addToReload(SPHBody &sph_body, const std::string &name)
 {
     if (isBodyIncluded(bodies_, &sph_body))
     {
-        sph_body.getBaseParticles().addEvolvingVariable<DataType>(name);
+        sph_body.getBaseParticles().addVariableToReload<DataType>(name);
     }
     else
     {

--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -33,7 +33,6 @@ std::string BaseParticles::getBodyName()
 void BaseParticles::initializeBasicDiscreteVariables()
 {
     addEvolvingVariable<Vecd>("Position");
-    addEvolvingVariable<Real>("VolumetricMeasure");
     addVariableToReload<Vecd>("Position");
     addVariableToReload<Real>("VolumetricMeasure");
     //----------------------------------------------------------------------

--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -34,6 +34,8 @@ void BaseParticles::initializeBasicDiscreteVariables()
 {
     addEvolvingVariable<Vecd>("Position");
     addEvolvingVariable<Real>("VolumetricMeasure");
+    addVariableToReload<Vecd>("Position");
+    addVariableToReload<Real>("VolumetricMeasure");
     //----------------------------------------------------------------------
     //		register non-geometric variables
     //----------------------------------------------------------------------
@@ -176,7 +178,8 @@ void BaseParticles::readReloadXmlFile(const std::string &filefullpath, const std
     exit(1);
 }
 //=================================================================================================//
-void BaseParticles::writeParticlesToXmlForRestart(XmlParser &xml_parser, TinyXMLElement *body_element)
+void BaseParticles::writeParticlesToXml(
+    DiscreteVariables &variables, XmlParser &xml_parser, TinyXMLElement *body_element)
 {
     // Resize the body element to have the correct number of particle children
     UnsignedInt total_real_particles = TotalRealParticles();
@@ -190,10 +193,11 @@ void BaseParticles::writeParticlesToXmlForRestart(XmlParser &xml_parser, TinyXML
     // Write all evolving variables to the body element's particle children
     OperationOnDataAssemble<DiscreteVariables, WriteParticleVariableToXmlElement>
         write_variable_to_element(body_element);
-    write_variable_to_element(evolving_variables_, xml_parser);
+    write_variable_to_element(variables, xml_parser);
 }
 //=================================================================================================//
-void BaseParticles::readParticlesFromXmlForRestart(XmlParser &xml_parser, TinyXMLElement *body_element)
+void BaseParticles::readParticlesFromXml(
+    DiscreteVariables &variables, XmlParser &xml_parser, TinyXMLElement *body_element)
 {
     // Reset total real particles from the body element's particle count
     sv_total_real_particles_->setValue(xml_parser.Size(body_element));
@@ -201,7 +205,7 @@ void BaseParticles::readParticlesFromXmlForRestart(XmlParser &xml_parser, TinyXM
     // Read all evolving variables from the body element's particle children
     OperationOnDataAssemble<DiscreteVariables, ReadParticleVariableFromXmlElement>
         read_variable_from_element(body_element);
-    read_variable_from_element(evolving_variables_, this, xml_parser);
+    read_variable_from_element(variables, this, xml_parser);
 }
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -148,6 +148,8 @@ class BaseParticles
 
     template <typename DataType, typename... Args>
     void addVariableToWrite(Args &&...args);
+    template <typename DataType, typename... Args>
+    void addVariableToReload(Args &&...args);
     //----------------------------------------------------------------------
     // Particle data for sorting
     //----------------------------------------------------------------------
@@ -160,14 +162,15 @@ class BaseParticles
     template <typename DataType, typename... Args>
     void addEvolvingVariable(Args &&...args);
     DiscreteVariables &VariablesToWrite() { return variables_to_write_; };
+    DiscreteVariables &VariablesToReload() { return variables_to_reload_; };
     DiscreteVariables &EvolvingVariables() { return evolving_variables_; };
     //----------------------------------------------------------------------
     // Particle data ouput functions
     //----------------------------------------------------------------------
     void resizeXmlDocForParticles(XmlParser &xml_parser);
     void resetTotalRealParticlesFromXmlDoc(XmlParser &xml_parser);
-    void writeParticlesToXmlForRestart(XmlParser &xml_parser, TinyXMLElement *body_element);
-    void readParticlesFromXmlForRestart(XmlParser &xml_parser, TinyXMLElement *body_element);
+    void writeParticlesToXml(DiscreteVariables &variables, XmlParser &xml_parser, TinyXMLElement *body_element);
+    void readParticlesFromXml(DiscreteVariables &variables, XmlParser &xml_parser, TinyXMLElement *body_element);
     void readReloadXmlFile(const std::string &filefullpath, const std::string &body_name);
     template <typename DataType>
     BaseParticles &reloadExtraVariable(const std::string &name);
@@ -190,6 +193,7 @@ class BaseParticles
     DiscreteVariables all_discrete_variables_;
     SingleVariables all_singular_variables_;
     DiscreteVariables variables_to_write_;
+    DiscreteVariables variables_to_reload_;
 
   protected:
     int total_body_parts_;                                /**< total number of body parts indicated particle groups*/

--- a/src/shared/particles/base_particles.hpp
+++ b/src/shared/particles/base_particles.hpp
@@ -158,6 +158,13 @@ void BaseParticles::addVariableToWrite(Args &&...args)
 {
     addDiscreteVariableToList<DataType>(variables_to_write_, std::forward<Args>(args)...);
 }
+//=================================================================================================//
+template <typename DataType, typename... Args>
+void BaseParticles::addVariableToReload(Args &&...args)
+{
+    addDiscreteVariableToList<DataType>(variables_to_reload_, std::forward<Args>(args)...);
+}
+
 //===============================================================================
 template <typename DataType>
 BaseParticles &BaseParticles::reloadExtraVariable(const std::string &name)

--- a/src/shared/particles/surface_particles.cpp
+++ b/src/shared/particles/surface_particles.cpp
@@ -1,8 +1,8 @@
 #include "surface_particles.h"
 
+#include "adaptation.h"
 #include "base_body.h"
 #include "vector_functions.h"
-#include "adaptation.h"
 
 namespace SPH
 {
@@ -27,8 +27,8 @@ void SurfaceParticles::registerSurfaceProperties(StdVec<Vecd> &n, StdVec<Real> &
 {
     n_ = registerStateVariableDataFrom<Vecd>("NormalDirection", n);
     thickness_ = registerStateVariableDataFrom<Real>("Thickness", thickness);
-    addEvolvingVariable<Vecd>("NormalDirection");
-    addEvolvingVariable<Real>("Thickness");
+    addVariableToReload<Vecd>("NormalDirection");
+    addVariableToReload<Real>("Thickness");
 }
 //=================================================================================================//
 void SurfaceParticles::registerSurfacePropertiesFromReload()

--- a/src/shared/shared_ck/io_system/io_base_ck.hpp
+++ b/src/shared/shared_ck/io_system/io_base_ck.hpp
@@ -184,7 +184,7 @@ void ReloadParticleIOCK<ExecutionPolicy>::writeToFile(size_t iteration_step)
     for (size_t i = 0; i < bodies_.size(); ++i)
     {
         BaseParticles &base_particles = bodies_[i]->getBaseParticles();
-        prepare_variable_to_reload_(base_particles.EvolvingVariables(), ExecutionPolicy{});
+        prepare_variable_to_reload_(base_particles.VariablesToReload(), ExecutionPolicy{});
     }
     ReloadParticleIO::writeToFile(iteration_step);
 }

--- a/tests/tests_sycl/3d_examples/test_3d_t_shape_pipe_sycl/test_3d_t_shape_pipe_sycl.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_t_shape_pipe_sycl/test_3d_t_shape_pipe_sycl.cpp
@@ -131,7 +131,7 @@ struct PressureBC
     Vec3d center;
     Rotation3d rot;
     Vec3d buffer_halfsize;
-    OrientedBox alignedbox;
+    OrientedBox oriented_box;
     OrientedBoxByCell alignedbox_by_cell;
     fluid_dynamics::BidirectionalBoundaryCK<ExecutionPolicy, CorrectionType, BoundaryPressurePrescribed> boundary_condition;
     StateDynamics<ExecutionPolicy, ResetBufferCorrectionMatrixCK> reset_buffer_correction_matrix;
@@ -143,8 +143,8 @@ struct PressureBC
           buffer_halfsize(params.L_emitter * 0.5,
                           params.diameter * 0.505,
                           params.diameter * 0.505),
-          alignedbox(xAxis, Transform(rot, center), buffer_halfsize),
-          alignedbox_by_cell(fluid_body, alignedbox),
+          oriented_box(xAxis, Transform(rot, center), buffer_halfsize),
+          alignedbox_by_cell(fluid_body, oriented_box),
           boundary_condition(alignedbox_by_cell, params.pressure, t_ref),
           reset_buffer_correction_matrix(alignedbox_by_cell) {}
 };


### PR DESCRIPTION
This pull request refactors how particle variables are managed for reload and restart operations, improving clarity and control over which variables are saved and restored. The main changes introduce a new `variables_to_reload_` set, replace the use of "evolving variables" in reload/restart logic with this new set, and update related I/O methods and usages accordingly.

**Refactoring and Clarification of Particle Variable Management:**

* Introduced a new `variables_to_reload_` member in the `BaseParticles` class, along with corresponding `addVariableToReload` and accessor methods, to clearly distinguish variables intended for reload from evolving variables. [[1]](diffhunk://#diff-429fe4c2d7d343634cb6b8f381e45b91cecbd79fa65b86c343c0b0318c70606eR151-R152) [[2]](diffhunk://#diff-429fe4c2d7d343634cb6b8f381e45b91cecbd79fa65b86c343c0b0318c70606eR165-R173) [[3]](diffhunk://#diff-429fe4c2d7d343634cb6b8f381e45b91cecbd79fa65b86c343c0b0318c70606eR196) [[4]](diffhunk://#diff-16ad8c0941eb1e568b8f4282768a4a7d6c18972873003e6e539d4f3756078777R161-R167)

* Updated particle registration in `LinearParticles` and `SurfaceParticles` to use `addVariableToReload` instead of `addEvolvingVariable` for properties that should be reloaded, and ensured basic variables like `Position` and `VolumetricMeasure` are also added to reload variables. [[1]](diffhunk://#diff-74cee131bfe8c74cebd104e38e905aa5634004139da4bbb75dfaae6b079d64e4L15-R16) [[2]](diffhunk://#diff-2093f1e7b22c998cfcea775b9788b7d4b9d66579039cfa1e2280a3b1e95100c3L30-R31) [[3]](diffhunk://#diff-d7dc99d92f4fd7062b15aacdd54fc73984fe85ae9b0408fc5caead8de70bfa93R37-R38)

**I/O Logic Updates:**

* Refactored the XML read/write methods in `BaseParticles` to accept an explicit set of variables (either evolving or reload), and updated all usages in restart and reload I/O classes to use the appropriate variable set (`EvolvingVariables` for restart, `VariablesToReload` for reload). [[1]](diffhunk://#diff-d7dc99d92f4fd7062b15aacdd54fc73984fe85ae9b0408fc5caead8de70bfa93L179-R182) [[2]](diffhunk://#diff-d7dc99d92f4fd7062b15aacdd54fc73984fe85ae9b0408fc5caead8de70bfa93L193-R208) [[3]](diffhunk://#diff-e0244fcab44ad1877b117de0f021069e3717b5b6bd474c67b6f7a4e3c0f67ef5L97-R98) [[4]](diffhunk://#diff-e0244fcab44ad1877b117de0f021069e3717b5b6bd474c67b6f7a4e3c0f67ef5L161-R163) [[5]](diffhunk://#diff-e0244fcab44ad1877b117de0f021069e3717b5b6bd474c67b6f7a4e3c0f67ef5L217-R220) [[6]](diffhunk://#diff-2ceccf63028366a8e888455c5f239d1af495a82fa86bf50cb44b6f1652204e07L55-R55) [[7]](diffhunk://#diff-e2526b55b1a6ecbb4ca057c1c115682728579ac09798a1245124ee22ff5d2c99L187-R187)

**Minor Code Cleanups:**

* Fixed an include order in `surface_particles.cpp` for clarity.
* Renamed a local variable in a test struct for better clarity. [[1]](diffhunk://#diff-923f32fedf6b7b594bd534af4226fe9574a43e6765cce0ce6b04ecdf8ab8198eL134-R134) [[2]](diffhunk://#diff-923f32fedf6b7b594bd534af4226fe9574a43e6765cce0ce6b04ecdf8ab8198eL146-R147)