### PR TITLE
relation view for flexible method constrcution

### DIFF
--- a/src/shared/shared_ck/body_relation/relation_ck.h
+++ b/src/shared/shared_ck/body_relation/relation_ck.h
@@ -49,7 +49,7 @@ class RelationBase
 {
   public:
     RelationBase() {}
-    virtual ~RelationBase() {};
+    virtual ~RelationBase(){};
     const std::string &Name() const { return names_.front(); }
 
   protected:
@@ -75,7 +75,7 @@ class Relation<SourceIdentifier, TargetIdentifier> : public RelationBase
     using NeighborhoodType = Neighbor<SourceAdaptation, TargetAdaptation>;
     Relation(SourceIdentifier &source_identifier, StdVec<TargetIdentifier *> contact_identifiers,
              ConfigType config_type = ConfigType::Eulerian);
-    virtual ~Relation() {};
+    virtual ~Relation(){};
     SPHBody &getSPHBody() { return *sph_body_; };
     DiscreteVariable<Vecd> *dvSourcePosition() { return dv_source_pos_; };
     DiscreteVariable<UnsignedInt> *dvNeighborSize() { return dv_neighbor_size_; };
@@ -121,7 +121,7 @@ class Inner<Relation<DynamicsIdentifier>> : public Relation<DynamicsIdentifier, 
     typedef DynamicsIdentifier SourceType;
     template <typename... Args>
     explicit Inner(DynamicsIdentifier &identifier, Args &&...args);
-    virtual ~Inner() {};
+    virtual ~Inner(){};
     DynamicsIdentifier &getDynamicsIdentifier() { return *identifier_; };
 
   protected:
@@ -135,7 +135,7 @@ class Inner<> : public Inner<Relation<RealBody>>
     template <typename... Args>
     Inner(RealBody &real_body, Args &&...args)
         : Inner<Relation<RealBody>>(real_body, std::forward<Args>(args)...) {}
-    virtual ~Inner() {};
+    virtual ~Inner(){};
 };
 
 template <typename SourceIdentifier, class TargetIdentifier>
@@ -144,7 +144,7 @@ class Contact<Relation<SourceIdentifier, TargetIdentifier>> : public Relation<So
   public:
     Contact(SourceIdentifier &source_identifier, StdVec<TargetIdentifier *> target_identifiers,
             ConfigType config_type = ConfigType::Eulerian);
-    virtual ~Contact() {};
+    virtual ~Contact(){};
     SourceIdentifier &getSourceIdentifier() { return *source_identifier_; };
     StdVec<SPHBody *> getContactBodies() { return contact_bodies_; };
     StdVec<BaseParticles *> getContactParticles() { return contact_particles_; };
@@ -170,7 +170,57 @@ class Contact<> : public Contact<Relation<SPHBody, RealBody>>
     template <typename... Args>
     Contact(SPHBody &sph_body, StdVec<RealBody *> contact_bodies, Args &&...args)
         : Contact<Relation<SPHBody, RealBody>>(sph_body, contact_bodies, std::forward<Args>(args)...) {}
-    virtual ~Contact() {};
+    virtual ~Contact(){};
 };
+
+template <typename...>
+class RelationView;
+
+template <typename... Parameters>
+class RelationView<Contact<Parameters...>>
+{
+    using RelationType = Contact<Parameters...>;
+    using NeighborList = typename RelationType::NeighborList;
+    using Neighborhood = typename RelationType::NeighborhoodType;
+
+  public:
+    RelationView(Contact<Parameters...> &contact_relation);
+    template <class TargetIdentifier>
+    RelationView(Contact<Parameters...> &contact_relation, StdVec<TargetIdentifier *> contact_identifiers);
+    template <class TargetIdentifier>
+    RelationView(Contact<Parameters...> &contact_relation,
+                 TargetIdentifier &contact_identifier);
+    Contact<Parameters...> &getContactRelation() const { return *contact_relation_; };
+    StdVec<SPHBody *> getContactBodies() const { return contact_bodies_; };
+    StdVec<BaseParticles *> getContactParticles() const { return contact_particles_; };
+    StdVec<SPHAdaptation *> getContactAdaptations() const { return contact_adaptations_; };
+
+    template <class ExecutionPolicy>
+    NeighborList getNeighborList(const ExecutionPolicy &ex_policy, UnsignedInt target_index)
+    {
+        return NeighborList(ex_policy, *contact_relation_, contact_target_indices_[target_index]);
+    };
+
+    Neighborhood &getNeighborhood(UnsignedInt target_index)
+    {
+        return contact_relation_->getNeighborhood(contact_target_indices_[target_index]);
+    };
+
+    void registerComputingKernel(execution::Implementation<Base> *implementation, UnsignedInt target_index);
+    void resetComputingKernelUpdated(UnsignedInt target_index);
+
+  protected:
+    Contact<Parameters...> *contact_relation_;
+    StdVec<SPHBody *> contact_bodies_;
+    StdVec<BaseParticles *> contact_particles_;
+    StdVec<SPHAdaptation *> contact_adaptations_;
+    StdVec<UnsignedInt> contact_target_indices_;
+};
+
+template <template <typename...> class RelationType, typename... Parameters, typename... Args>
+auto makeRelationView(RelationType<Parameters...> &relation, Args &&...args)
+{
+    return RelationView<RelationType<Parameters...>>(relation, std::forward<Args>(args)...);
+}
 } // namespace SPH
 #endif // RELATION_CK_H

--- a/src/shared/shared_ck/body_relation/relation_ck.hpp
+++ b/src/shared/shared_ck/body_relation/relation_ck.hpp
@@ -107,5 +107,63 @@ Contact<Relation<SourceIdentifier, TargetIdentifier>>::Contact(
     }
 }
 //=================================================================================================//
+template <typename... Parameters>
+RelationView<Contact<Parameters...>>::RelationView(Contact<Parameters...> &contact_relation)
+    : contact_relation_(&contact_relation),
+      contact_bodies_(contact_relation.getContactBodies()),
+      contact_particles_(contact_relation.getContactParticles()),
+      contact_adaptations_(contact_relation.getContactAdaptations())
+{
+    for (size_t k = 0; k != contact_bodies_.size(); ++k)
+    {
+        contact_target_indices_.push_back(k);
+    }
+}
+//=================================================================================================//
+template <typename... Parameters>
+template <class TargetIdentifier>
+RelationView<Contact<Parameters...>>::RelationView(
+    Contact<Parameters...> &contact_relation, StdVec<TargetIdentifier *> contact_identifiers)
+    : contact_relation_(&contact_relation)
+{
+    StdVec<SPHBody *> all_contact_bodies = contact_relation.getContactBodies();
+    StdVec<BaseParticles *> all_contact_particles = contact_relation.getContactParticles();
+    StdVec<SPHAdaptation *> all_contact_adaptations = contact_relation.getContactAdaptations();
+    for (size_t k = 0; k != contact_identifiers.size(); ++k)
+    {
+        TargetIdentifier *target_identifier = contact_identifiers[k];
+        for (size_t j = 0; j != all_contact_bodies.size(); ++j)
+        {
+            if (all_contact_bodies[j]->Name() == target_identifier->Name())
+            {
+                contact_bodies_.push_back(all_contact_bodies[j]);
+                contact_particles_.push_back(all_contact_particles[j]);
+                contact_adaptations_.push_back(all_contact_adaptations[j]);
+                contact_target_indices_.push_back(j);
+                break;
+            }
+        }
+    }
+}
+//=================================================================================================//
+template <typename... Parameters>
+template <class TargetIdentifier>
+RelationView<Contact<Parameters...>>::RelationView(
+    Contact<Parameters...> &contact_relation, TargetIdentifier &contact_identifiers)
+    : RelationView(contact_relation, StdVec<TargetIdentifier *>{&contact_identifiers}) {}
+//=================================================================================================//
+template <typename... Parameters>
+void RelationView<Contact<Parameters...>>::registerComputingKernel(
+    execution::Implementation<Base> *implementation, UnsignedInt target_index)
+{
+    contact_relation_->registerComputingKernel(implementation, contact_target_indices_[target_index]);
+}
+//=================================================================================================//
+template <typename... Parameters>
+void RelationView<Contact<Parameters...>>::resetComputingKernelUpdated(UnsignedInt target_index)
+{
+    contact_relation_->resetComputingKernelUpdated(contact_target_indices_[target_index]);
+}
+//=================================================================================================//
 } // namespace SPH
 #endif // RELATION_CK_HPP

--- a/src/shared/shared_ck/particle_dynamics/continum_dynamics/continuum_integration_1st_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/continum_dynamics/continuum_integration_1st_ck.h
@@ -44,7 +44,7 @@ class PlasticAcousticStep : public fluid_dynamics::AcousticStep<BaseInteractionT
   public:
     template <class DynamicsIdentifier>
     explicit PlasticAcousticStep(DynamicsIdentifier &identifier);
-    virtual ~PlasticAcousticStep() {};
+    virtual ~PlasticAcousticStep(){};
 
   protected:
     PlasticContinuum &plastic_continuum_;
@@ -63,8 +63,9 @@ class PlasticAcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrec
     using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
 
   public:
-    explicit PlasticAcousticStep1stHalf(Inner<Parameters...> &inner_relation);
-    virtual ~PlasticAcousticStep1stHalf() {};
+    template <class DynamicsIdentifier>
+    explicit PlasticAcousticStep1stHalf(DynamicsIdentifier &identifier);
+    virtual ~PlasticAcousticStep1stHalf(){};
 
     class InitializeKernel
     {
@@ -119,8 +120,9 @@ class PlasticAcousticStep1stHalf<Contact<Wall, RiemannSolverType, KernelCorrecti
     using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
 
   public:
-    explicit PlasticAcousticStep1stHalf(Contact<Parameters...> &wall_contact_relation);
-    virtual ~PlasticAcousticStep1stHalf() {};
+    template <class DynamicsIdentifier>
+    explicit PlasticAcousticStep1stHalf(DynamicsIdentifier &identifier);
+    virtual ~PlasticAcousticStep1stHalf(){};
 
     class InteractKernel : public BaseInteraction::InteractKernel
     {

--- a/src/shared/shared_ck/particle_dynamics/continum_dynamics/continuum_integration_1st_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/continum_dynamics/continuum_integration_1st_ck.hpp
@@ -26,9 +26,10 @@ PlasticAcousticStep<BaseInteractionType>::PlasticAcousticStep(DynamicsIdentifier
 }
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
+template <class DynamicsIdentifier>
 PlasticAcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    PlasticAcousticStep1stHalf(Inner<Parameters...> &inner_relation)
-    : PlasticAcousticStep<Interaction<Inner<Parameters...>>>(inner_relation),
+    PlasticAcousticStep1stHalf(DynamicsIdentifier &identifier)
+    : PlasticAcousticStep<Interaction<Inner<Parameters...>>>(identifier),
       correction_method_(this->particles_),
       riemann_solver_(this->plastic_continuum_, this->plastic_continuum_)
 {
@@ -110,9 +111,10 @@ void PlasticAcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrect
 
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
+template <class DynamicsIdentifier>
 PlasticAcousticStep1stHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    PlasticAcousticStep1stHalf(Contact<Parameters...> &wall_contact_relation)
-    : BaseInteraction(wall_contact_relation), Interaction<Wall>(wall_contact_relation),
+    PlasticAcousticStep1stHalf(DynamicsIdentifier &identifier)
+    : BaseInteraction(identifier), Interaction<Wall>(identifier),
       correction_method_(this->particles_),
       riemann_solver_(this->plastic_continuum_, this->plastic_continuum_) {}
 //=================================================================================================//

--- a/src/shared/shared_ck/particle_dynamics/continum_dynamics/continuum_integration_2nd_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/continum_dynamics/continuum_integration_2nd_ck.h
@@ -48,8 +48,9 @@ class PlasticAcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrec
     using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
 
   public:
-    explicit PlasticAcousticStep2ndHalf(Inner<Parameters...> &inner_relation);
-    virtual ~PlasticAcousticStep2ndHalf() {};
+    template <class DynamicsIdentifier>
+    explicit PlasticAcousticStep2ndHalf(DynamicsIdentifier &identifier);
+    virtual ~PlasticAcousticStep2ndHalf(){};
 
     class InitializeKernel
     {
@@ -104,8 +105,9 @@ class PlasticAcousticStep2ndHalf<Contact<Wall, RiemannSolverType, KernelCorrecti
     using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
 
   public:
-    explicit PlasticAcousticStep2ndHalf(Contact<Parameters...> &wall_contact_relation);
-    virtual ~PlasticAcousticStep2ndHalf() {};
+    template <class DynamicsIdentifier>
+    explicit PlasticAcousticStep2ndHalf(DynamicsIdentifier &identifier);
+    virtual ~PlasticAcousticStep2ndHalf(){};
 
     class InteractKernel : public BaseInteraction::InteractKernel
     {

--- a/src/shared/shared_ck/particle_dynamics/continum_dynamics/continuum_integration_2nd_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/continum_dynamics/continuum_integration_2nd_ck.hpp
@@ -9,9 +9,10 @@ namespace continuum_dynamics
 {
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
+template <class DynamicsIdentifier>
 PlasticAcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    PlasticAcousticStep2ndHalf(Inner<Parameters...> &inner_relation)
-    : PlasticAcousticStep<Interaction<Inner<Parameters...>>>(inner_relation),
+    PlasticAcousticStep2ndHalf(DynamicsIdentifier &identifier)
+    : PlasticAcousticStep<Interaction<Inner<Parameters...>>>(identifier),
       correction_method_(this->particles_),
       riemann_solver_(this->plastic_continuum_, this->plastic_continuum_, 20.0 * (Real)Dimensions)
 {
@@ -99,9 +100,10 @@ void PlasticAcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrect
 }
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
+template <class DynamicsIdentifier>
 PlasticAcousticStep2ndHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    PlasticAcousticStep2ndHalf(Contact<Parameters...> &wall_contact_relation)
-    : BaseInteraction(wall_contact_relation), Interaction<Wall>(wall_contact_relation),
+    PlasticAcousticStep2ndHalf(DynamicsIdentifier &identifier)
+    : BaseInteraction(identifier), Interaction<Wall>(identifier),
       correction_method_(this->particles_),
       riemann_solver_(this->plastic_continuum_, this->plastic_continuum_) {}
 //=================================================================================================//

--- a/src/shared/shared_ck/particle_dynamics/continum_dynamics/shear_integration.h
+++ b/src/shared/shared_ck/particle_dynamics/continum_dynamics/shear_integration.h
@@ -52,8 +52,9 @@ class ShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>
     using ConstituteKernel = typename MaterialType::ConstituteKernel;
 
   public:
-    explicit ShearIntegration(Inner<Parameters...> &inner_relation, Real xi = 2.0, Real shear_stress_damping = 0.0);
-    virtual ~ShearIntegration() {};
+    template <class DynamicsIdentifier>
+    explicit ShearIntegration(DynamicsIdentifier &identifier, Real xi = 2.0, Real shear_stress_damping = 0.0);
+    virtual ~ShearIntegration(){};
 
     class InitializeKernel
     {

--- a/src/shared/shared_ck/particle_dynamics/continum_dynamics/shear_integration.hpp
+++ b/src/shared/shared_ck/particle_dynamics/continum_dynamics/shear_integration.hpp
@@ -11,9 +11,10 @@ namespace continuum_dynamics
 {
 //====================================================================================//
 template <class MaterialType, typename... Parameters>
+template <class DynamicsIdentifier>
 ShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::
-    ShearIntegration(Inner<Parameters...> &inner_relation, Real xi, Real shear_stress_damping)
-    : BaseInteraction(inner_relation), ForcePriorCK(this->particles_, "ShearForce"),
+    ShearIntegration(DynamicsIdentifier &identifier, Real xi, Real shear_stress_damping)
+    : BaseInteraction(identifier), ForcePriorCK(this->particles_, "ShearForce"),
       material_(DynamicCast<MaterialType>(this, this->sph_body_->getMatterMaterial())),
       adaptation_(DynamicCast<Adaptation>(this, this->sph_body_->getSPHAdaptation())),
       h_ref_(adaptation_.ReferenceSmoothingLength()), shear_stress_damping_(shear_stress_damping),

--- a/src/shared/shared_ck/particle_dynamics/continum_dynamics/stress_diffusion_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/continum_dynamics/stress_diffusion_ck.h
@@ -49,8 +49,9 @@ class StressDiffusionCK<Inner<Parameters...>> : public PlasticAcousticStep<Inter
     using BaseInteraction = PlasticAcousticStep<Interaction<Inner<Parameters...>>>;
 
   public:
-    explicit StressDiffusionCK(Inner<Parameters...> &inner_relation);
-    virtual ~StressDiffusionCK() {};
+    template <class DynamicsIdentifier>
+    explicit StressDiffusionCK(DynamicsIdentifier &identifier);
+    virtual ~StressDiffusionCK(){};
 
     class InteractKernel : public BaseInteraction::InteractKernel
     {

--- a/src/shared/shared_ck/particle_dynamics/continum_dynamics/stress_diffusion_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/continum_dynamics/stress_diffusion_ck.hpp
@@ -9,8 +9,9 @@ namespace continuum_dynamics
 {
 //=================================================================================================//
 template <typename... Parameters>
-StressDiffusionCK<Inner<Parameters...>>::StressDiffusionCK(Inner<Parameters...> &inner_relation)
-    : PlasticAcousticStep<Interaction<Inner<Parameters...>>>(inner_relation),
+template <class DynamicsIdentifier>
+StressDiffusionCK<Inner<Parameters...>>::StressDiffusionCK(DynamicsIdentifier &identifier)
+    : PlasticAcousticStep<Interaction<Inner<Parameters...>>>(identifier),
       dv_phi_(DynamicCast<PlasticContinuum>(this, this->plastic_continuum_).getFrictionAngle()),
       dv_smoothing_length_(this->getSPHAdaptation().ReferenceSmoothingLength()),
       dv_sound_speed_(this->plastic_continuum_.ReferenceSoundSpeed()),

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.h
@@ -68,7 +68,8 @@ class AcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionTyp
     using CorrectionDataType = typename KernelCorrectionType::CorrectionDataType;
 
   public:
-    explicit AcousticStep1stHalf(Inner<Parameters...> &inner_relation);
+    template <class DynamicsIdentifier>
+    explicit AcousticStep1stHalf(DynamicsIdentifier &identifier);
     virtual ~AcousticStep1stHalf(){};
 
     class InitializeKernel
@@ -125,7 +126,8 @@ class AcousticStep1stHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType,
     using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
 
   public:
-    explicit AcousticStep1stHalf(Contact<Parameters...> &wall_contact_relation);
+    template <class DynamicsIdentifier>
+    explicit AcousticStep1stHalf(DynamicsIdentifier &identifier);
     virtual ~AcousticStep1stHalf(){};
 
     class InteractKernel : public BaseInteraction::InteractKernel
@@ -161,7 +163,8 @@ class AcousticStep1stHalf<Contact<RiemannSolverType, KernelCorrectionType, Param
     using CorrectionDataType = typename KernelCorrectionType::CorrectionDataType;
 
   public:
-    explicit AcousticStep1stHalf(Contact<Parameters...> &wall_contact_relation);
+    template <class DynamicsIdentifier>
+    explicit AcousticStep1stHalf(DynamicsIdentifier &identifier);
     virtual ~AcousticStep1stHalf(){};
 
     class InteractKernel : public BaseInteraction::InteractKernel

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.hpp
@@ -37,9 +37,10 @@ AcousticStep<BaseInteractionType>::AcousticStep(DynamicsIdentifier &identifier)
 }
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
+template <class DynamicsIdentifier>
 AcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    AcousticStep1stHalf(Inner<Parameters...> &inner_relation)
-    : AcousticStep<Interaction<Inner<Parameters...>>>(inner_relation),
+    AcousticStep1stHalf(DynamicsIdentifier &identifier)
+    : AcousticStep<Interaction<Inner<Parameters...>>>(identifier),
       kernel_correction_(this->particles_),
       fluid_(DynamicCast<FluidType>(this, this->sph_body_->getMatterMaterial())),
       riemann_solver_(this->fluid_, this->fluid_)
@@ -121,9 +122,10 @@ void AcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType
 }
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
+template <class DynamicsIdentifier>
 AcousticStep1stHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    AcousticStep1stHalf(Contact<Parameters...> &wall_contact_relation)
-    : BaseInteraction(wall_contact_relation), Interaction<Wall>(wall_contact_relation),
+    AcousticStep1stHalf(DynamicsIdentifier &identifier)
+    : BaseInteraction(identifier), Interaction<Wall>(identifier),
       kernel_correction_(this->particles_),
       fluid_(DynamicCast<FluidType>(this, this->sph_body_->getMatterMaterial())),
       riemann_solver_(this->fluid_, this->fluid_) {}
@@ -169,9 +171,10 @@ void AcousticStep1stHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType, 
 }
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
+template <class DynamicsIdentifier>
 AcousticStep1stHalf<Contact<RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    AcousticStep1stHalf(Contact<Parameters...> &contact_relation)
-    : BaseInteraction(contact_relation), kernel_correction_(this->particles_)
+    AcousticStep1stHalf(DynamicsIdentifier &identifier)
+    : BaseInteraction(identifier), kernel_correction_(this->particles_)
 {
     SourceFluidType &source_fluid =
         DynamicCast<SourceFluidType>(this, this->sph_body_->getMatterMaterial());

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_2nd_half.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_2nd_half.h
@@ -55,8 +55,9 @@ class AcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionTyp
     using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
 
   public:
-    explicit AcousticStep2ndHalf(Inner<Parameters...> &inner_relation);
-    virtual ~AcousticStep2ndHalf() {};
+    template <class DynamicsIdentifier>
+    explicit AcousticStep2ndHalf(DynamicsIdentifier &identifier);
+    virtual ~AcousticStep2ndHalf(){};
 
     class InitializeKernel
     {
@@ -109,8 +110,9 @@ class AcousticStep2ndHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType,
     using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
 
   public:
-    explicit AcousticStep2ndHalf(Contact<Parameters...> &wall_contact_relation);
-    virtual ~AcousticStep2ndHalf() {};
+    template <class DynamicsIdentifier>
+    explicit AcousticStep2ndHalf(DynamicsIdentifier &identifier);
+    virtual ~AcousticStep2ndHalf(){};
 
     class InteractKernel : public BaseInteraction::InteractKernel
     {
@@ -147,8 +149,9 @@ class AcousticStep2ndHalf<Contact<RiemannSolverType, KernelCorrectionType, Param
     using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
 
   public:
-    explicit AcousticStep2ndHalf(Contact<Parameters...> &wall_contact_relation);
-    virtual ~AcousticStep2ndHalf() {};
+    template <class DynamicsIdentifier>
+    explicit AcousticStep2ndHalf(DynamicsIdentifier &identifier);
+    virtual ~AcousticStep2ndHalf(){};
 
     class InteractKernel : public BaseInteraction::InteractKernel
     {

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_2nd_half.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_2nd_half.hpp
@@ -9,9 +9,10 @@ namespace fluid_dynamics
 {
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
+template <class DynamicsIdentifier>
 AcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    AcousticStep2ndHalf(Inner<Parameters...> &inner_relation)
-    : AcousticStep<Interaction<Inner<Parameters...>>>(inner_relation),
+    AcousticStep2ndHalf(DynamicsIdentifier &identifier)
+    : AcousticStep<Interaction<Inner<Parameters...>>>(identifier),
       kernel_correction_(this->particles_),
       fluid_(DynamicCast<FluidType>(this, this->sph_body_->getMatterMaterial())),
       riemann_solver_(this->fluid_, this->fluid_)
@@ -82,9 +83,10 @@ void AcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType
 }
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
+template <class DynamicsIdentifier>
 AcousticStep2ndHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    AcousticStep2ndHalf(Contact<Parameters...> &wall_contact_relation)
-    : BaseInteraction(wall_contact_relation), Interaction<Wall>(wall_contact_relation),
+    AcousticStep2ndHalf(DynamicsIdentifier &identifier)
+    : BaseInteraction(identifier), Interaction<Wall>(identifier),
       kernel_correction_(this->particles_),
       fluid_(DynamicCast<FluidType>(this, this->sph_body_->getMatterMaterial())),
       riemann_solver_(this->fluid_, this->fluid_) {}
@@ -129,9 +131,10 @@ void AcousticStep2ndHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType, 
 }
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
+template <class DynamicsIdentifier>
 AcousticStep2ndHalf<Contact<RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    AcousticStep2ndHalf(Contact<Parameters...> &wall_contact_relation)
-    : BaseInteraction(wall_contact_relation), kernel_correction_(this->particles_)
+    AcousticStep2ndHalf(DynamicsIdentifier &identifier)
+    : BaseInteraction(identifier), kernel_correction_(this->particles_)
 {
     SourceFluidType &source_fluid =
         DynamicCast<SourceFluidType>(this, this->sph_body_->getMatterMaterial());

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.h
@@ -50,7 +50,7 @@ class DensitySummationCK<Base, RelationType<Parameters...>>
   public:
     template <class DynamicsIdentifier>
     explicit DensitySummationCK(DynamicsIdentifier &identifier);
-    virtual ~DensitySummationCK() {};
+    virtual ~DensitySummationCK(){};
 
     class InteractKernel : public Interaction<RelationType<Parameters...>>::InteractKernel
     {
@@ -74,8 +74,9 @@ class DensitySummationCK<Inner<Parameters...>>
     : public DensitySummationCK<Base, Inner<Parameters...>>
 {
   public:
-    explicit DensitySummationCK(Inner<Parameters...> &inner_relation);
-    virtual ~DensitySummationCK() {};
+    template <class DynamicsIdentifier>
+    explicit DensitySummationCK(DynamicsIdentifier &identifier);
+    virtual ~DensitySummationCK(){};
 
     class InteractKernel
         : public DensitySummationCK<Base, Inner<Parameters...>>::InteractKernel
@@ -95,8 +96,9 @@ class DensitySummationCK<Contact<Parameters...>>
     : public DensitySummationCK<Base, Contact<Parameters...>>
 {
   public:
-    explicit DensitySummationCK(Contact<Parameters...> &contact_relation);
-    virtual ~DensitySummationCK() {};
+    template <class DynamicsIdentifier>
+    explicit DensitySummationCK(DynamicsIdentifier &identifier);
+    virtual ~DensitySummationCK(){};
 
     class InteractKernel
         : public DensitySummationCK<Base, Contact<Parameters...>>::InteractKernel
@@ -125,7 +127,7 @@ template <>
 class Regularization<Internal>
 {
   public:
-    Regularization(BaseParticles *particles) {};
+    Regularization(BaseParticles *particles){};
 
     class ComputingKernel
     {
@@ -143,7 +145,7 @@ template <>
 class Regularization<FreeSurface>
 {
   public:
-    Regularization(BaseParticles *particles) {};
+    Regularization(BaseParticles *particles){};
 
     class ComputingKernel
     {
@@ -168,7 +170,7 @@ class Regularization<FreeStream>
 
   public:
     Regularization(BaseParticles *particles)
-        : dv_indicator_(particles->getVariableByName<int>("Indicator")) {};
+        : dv_indicator_(particles->getVariableByName<int>("Indicator")){};
 
     class ComputingKernel
     {
@@ -195,7 +197,7 @@ class DensityRegularization : public BaseLocalDynamics<DynamicsIdentifier>
 
   public:
     explicit DensityRegularization(DynamicsIdentifier &identifier);
-    virtual ~DensityRegularization() {};
+    virtual ~DensityRegularization(){};
 
     class UpdateKernel
     {

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.hpp
@@ -33,8 +33,9 @@ DensitySummationCK<Base, RelationType<Parameters...>>::InteractKernel::InteractK
       rho0_(encloser.rho0_) {}
 //=================================================================================================//
 template <typename... Parameters>
-DensitySummationCK<Inner<Parameters...>>::DensitySummationCK(Inner<Parameters...> &inner_relation)
-    : DensitySummationCK<Base, Inner<Parameters...>>(inner_relation) {}
+template <class DynamicsIdentifier>
+DensitySummationCK<Inner<Parameters...>>::DensitySummationCK(DynamicsIdentifier &identifier)
+    : DensitySummationCK<Base, Inner<Parameters...>>(identifier) {}
 //=================================================================================================//
 template <typename... Parameters>
 template <class ExecutionPolicy, class Encloser>
@@ -57,9 +58,10 @@ void DensitySummationCK<Inner<Parameters...>>::
 }
 //=================================================================================================//
 template <typename... Parameters>
+template <class DynamicsIdentifier>
 DensitySummationCK<Contact<Parameters...>>::
-    DensitySummationCK(Contact<Parameters...> &contact_relation)
-    : DensitySummationCK<Base, Contact<Parameters...>>(contact_relation)
+    DensitySummationCK(DynamicsIdentifier &identifier)
+    : DensitySummationCK<Base, Contact<Parameters...>>(identifier)
 {
     for (size_t k = 0; k != this->contact_particles_.size(); ++k)
     {

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.h
@@ -51,7 +51,7 @@ class ViscousForceCK<Base, ViscosityType, KernelCorrectionType, RelationType<Par
   public:
     template <class BaseRelationType>
     explicit ViscousForceCK(BaseRelationType &base_relation);
-    virtual ~ViscousForceCK() {};
+    virtual ~ViscousForceCK(){};
 
   protected:
     using ViscosityModel = ViscosityType;
@@ -71,8 +71,9 @@ class ViscousForceCK<Inner<WithUpdate, ViscosityType, KernelCorrectionType, Para
     using BaseViscousForceType = ViscousForceCK<Base, ViscosityType, KernelCorrectionType, Inner<Parameters...>>;
 
   public:
-    explicit ViscousForceCK(Inner<Parameters...> &inner_relation);
-    virtual ~ViscousForceCK() {};
+    template <class DynamicsIdentifier>
+    explicit ViscousForceCK(DynamicsIdentifier &identifier);
+    virtual ~ViscousForceCK(){};
 
     class InteractKernel : public BaseViscousForceType::InteractKernel
     {
@@ -100,8 +101,9 @@ class ViscousForceCK<Contact<Wall, ViscosityType, KernelCorrectionType, Paramete
     using BaseViscousForceType = ViscousForceCK<Base, ViscosityType, KernelCorrectionType, Contact<Parameters...>>;
 
   public:
-    explicit ViscousForceCK(Contact<Parameters...> &contact_relation);
-    virtual ~ViscousForceCK() {};
+    template <class DynamicsIdentifier>
+    explicit ViscousForceCK(DynamicsIdentifier &identifier);
+    virtual ~ViscousForceCK(){};
 
     class InteractKernel : public BaseViscousForceType::InteractKernel
     {

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "viscous_force.h"
 #include "base_body.hpp"
+#include "viscous_force.h"
 
 namespace SPH
 {
@@ -21,9 +21,10 @@ ViscousForceCK<Base, ViscosityType, KernelCorrectionType, RelationType<Parameter
       smoothing_length_sq_(pow(this->getSPHAdaptation().ReferenceSmoothingLength(), 2)) {}
 //=================================================================================================//
 template <typename ViscosityType, class KernelCorrectionType, typename... Parameters>
+template <class DynamicsIdentifier>
 ViscousForceCK<Inner<WithUpdate, ViscosityType, KernelCorrectionType, Parameters...>>::
-    ViscousForceCK(Inner<Parameters...> &inner_relation)
-    : BaseViscousForceType(inner_relation),
+    ViscousForceCK(DynamicsIdentifier &identifier)
+    : BaseViscousForceType(identifier),
       ForcePriorCK(this->particles_, this->dv_viscous_force_) {}
 //=================================================================================================//
 template <typename ViscosityType, class KernelCorrectionType, typename... Parameters>
@@ -61,9 +62,10 @@ void ViscousForceCK<Inner<WithUpdate, ViscosityType, KernelCorrectionType, Param
 }
 //=================================================================================================//
 template <typename ViscosityType, class KernelCorrectionType, typename... Parameters>
+template <class DynamicsIdentifier>
 ViscousForceCK<Contact<Wall, ViscosityType, KernelCorrectionType, Parameters...>>::
-    ViscousForceCK(Contact<Parameters...> &contact_relation)
-    : BaseViscousForceType(contact_relation), Interaction<Wall>(contact_relation) {}
+    ViscousForceCK(DynamicsIdentifier &identifier)
+    : BaseViscousForceType(identifier), Interaction<Wall>(identifier) {}
 //=================================================================================================//
 template <typename ViscosityType, class KernelCorrectionType, typename... Parameters>
 template <class ExecutionPolicy, class EncloserType>

--- a/src/shared/shared_ck/particle_dynamics/fluid_structure_interaction/force_on_structure.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_structure_interaction/force_on_structure.h
@@ -49,7 +49,7 @@ class ForceFromFluid : public Interaction<Contact<Parameters...>>, public ForceP
   public:
     template <class ContactRelationType>
     explicit ForceFromFluid(ContactRelationType &contact_relation, const std::string &force_name);
-    virtual ~ForceFromFluid() {};
+    virtual ~ForceFromFluid(){};
 
     class InteractKernel
         : public Interaction<Contact<Parameters...>>::InteractKernel
@@ -87,7 +87,7 @@ class ViscousForceFromFluid<Contact<WithUpdate, ViscosityType, KernelCorrectionT
   public:
     template <class ContactRelationType>
     explicit ViscousForceFromFluid(ContactRelationType &contact_relation);
-    virtual ~ViscousForceFromFluid() {};
+    virtual ~ViscousForceFromFluid(){};
     class InteractKernel : public BaseForceFromFluid::InteractKernel
     {
       public:
@@ -113,11 +113,12 @@ class ViscousForceFromFluid<Contact<WithUpdate, ViscousForceType, Parameters...>
           decltype(ViscousForceType::kernel_correction_), Parameters...>>
 {
   public:
-    explicit ViscousForceFromFluid(Contact<Parameters...> &contact_relation)
+    template <class DynamicsIdentifier>
+    explicit ViscousForceFromFluid(DynamicsIdentifier &contact_relation)
         : ViscousForceFromFluid<Contact<
               WithUpdate, typename ViscousForceType::ViscosityModel,
-              decltype(ViscousForceType::kernel_correction_), Parameters...>>(contact_relation) {};
-    virtual ~ViscousForceFromFluid() {};
+              decltype(ViscousForceType::kernel_correction_), Parameters...>>(contact_relation){};
+    virtual ~ViscousForceFromFluid(){};
 };
 
 template <typename ViscousForceType>
@@ -136,7 +137,7 @@ class PressureForceFromFluid<Contact<WithUpdate, RiemannSolverType, KernelCorrec
   public:
     template <class ContactRelationType>
     explicit PressureForceFromFluid(ContactRelationType &contact_relation);
-    virtual ~PressureForceFromFluid() {};
+    virtual ~PressureForceFromFluid(){};
 
     class InteractKernel : public BaseForceFromFluid::InteractKernel
     {
@@ -173,7 +174,7 @@ class PressureForceFromFluid<Contact<WithUpdate, AcousticStep2ndHalfType, Parame
               WithUpdate, decltype(AcousticStep2ndHalfType::riemann_solver_),
               decltype(AcousticStep2ndHalfType::kernel_correction_),
               Parameters...>>(contact_relation){};
-    virtual ~PressureForceFromFluid() {};
+    virtual ~PressureForceFromFluid(){};
 };
 
 template <typename AcousticStep2ndHalfType>

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.h
@@ -89,7 +89,7 @@ class Gradient<Base, DataType, RelationType<Parameters...>>
     template <typename FirstArg>
     explicit Gradient(DynamicsArgs<RelationType<Parameters...>, FirstArg> parameters)
         : Gradient(parameters.identifier_, std::get<0>(parameters.others_)){};
-    virtual ~Gradient() {};
+    virtual ~Gradient(){};
 
     class InteractKernel : public BaseDynamicsType::InteractKernel
     {
@@ -121,12 +121,13 @@ class LinearGradient<Inner<DataType, Parameters...>>
     using BaseDynamicsType = Gradient<Base, DataType, Inner<Parameters...>>;
 
   public:
-    explicit LinearGradient(Inner<Parameters...> &inner_relation, const std::string &variable_name)
-        : BaseDynamicsType(inner_relation, variable_name) {};
+    template <class DynamicsIdentifier>
+    explicit LinearGradient(DynamicsIdentifier &identifier, const std::string &variable_name)
+        : BaseDynamicsType(identifier, variable_name){};
     template <typename FirstArg>
     explicit LinearGradient(DynamicsArgs<Inner<Parameters...>, FirstArg> parameters)
         : LinearGradient(parameters.identifier_, std::get<0>(parameters.others_)){};
-    virtual ~LinearGradient() {};
+    virtual ~LinearGradient(){};
 
     class InteractKernel : public BaseDynamicsType::InteractKernel
     {
@@ -145,11 +146,12 @@ class LinearGradient<Contact<DataType, Parameters...>>
     using BaseDynamicsType = Gradient<Base, DataType, Contact<Parameters...>>;
 
   public:
-    explicit LinearGradient(Contact<Parameters...> &contact_relation, const std::string &variable_name);
+    template <class DynamicsIdentifier>
+    explicit LinearGradient(DynamicsIdentifier &identifier, const std::string &variable_name);
     template <typename FirstArg>
     explicit LinearGradient(DynamicsArgs<Contact<Parameters...>, FirstArg> parameters)
         : LinearGradient(parameters.identifier_, std::get<0>(parameters.others_)){};
-    virtual ~LinearGradient() {};
+    virtual ~LinearGradient(){};
 
     class InteractKernel : public BaseDynamicsType::InteractKernel
     {
@@ -179,7 +181,7 @@ class Hessian<Base, DataType, RelationType<Parameters...>>
   public:
     template <typename... Args>
     explicit Hessian(Args &&...args);
-    virtual ~Hessian() {};
+    virtual ~Hessian(){};
 
     class InteractKernel : public BaseDynamicsType::InteractKernel
     {
@@ -206,7 +208,7 @@ class Hessian<Inner<DataType, Parameters...>>
   public:
     template <typename... Args>
     explicit Hessian(Args &&...args) : BaseDynamicsType(std::forward<Args>(args)...){};
-    virtual ~Hessian() {};
+    virtual ~Hessian(){};
 
     class InteractKernel : public BaseDynamicsType::InteractKernel
     {
@@ -227,7 +229,7 @@ class Hessian<Contact<DataType, Parameters...>>
   public:
     template <typename... Args>
     explicit Hessian(Args &&...args);
-    virtual ~Hessian() {};
+    virtual ~Hessian(){};
 
     class InteractKernel : public BaseDynamicsType::InteractKernel
     {
@@ -257,7 +259,7 @@ class SecondOrderGradient<Inner<DataType, Parameters...>>
   public:
     template <typename... Args>
     explicit SecondOrderGradient(Args &&...args) : BaseDynamicsType(std::forward<Args>(args)...){};
-    virtual ~SecondOrderGradient() {};
+    virtual ~SecondOrderGradient(){};
 
     class InteractKernel : public BaseDynamicsType::InteractKernel
     {
@@ -278,7 +280,7 @@ class SecondOrderGradient<Contact<DataType, Parameters...>>
   public:
     template <typename... Args>
     explicit SecondOrderGradient(Args &&...args);
-    virtual ~SecondOrderGradient() {};
+    virtual ~SecondOrderGradient(){};
 
     class InteractKernel : public BaseDynamicsType::InteractKernel
     {

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.hpp
@@ -43,9 +43,10 @@ void LinearGradient<Inner<DataType, Parameters...>>::InteractKernel::interact(si
 }
 //=================================================================================================//
 template <typename DataType, typename... Parameters>
+template <class DynamicsIdentifier>
 LinearGradient<Contact<DataType, Parameters...>>::LinearGradient(
-    Contact<Parameters...> &contact_relation, const std::string &variable_name)
-    : BaseDynamicsType(contact_relation, variable_name)
+    DynamicsIdentifier &identifier, const std::string &variable_name)
+    : BaseDynamicsType(identifier, variable_name)
 {
     for (UnsignedInt k = 0; k != this->contact_particles_.size(); ++k)
     {

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.h
@@ -47,7 +47,7 @@ class HessianCorrectionMatrix<Base, RelationType<Parameters...>>
   public:
     template <class DynamicsIdentifier>
     explicit HessianCorrectionMatrix(DynamicsIdentifier &identifier);
-    virtual ~HessianCorrectionMatrix() {};
+    virtual ~HessianCorrectionMatrix(){};
 
     class InteractKernel
         : public Interaction<RelationType<Parameters...>>::InteractKernel
@@ -81,9 +81,10 @@ class DisplacementMatrixGradient<Inner<Parameters...>>
     using BaseDynamicsType = HessianCorrectionMatrix<Base, Inner<Parameters...>>;
 
   public:
-    explicit DisplacementMatrixGradient(Inner<Parameters...> &inner_relation)
-        : BaseDynamicsType(inner_relation) {};
-    virtual ~DisplacementMatrixGradient() {};
+    template <class DynamicsIdentifier>
+    explicit DisplacementMatrixGradient(DynamicsIdentifier &identifier)
+        : BaseDynamicsType(identifier){};
+    virtual ~DisplacementMatrixGradient(){};
 
     class InteractKernel : public BaseDynamicsType::InteractKernel
     {
@@ -102,8 +103,9 @@ class DisplacementMatrixGradient<Contact<Parameters...>>
     using BaseDynamicsType = HessianCorrectionMatrix<Base, Contact<Parameters...>>;
 
   public:
-    explicit DisplacementMatrixGradient(Contact<Parameters...> &contact_relation);
-    virtual ~DisplacementMatrixGradient() {};
+    template <class DynamicsIdentifier>
+    explicit DisplacementMatrixGradient(DynamicsIdentifier &identifier);
+    virtual ~DisplacementMatrixGradient(){};
 
     class InteractKernel : public BaseDynamicsType::InteractKernel
     {
@@ -126,12 +128,13 @@ class HessianCorrectionMatrix<Inner<WithUpdate, Parameters...>>
     using BaseDynamicsType = HessianCorrectionMatrix<Base, Inner<Parameters...>>;
 
   public:
-    explicit HessianCorrectionMatrix(Inner<Parameters...> &inner_relation, Real alpha = Real(0))
-        : BaseDynamicsType(inner_relation), alpha_(alpha) {};
+    template <class DynamicsIdentifier>
+    explicit HessianCorrectionMatrix(DynamicsIdentifier &identifier, Real alpha = Real(0))
+        : BaseDynamicsType(identifier), alpha_(alpha){};
     template <typename BodyRelationType, typename FirstArg>
     explicit HessianCorrectionMatrix(DynamicsArgs<BodyRelationType, FirstArg> parameters)
         : HessianCorrectionMatrix(parameters.identifier_, std::get<0>(parameters.others_)){};
-    virtual ~HessianCorrectionMatrix() {};
+    virtual ~HessianCorrectionMatrix(){};
 
     class InteractKernel : public BaseDynamicsType::InteractKernel
     {
@@ -166,8 +169,9 @@ class HessianCorrectionMatrix<Contact<Parameters...>>
     using BaseDynamicsType = HessianCorrectionMatrix<Base, Contact<Parameters...>>;
 
   public:
-    explicit HessianCorrectionMatrix(Contact<Parameters...> &contact_relation);
-    virtual ~HessianCorrectionMatrix() {};
+    template <class DynamicsIdentifier>
+    explicit HessianCorrectionMatrix(DynamicsIdentifier &identifier);
+    virtual ~HessianCorrectionMatrix(){};
 
     class InteractKernel : public BaseDynamicsType::InteractKernel
     {

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.hpp
@@ -47,9 +47,10 @@ void DisplacementMatrixGradient<Inner<Parameters...>>::
 }
 //=================================================================================================//
 template <typename... Parameters>
+template <class DynamicsIdentifier>
 DisplacementMatrixGradient<Contact<Parameters...>>::
-    DisplacementMatrixGradient(Contact<Parameters...> &contact_relation)
-    : BaseDynamicsType(contact_relation) {}
+    DisplacementMatrixGradient(DynamicsIdentifier &identifier)
+    : BaseDynamicsType(identifier) {}
 //=================================================================================================//
 template <typename... Parameters>
 void DisplacementMatrixGradient<Contact<Parameters...>>::
@@ -102,9 +103,10 @@ void HessianCorrectionMatrix<Inner<WithUpdate, Parameters...>>::
 }
 //=================================================================================================//
 template <typename... Parameters>
+template <class DynamicsIdentifier>
 HessianCorrectionMatrix<Contact<Parameters...>>::
-    HessianCorrectionMatrix(Contact<Parameters...> &contact_relation)
-    : BaseDynamicsType(contact_relation) {}
+    HessianCorrectionMatrix(DynamicsIdentifier &identifier)
+    : BaseDynamicsType(identifier) {}
 //=================================================================================================//
 template <typename... Parameters>
 void HessianCorrectionMatrix<Contact<Parameters...>>::

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.h
@@ -52,13 +52,15 @@ template <typename DataType, typename... Parameters>
 class Interpolation<Contact<Base, DataType, Parameters...>> : public Interaction<Contact<Parameters...>>
 {
   public:
-    Interpolation(Contact<Parameters...> &pair_contact_relation, const std::string &variable_name);
-    Interpolation(Contact<Parameters...> &pair_contact_relation,
+    template <class DynamicsIdentifier>
+    Interpolation(DynamicsIdentifier &identifier, const std::string &variable_name);
+    template <class DynamicsIdentifier>
+    Interpolation(DynamicsIdentifier &identifier,
                   const std::string &variable_name, const std::string &entry_name);
     template <typename BodyRelationType, typename FirstArg>
     explicit Interpolation(DynamicsArgs<BodyRelationType, FirstArg> parameters)
         : Interpolation(parameters.identifier_, std::get<0>(parameters.others_)){};
-    virtual ~Interpolation() {};
+    virtual ~Interpolation(){};
     DiscreteVariable<DataType> *dvInterpolatedQuantities() { return dv_interpolated_quantities_; };
 
   protected:
@@ -134,7 +136,7 @@ class ObservingQuantityCK : public InteractionDynamicsCK<ExecutionPolicy, Interp
   public:
     template <typename... Args>
     ObservingQuantityCK(Args &&...args) : BaseDynamicsType(std::forward<Args>(args)...){};
-    virtual ~ObservingQuantityCK() {};
+    virtual ~ObservingQuantityCK(){};
 };
 } // namespace SPH
 #endif // INTERPOLATION_DYNAMICS_H

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.hpp
@@ -7,9 +7,10 @@ namespace SPH
 {
 //=================================================================================================//
 template <typename DataType, typename... Parameters>
+template <class DynamicsIdentifier>
 Interpolation<Contact<Base, DataType, Parameters...>>::Interpolation(
-    Contact<Parameters...> &pair_contact_relation, const std::string &variable_name)
-    : Interaction<Contact<Parameters...>>(pair_contact_relation),
+    DynamicsIdentifier &identifier, const std::string &variable_name)
+    : Interaction<Contact<Parameters...>>(identifier),
       dv_interpolated_quantities_(this->particles_->template registerStateVariable<DataType>(variable_name))
 {
     if (this->contact_particles_.size() > 1)
@@ -22,9 +23,10 @@ Interpolation<Contact<Base, DataType, Parameters...>>::Interpolation(
 }
 //=================================================================================================//
 template <typename DataType, typename... Parameters>
+template <class DynamicsIdentifier>
 Interpolation<Contact<Base, DataType, Parameters...>>::Interpolation(
-    Contact<Parameters...> &pair_contact_relation, const std::string &variable_name, const std::string &entry_name)
-    : Interpolation(pair_contact_relation, variable_name)
+    DynamicsIdentifier &identifier, const std::string &variable_name, const std::string &entry_name)
+    : Interpolation(identifier, variable_name)
 {
     dv_interpolated_quantities_->setName(variable_name + entry_name);
     entry_ = dv_contact_data_[0]->getEntryIndexByName(entry_name);

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.h
@@ -50,7 +50,7 @@ class LinearCorrectionMatrix<Base, RelationType<Parameters...>>
   public:
     template <class DynamicsIdentifier>
     explicit LinearCorrectionMatrix(DynamicsIdentifier &identifier);
-    virtual ~LinearCorrectionMatrix() {};
+    virtual ~LinearCorrectionMatrix(){};
 
     class InteractKernel
         : public Interaction<RelationType<Parameters...>>::InteractKernel
@@ -76,12 +76,13 @@ class LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>>
 {
 
   public:
-    explicit LinearCorrectionMatrix(Inner<Parameters...> &inner_relation, Real alpha = Real(0))
-        : LinearCorrectionMatrix<Base, Inner<Parameters...>>(inner_relation), alpha_(alpha) {};
+    template <class DynamicsIdentifier>
+    explicit LinearCorrectionMatrix(DynamicsIdentifier &identifier, Real alpha = Real(0))
+        : LinearCorrectionMatrix<Base, Inner<Parameters...>>(identifier), alpha_(alpha){};
     template <typename BodyRelationType, typename FirstArg>
     explicit LinearCorrectionMatrix(DynamicsArgs<BodyRelationType, FirstArg> parameters)
         : LinearCorrectionMatrix(parameters.identifier_, std::get<0>(parameters.others_)){};
-    virtual ~LinearCorrectionMatrix() {};
+    virtual ~LinearCorrectionMatrix(){};
 
     class InteractKernel
         : public LinearCorrectionMatrix<Base, Inner<Parameters...>>::InteractKernel
@@ -116,8 +117,9 @@ class LinearCorrectionMatrix<Contact<Parameters...>>
     : public LinearCorrectionMatrix<Base, Contact<Parameters...>>
 {
   public:
-    explicit LinearCorrectionMatrix(Contact<Parameters...> &contact_relation);
-    virtual ~LinearCorrectionMatrix() {};
+    template <class DynamicsIdentifier>
+    explicit LinearCorrectionMatrix(DynamicsIdentifier &identifier);
+    virtual ~LinearCorrectionMatrix(){};
 
     class InteractKernel
         : public LinearCorrectionMatrix<Base, Contact<Parameters...>>::InteractKernel
@@ -140,7 +142,7 @@ class NoKernelCorrectionCK : public KernelCorrection
 {
   public:
     typedef Real CorrectionDataType;
-    NoKernelCorrectionCK(BaseParticles *particles) : KernelCorrection() {};
+    NoKernelCorrectionCK(BaseParticles *particles) : KernelCorrection(){};
 
     class ComputingKernel : public ParameterFixed<Real>
     {
@@ -158,7 +160,7 @@ class LinearCorrectionCK : public KernelCorrection
     typedef Matd CorrectionDataType;
     LinearCorrectionCK(BaseParticles *particles)
         : KernelCorrection(),
-          dv_B_(particles->getVariableByName<Matd>("LinearCorrectionMatrix")) {};
+          dv_B_(particles->getVariableByName<Matd>("LinearCorrectionMatrix")){};
 
     class ComputingKernel : public ParameterVariable<Matd>
     {

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.hpp
@@ -66,9 +66,10 @@ void LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>>::
 }
 //=================================================================================================//
 template <typename... Parameters>
+template <class DynamicsIdentifier>
 LinearCorrectionMatrix<Contact<Parameters...>>::
-    LinearCorrectionMatrix(Contact<Parameters...> &contact_relation)
-    : LinearCorrectionMatrix<Base, Contact<Parameters...>>(contact_relation) {}
+    LinearCorrectionMatrix(DynamicsIdentifier &identifier)
+    : LinearCorrectionMatrix<Base, Contact<Parameters...>>(identifier) {}
 //=================================================================================================//
 template <typename... Parameters>
 template <class ExecutionPolicy>

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_gradient_integral.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_gradient_integral.h
@@ -57,7 +57,8 @@ class KernelGradientIntegral<Inner<KernelCorrectionType, Parameters...>>
     using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
 
   public:
-    explicit KernelGradientIntegral(Inner<Parameters...> &inner_relation);
+    template <class DynamicsIdentifier>
+    explicit KernelGradientIntegral(DynamicsIdentifier &identifier);
     virtual ~KernelGradientIntegral() {}
 
     class InteractKernel : public BaseInteraction::InteractKernel
@@ -85,7 +86,8 @@ class KernelGradientIntegral<Contact<Boundary, KernelCorrectionType, Parameters.
     using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
 
   public:
-    explicit KernelGradientIntegral(Contact<Parameters...> &contact_relation);
+    template <class DynamicsIdentifier>
+    explicit KernelGradientIntegral(DynamicsIdentifier &identifier);
     virtual ~KernelGradientIntegral() {}
 
     class InteractKernel : public BaseInteraction::InteractKernel

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_gradient_integral.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_gradient_integral.hpp
@@ -14,9 +14,10 @@ KernelGradientIntegralBase<BaseInteractionType>::KernelGradientIntegralBase(Dyna
           this->particles_->template registerStateVariable<Vecd>("KernelGradientIntegral")) {}
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
+template <class DynamicsIdentifier>
 KernelGradientIntegral<Inner<KernelCorrectionType, Parameters...>>::KernelGradientIntegral(
-    Inner<Parameters...> &inner_relation)
-    : KernelGradientIntegralBase<Interaction<Inner<Parameters...>>>(inner_relation),
+    DynamicsIdentifier &identifier)
+    : KernelGradientIntegralBase<Interaction<Inner<Parameters...>>>(identifier),
       kernel_correction_(this->particles_)
 {
     static_assert(std::is_base_of<KernelCorrection, KernelCorrectionType>::value,
@@ -48,9 +49,10 @@ void KernelGradientIntegral<Inner<KernelCorrectionType, Parameters...>>::
 }
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
+template <class DynamicsIdentifier>
 KernelGradientIntegral<Contact<Boundary, KernelCorrectionType, Parameters...>>::
-    KernelGradientIntegral(Contact<Parameters...> &contact_relation)
-    : KernelGradientIntegralBase<Interaction<Contact<Parameters...>>>(contact_relation),
+    KernelGradientIntegral(DynamicsIdentifier &identifier)
+    : KernelGradientIntegralBase<Interaction<Contact<Parameters...>>>(identifier),
       kernel_correction_(this->particles_)
 {
     static_assert(std::is_base_of<KernelCorrection, KernelCorrectionType>::value,

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/surface_indication/surface_indication_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/surface_indication/surface_indication_ck.h
@@ -80,7 +80,8 @@ class FreeSurfaceIndicationCK<Inner<WithUpdate, Parameters...>>
     : public FreeSurfaceIndicationCK<Base, Inner<Parameters...>>
 {
   public:
-    explicit FreeSurfaceIndicationCK(Inner<Parameters...> &inner_relation);
+    template <class DynamicsIdentifier>
+    explicit FreeSurfaceIndicationCK(DynamicsIdentifier &identifier);
     virtual ~FreeSurfaceIndicationCK() {}
 
     //------------------------------------------------------------------------------------------//
@@ -139,7 +140,8 @@ class FreeSurfaceIndicationCK<Contact<Parameters...>>
     : public FreeSurfaceIndicationCK<Base, Contact<Parameters...>>
 {
   public:
-    explicit FreeSurfaceIndicationCK(Contact<Parameters...> &contact_relation);
+    template <class DynamicsIdentifier>
+    explicit FreeSurfaceIndicationCK(DynamicsIdentifier &identifier);
     virtual ~FreeSurfaceIndicationCK() {}
 
     //------------------------------------------------------------------------------------------//

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/surface_indication/surface_indication_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/surface_indication/surface_indication_ck.hpp
@@ -33,9 +33,10 @@ FreeSurfaceIndicationCK<Base, RelationType<Parameters...>>::InteractKernel::
       smoothing_length_(encloser.dv_smoothing_length_) {}
 //=================================================================================================//
 template <typename... Parameters>
+template <class DynamicsIdentifier>
 FreeSurfaceIndicationCK<Inner<WithUpdate, Parameters...>>::
-    FreeSurfaceIndicationCK(Inner<Parameters...> &inner_relation)
-    : FreeSurfaceIndicationCK<Base, Inner<Parameters...>>(inner_relation),
+    FreeSurfaceIndicationCK(DynamicsIdentifier &identifier)
+    : FreeSurfaceIndicationCK<Base, Inner<Parameters...>>(identifier),
       dv_previous_surface_indicator_(
           this->particles_->template registerStateVariable<int>("PreviousSurfaceIndicator", 1))
 {
@@ -128,9 +129,10 @@ bool FreeSurfaceIndicationCK<Inner<WithUpdate, Parameters...>>::UpdateKernel::
 }
 //=================================================================================================//
 template <typename... Parameters>
+template <class DynamicsIdentifier>
 FreeSurfaceIndicationCK<Contact<Parameters...>>::
-    FreeSurfaceIndicationCK(Contact<Parameters...> &contact_relation)
-    : FreeSurfaceIndicationCK<Base, Contact<Parameters...>>(contact_relation) {}
+    FreeSurfaceIndicationCK(DynamicsIdentifier &identifier)
+    : FreeSurfaceIndicationCK<Base, Contact<Parameters...>>(identifier) {}
 //=================================================================================================//
 template <typename... Parameters>
 template <class ExecutionPolicy>

--- a/src/shared/shared_ck/particle_dynamics/interaction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/interaction_ck.h
@@ -102,6 +102,10 @@ class Interaction<Contact<Parameters...>>
 
   public:
     explicit Interaction(ContactRelationType &contact_relation);
+    template <class TargetIdentifier>
+    Interaction(ContactRelationType &contact_relation, const StdVec<TargetIdentifier *> &target_identifiers);
+    template <class TargetIdentifier>
+    Interaction(ContactRelationType &contact_relation, TargetIdentifier &target_identifiers);
     virtual ~Interaction(){};
 
     ContactRelationType &getRelation() { return *contact_relation_; }
@@ -129,6 +133,9 @@ class Interaction<Contact<Parameters...>>
     StdVec<SPHAdaptation *> contact_adaptations_;
     DiscreteVariable<Real> *dv_Vol_;
     StdVec<DiscreteVariable<Real> *> dv_contact_Vol_;
+    StdVec<UnsignedInt> contact_target_indices_;
+
+    UnsignedInt getContactIndex(UnsignedInt target_index);
 };
 
 template <>

--- a/src/shared/shared_ck/particle_dynamics/interaction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/interaction_ck.h
@@ -69,7 +69,10 @@ class Interaction<Inner<Parameters...>>
 
   public:
     explicit Interaction(InnerRelationType &inner_relation);
-    virtual ~Interaction() {};
+    virtual ~Interaction(){};
+
+    InnerRelationType &getRelation() { return *inner_relation_; }
+    const InnerRelationType &getRelation() const { return *inner_relation_; }
 
     class InteractKernel : public NeighborList, public NeighborKernel
     {
@@ -99,7 +102,13 @@ class Interaction<Contact<Parameters...>>
 
   public:
     explicit Interaction(ContactRelationType &contact_relation);
-    virtual ~Interaction() {};
+    virtual ~Interaction(){};
+
+    ContactRelationType &getRelation() { return *contact_relation_; }
+    const ContactRelationType &getRelation() const { return *contact_relation_; }
+    const StdVec<SPHBody *> &getContactBodies() const { return contact_bodies_; }
+    const StdVec<BaseParticles *> &getContactParticles() const { return contact_particles_; }
+    const StdVec<SPHAdaptation *> &getContactAdaptations() const { return contact_adaptations_; }
 
     class InteractKernel : public NeighborList, public NeighborKernel
     {
@@ -128,7 +137,7 @@ class Interaction<Wall>
   public:
     template <class WallContactRelationType>
     Interaction(WallContactRelationType &wall_contact_relation);
-    virtual ~Interaction() {};
+    virtual ~Interaction(){};
 
   protected:
     StdVec<DiscreteVariable<Vecd> *> dv_wall_vel_ave_, dv_wall_acc_ave_, dv_wall_n_;

--- a/src/shared/shared_ck/particle_dynamics/interaction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/interaction_ck.h
@@ -138,6 +138,30 @@ class Interaction<Contact<Parameters...>>
     UnsignedInt getContactIndex(UnsignedInt target_index);
 };
 
+template <typename... P, typename... Args>
+auto makeInteraction(Inner<P...> &relation, Args &&...args)
+{
+    return Interaction<Inner<P...>>(relation, std::forward<Args>(args)...);
+}
+
+template <typename... P, typename... Args>
+auto makeInteraction(Contact<P...> &relation, Args &&...args)
+{
+    return Interaction<Contact<P...>>(relation, std::forward<Args>(args)...);
+}
+
+template <typename... P>
+Interaction<Inner<P...>> &asInteraction(Interaction<Inner<P...>> &view)
+{
+    return view;
+}
+
+template <typename... P>
+Interaction<Contact<P...>> &asInteraction(Interaction<Contact<P...>> &view)
+{
+    return view;
+}
+
 template <>
 class Interaction<Wall>
 {

--- a/src/shared/shared_ck/particle_dynamics/interaction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/interaction_ck.h
@@ -71,9 +71,6 @@ class Interaction<Inner<Parameters...>>
     explicit Interaction(InnerRelationType &inner_relation);
     virtual ~Interaction(){};
 
-    InnerRelationType &getRelation() { return *inner_relation_; }
-    const InnerRelationType &getRelation() const { return *inner_relation_; }
-
     class InteractKernel : public NeighborList, public NeighborKernel
     {
       public:
@@ -101,18 +98,9 @@ class Interaction<Contact<Parameters...>>
     using NeighborKernel = typename Neighborhood::NeighborKernel;
 
   public:
+    explicit Interaction(const RelationView<ContactRelationType> &contact_relation_view);
     explicit Interaction(ContactRelationType &contact_relation);
-    template <class TargetIdentifier>
-    Interaction(ContactRelationType &contact_relation, const StdVec<TargetIdentifier *> &target_identifiers);
-    template <class TargetIdentifier>
-    Interaction(ContactRelationType &contact_relation, TargetIdentifier &target_identifiers);
     virtual ~Interaction(){};
-
-    ContactRelationType &getRelation() { return *contact_relation_; }
-    const ContactRelationType &getRelation() const { return *contact_relation_; }
-    const StdVec<SPHBody *> &getContactBodies() const { return contact_bodies_; }
-    const StdVec<BaseParticles *> &getContactParticles() const { return contact_particles_; }
-    const StdVec<SPHAdaptation *> &getContactAdaptations() const { return contact_adaptations_; }
 
     class InteractKernel : public NeighborList, public NeighborKernel
     {
@@ -127,40 +115,13 @@ class Interaction<Contact<Parameters...>>
     void resetComputingKernelUpdated(UnsignedInt contact_index);
 
   protected:
-    ContactRelationType *contact_relation_;
+    RelationView<ContactRelationType> contact_relation_view_;
     StdVec<SPHBody *> contact_bodies_;
     StdVec<BaseParticles *> contact_particles_;
     StdVec<SPHAdaptation *> contact_adaptations_;
     DiscreteVariable<Real> *dv_Vol_;
     StdVec<DiscreteVariable<Real> *> dv_contact_Vol_;
-    StdVec<UnsignedInt> contact_target_indices_;
-
-    UnsignedInt getContactIndex(UnsignedInt target_index);
 };
-
-template <typename... P, typename... Args>
-auto makeInteraction(Inner<P...> &relation, Args &&...args)
-{
-    return Interaction<Inner<P...>>(relation, std::forward<Args>(args)...);
-}
-
-template <typename... P, typename... Args>
-auto makeInteraction(Contact<P...> &relation, Args &&...args)
-{
-    return Interaction<Contact<P...>>(relation, std::forward<Args>(args)...);
-}
-
-template <typename... P>
-Interaction<Inner<P...>> &asInteraction(Interaction<Inner<P...>> &view)
-{
-    return view;
-}
-
-template <typename... P>
-Interaction<Contact<P...>> &asInteraction(Interaction<Contact<P...>> &view)
-{
-    return view;
-}
 
 template <>
 class Interaction<Wall>

--- a/src/shared/shared_ck/particle_dynamics/interaction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/interaction_ck.hpp
@@ -5,6 +5,9 @@
 
 #include "base_material.h"
 
+#include <cstdlib>
+#include <iostream>
+
 namespace SPH
 {
 //=================================================================================================//
@@ -36,8 +39,7 @@ Interaction<Inner<Parameters...>>::InteractKernel::
       NeighborKernel(ex_policy, encloser.inner_relation_->getNeighborhood()) {}
 //=================================================================================================//
 template <typename... Parameters>
-Interaction<Contact<Parameters...>>::
-    Interaction(ContactRelationType &contact_relation)
+Interaction<Contact<Parameters...>>::Interaction(ContactRelationType &contact_relation)
     : BaseLocalDynamicsType(contact_relation.getSourceIdentifier()),
       contact_relation_(&contact_relation),
       contact_bodies_(contact_relation.getContactBodies()),
@@ -45,32 +47,85 @@ Interaction<Contact<Parameters...>>::
       contact_adaptations_(contact_relation.getContactAdaptations()),
       dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure"))
 {
-    for (auto &particles : contact_particles_)
+    for (size_t j = 0; j != contact_particles_.size(); ++j)
     {
         dv_contact_Vol_.push_back(
-            particles->template getVariableByName<Real>("VolumetricMeasure"));
+            contact_particles_[j]->template getVariableByName<Real>("VolumetricMeasure"));
+        contact_target_indices_.push_back(j);
     }
 }
 //=================================================================================================//
 template <typename... Parameters>
-void Interaction<Contact<Parameters...>>::
-    registerComputingKernel(Implementation<Base> *implementation, UnsignedInt contact_index)
+template <class TargetIdentifier>
+Interaction<Contact<Parameters...>>::Interaction(
+    ContactRelationType &contact_relation, const StdVec<TargetIdentifier *> &target_identifiers)
+    : BaseLocalDynamicsType(contact_relation.getSourceIdentifier()),
+      contact_relation_(&contact_relation),
+      dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure"))
 {
-    contact_relation_->registerComputingKernel(implementation, contact_index);
+    StdVec<SPHBody *> all_contact_bodies = contact_relation.getContactBodies();
+    StdVec<BaseParticles *> all_contact_particles = contact_relation.getContactParticles();
+    StdVec<SPHAdaptation *> all_contact_adaptations = contact_relation.getContactAdaptations();
+    for (size_t k = 0; k != target_identifiers.size(); ++k)
+    {
+        TargetIdentifier *target_identifier = target_identifiers[k];
+        bool target_found = false;
+        for (size_t j = 0; j != all_contact_bodies.size(); ++j)
+        {
+            if (all_contact_bodies[j]->Name() == target_identifier->Name())
+            {
+                contact_bodies_.push_back(all_contact_bodies[j]);
+                contact_particles_.push_back(all_contact_particles[j]);
+                contact_adaptations_.push_back(all_contact_adaptations[j]);
+                contact_target_indices_.push_back(j);
+                dv_contact_Vol_.push_back(
+                    all_contact_particles[j]->template getVariableByName<Real>("VolumetricMeasure"));
+                target_found = true;
+                break;
+            }
+        }
+
+        if (!target_found)
+        {
+            std::cout << "Error: target body " << target_identifier->Name()
+                      << " is not found in contact relation " << contact_relation.Name() << std::endl;
+            std::exit(1);
+        }
+    }
 }
 //=================================================================================================//
 template <typename... Parameters>
-void Interaction<Contact<Parameters...>>::resetComputingKernelUpdated(UnsignedInt contact_index)
+template <class TargetIdentifier>
+Interaction<Contact<Parameters...>>::Interaction(
+    ContactRelationType &contact_relation, TargetIdentifier &target_identifiers)
+    : Interaction(contact_relation, StdVec<TargetIdentifier *>({&target_identifiers})) {}
+//=================================================================================================//
+template <typename... Parameters>
+void Interaction<Contact<Parameters...>>::
+    registerComputingKernel(Implementation<Base> *implementation, UnsignedInt target_index)
 {
-    contact_relation_->resetComputingKernelUpdated(contact_index);
+    contact_relation_->registerComputingKernel(implementation, getContactIndex(target_index));
+}
+//=================================================================================================//
+template <typename... Parameters>
+void Interaction<Contact<Parameters...>>::resetComputingKernelUpdated(UnsignedInt target_index)
+{
+    contact_relation_->resetComputingKernelUpdated(getContactIndex(target_index));
+}
+//=================================================================================================//
+template <typename... Parameters>
+UnsignedInt Interaction<Contact<Parameters...>>::getContactIndex(UnsignedInt target_index)
+{
+    return contact_target_indices_[target_index];
 }
 //=================================================================================================//
 template <typename... Parameters>
 template <class ExecutionPolicy, class EncloserType>
 Interaction<Contact<Parameters...>>::InteractKernel::
-    InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt contact_index)
-    : NeighborList(ex_policy, *encloser.contact_relation_, contact_index),
-      NeighborKernel(ex_policy, encloser.contact_relation_->getNeighborhood(contact_index)) {}
+    InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt target_index)
+    : NeighborList(ex_policy, *encloser.contact_relation_, encloser.getContactIndex(target_index)),
+      NeighborKernel(ex_policy, encloser.contact_relation_
+                                    ->getNeighborhood(encloser.getContactIndex(target_index))) {}
 //=================================================================================================//
 template <class WallContactRelationType>
 Interaction<Wall>::Interaction(WallContactRelationType &wall_contact_relation)

--- a/src/shared/shared_ck/particle_dynamics/interaction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/interaction_ck.hpp
@@ -5,9 +5,6 @@
 
 #include "base_material.h"
 
-#include <cstdlib>
-#include <iostream>
-
 namespace SPH
 {
 //=================================================================================================//
@@ -39,93 +36,45 @@ Interaction<Inner<Parameters...>>::InteractKernel::
       NeighborKernel(ex_policy, encloser.inner_relation_->getNeighborhood()) {}
 //=================================================================================================//
 template <typename... Parameters>
-Interaction<Contact<Parameters...>>::Interaction(ContactRelationType &contact_relation)
-    : BaseLocalDynamicsType(contact_relation.getSourceIdentifier()),
-      contact_relation_(&contact_relation),
-      contact_bodies_(contact_relation.getContactBodies()),
-      contact_particles_(contact_relation.getContactParticles()),
-      contact_adaptations_(contact_relation.getContactAdaptations()),
+Interaction<Contact<Parameters...>>::Interaction(
+    const RelationView<Contact<Parameters...>> &contact_relation_view)
+    : BaseLocalDynamicsType(contact_relation_view.getContactRelation().getSourceIdentifier()),
+      contact_relation_view_(contact_relation_view),
+      contact_bodies_(contact_relation_view.getContactBodies()),
+      contact_particles_(contact_relation_view.getContactParticles()),
+      contact_adaptations_(contact_relation_view.getContactAdaptations()),
       dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure"))
 {
-    for (size_t j = 0; j != contact_particles_.size(); ++j)
+    for (auto &particles : contact_particles_)
     {
         dv_contact_Vol_.push_back(
-            contact_particles_[j]->template getVariableByName<Real>("VolumetricMeasure"));
-        contact_target_indices_.push_back(j);
+            particles->template getVariableByName<Real>("VolumetricMeasure"));
     }
 }
 //=================================================================================================//
 template <typename... Parameters>
-template <class TargetIdentifier>
-Interaction<Contact<Parameters...>>::Interaction(
-    ContactRelationType &contact_relation, const StdVec<TargetIdentifier *> &target_identifiers)
-    : BaseLocalDynamicsType(contact_relation.getSourceIdentifier()),
-      contact_relation_(&contact_relation),
-      dv_Vol_(this->particles_->template getVariableByName<Real>("VolumetricMeasure"))
-{
-    StdVec<SPHBody *> all_contact_bodies = contact_relation.getContactBodies();
-    StdVec<BaseParticles *> all_contact_particles = contact_relation.getContactParticles();
-    StdVec<SPHAdaptation *> all_contact_adaptations = contact_relation.getContactAdaptations();
-    for (size_t k = 0; k != target_identifiers.size(); ++k)
-    {
-        TargetIdentifier *target_identifier = target_identifiers[k];
-        bool target_found = false;
-        for (size_t j = 0; j != all_contact_bodies.size(); ++j)
-        {
-            if (all_contact_bodies[j]->Name() == target_identifier->Name())
-            {
-                contact_bodies_.push_back(all_contact_bodies[j]);
-                contact_particles_.push_back(all_contact_particles[j]);
-                contact_adaptations_.push_back(all_contact_adaptations[j]);
-                contact_target_indices_.push_back(j);
-                dv_contact_Vol_.push_back(
-                    all_contact_particles[j]->template getVariableByName<Real>("VolumetricMeasure"));
-                target_found = true;
-                break;
-            }
-        }
-
-        if (!target_found)
-        {
-            std::cout << "Error: target body " << target_identifier->Name()
-                      << " is not found in contact relation " << contact_relation.Name() << std::endl;
-            std::exit(1);
-        }
-    }
-}
-//=================================================================================================//
-template <typename... Parameters>
-template <class TargetIdentifier>
-Interaction<Contact<Parameters...>>::Interaction(
-    ContactRelationType &contact_relation, TargetIdentifier &target_identifiers)
-    : Interaction(contact_relation, StdVec<TargetIdentifier *>({&target_identifiers})) {}
+Interaction<Contact<Parameters...>>::Interaction(Contact<Parameters...> &contact_relation)
+    : Interaction(RelationView<Contact<Parameters...>>(contact_relation)) {}
 //=================================================================================================//
 template <typename... Parameters>
 void Interaction<Contact<Parameters...>>::
-    registerComputingKernel(Implementation<Base> *implementation, UnsignedInt target_index)
+    registerComputingKernel(Implementation<Base> *implementation, UnsignedInt contact_index)
 {
-    contact_relation_->registerComputingKernel(implementation, getContactIndex(target_index));
+    contact_relation_view_.registerComputingKernel(implementation, contact_index);
 }
 //=================================================================================================//
 template <typename... Parameters>
-void Interaction<Contact<Parameters...>>::resetComputingKernelUpdated(UnsignedInt target_index)
+void Interaction<Contact<Parameters...>>::resetComputingKernelUpdated(UnsignedInt contact_index)
 {
-    contact_relation_->resetComputingKernelUpdated(getContactIndex(target_index));
-}
-//=================================================================================================//
-template <typename... Parameters>
-UnsignedInt Interaction<Contact<Parameters...>>::getContactIndex(UnsignedInt target_index)
-{
-    return contact_target_indices_[target_index];
+    contact_relation_view_.resetComputingKernelUpdated(contact_index);
 }
 //=================================================================================================//
 template <typename... Parameters>
 template <class ExecutionPolicy, class EncloserType>
 Interaction<Contact<Parameters...>>::InteractKernel::
-    InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt target_index)
-    : NeighborList(ex_policy, *encloser.contact_relation_, encloser.getContactIndex(target_index)),
-      NeighborKernel(ex_policy, encloser.contact_relation_
-                                    ->getNeighborhood(encloser.getContactIndex(target_index))) {}
+    InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser, UnsignedInt contact_index)
+    : NeighborList(encloser.contact_relation_view_.getNeighborList(ex_policy, contact_index)),
+      NeighborKernel(ex_policy, encloser.contact_relation_view_.getNeighborhood(contact_index)) {}
 //=================================================================================================//
 template <class WallContactRelationType>
 Interaction<Wall>::Interaction(WallContactRelationType &wall_contact_relation)

--- a/src/shared/shared_ck/particle_dynamics/particle_method_container.h
+++ b/src/shared/shared_ck/particle_dynamics/particle_method_container.h
@@ -49,10 +49,10 @@ class ParticleDynamicsGroup : public BaseDynamics<void>
     StdVec<BaseDynamics<void> *> particle_dynamics_;
 
   public:
-    ParticleDynamicsGroup() : BaseDynamics<void>() {};
+    ParticleDynamicsGroup() : BaseDynamics<void>(){};
     ParticleDynamicsGroup(const StdVec<BaseDynamics<void> *> &particle_dynamics)
         : BaseDynamics<void>(), particle_dynamics_(particle_dynamics) {}
-    ~ParticleDynamicsGroup() {};
+    ~ParticleDynamicsGroup(){};
 
     bool hasDynamics() const
     {
@@ -168,7 +168,7 @@ class IODynamicsGroup : public BaseIO
     StdVec<BaseIO *> io_dynamics_;
 
   public:
-    IODynamicsGroup(SPHSystem &sph_system) : BaseIO(sph_system) {};
+    IODynamicsGroup(SPHSystem &sph_system) : BaseIO(sph_system){};
     ~IODynamicsGroup() = default;
 
     IODynamicsGroup &add(BaseIO *io_dynamics)
@@ -194,7 +194,7 @@ class IODynamicsGroup : public BaseIO
 class BaseMethodContainer
 {
   public:
-    virtual ~BaseMethodContainer() {};
+    virtual ~BaseMethodContainer(){};
 };
 
 template <typename ExecutionPolicy>
@@ -205,8 +205,8 @@ class ParticleMethodContainer : public BaseMethodContainer
     UniquePtrsKeeper<BaseIO> other_io_keeper_;
 
   public:
-    ParticleMethodContainer(const ExecutionPolicy &ex_policy) : BaseMethodContainer() {};
-    virtual ~ParticleMethodContainer() {};
+    ParticleMethodContainer(const ExecutionPolicy &ex_policy) : BaseMethodContainer(){};
+    virtual ~ParticleMethodContainer(){};
 
     ParticleDynamicsGroup &addParticleDynamicsGroup()
     {
@@ -369,6 +369,17 @@ class ParticleMethodContainer : public BaseMethodContainer
 
     template <template <typename...> class InteractionType, typename... ControlParameters,
               template <typename...> class RelationType, typename... RelationParameters, typename... Args>
+    auto &addInteractionDynamics(
+        Interaction<RelationType<RelationParameters...>> &interaction, Args &&...args)
+    {
+        return *particle_dynamics_keeper_.createPtr<
+            InteractionDynamicsCK<
+                ExecutionPolicy, InteractionType<RelationType<ControlParameters..., RelationParameters...>>>>(
+            interaction, std::forward<Args>(args)...);
+    };
+
+    template <template <typename...> class InteractionType, typename... ControlParameters,
+              template <typename...> class RelationType, typename... RelationParameters, typename... Args>
     auto &addInteractionDynamicsOneLevel(
         RelationType<RelationParameters...> &relation, Args &&...args)
     {
@@ -376,6 +387,17 @@ class ParticleMethodContainer : public BaseMethodContainer
             InteractionDynamicsCK<
                 ExecutionPolicy, InteractionType<RelationType<OneLevel, ControlParameters..., RelationParameters...>>>>(
             relation, std::forward<Args>(args)...);
+    };
+
+    template <template <typename...> class InteractionType, typename... ControlParameters,
+              template <typename...> class RelationType, typename... RelationParameters, typename... Args>
+    auto &addInteractionDynamicsOneLevel(
+        Interaction<RelationType<RelationParameters...>> &interaction, Args &&...args)
+    {
+        return *particle_dynamics_keeper_.createPtr<
+            InteractionDynamicsCK<
+                ExecutionPolicy, InteractionType<RelationType<OneLevel, ControlParameters..., RelationParameters...>>>>(
+            interaction, std::forward<Args>(args)...);
     };
 
     template <template <typename...> class InteractionType, typename... ControlParameters,
@@ -391,6 +413,17 @@ class ParticleMethodContainer : public BaseMethodContainer
 
     template <template <typename...> class InteractionType, typename... ControlParameters,
               template <typename...> class RelationType, typename... RelationParameters, typename... Args>
+    auto &addInteractionDynamicsWithUpdate(
+        Interaction<RelationType<RelationParameters...>> &interaction, Args &&...args)
+    {
+        return *particle_dynamics_keeper_.createPtr<
+            InteractionDynamicsCK<
+                ExecutionPolicy, InteractionType<RelationType<WithUpdate, ControlParameters..., RelationParameters...>>>>(
+            interaction, std::forward<Args>(args)...);
+    };
+
+    template <template <typename...> class InteractionType, typename... ControlParameters,
+              template <typename...> class RelationType, typename... RelationParameters, typename... Args>
     auto &addInteractionDynamicsWithInitialization(
         RelationType<RelationParameters...> &relation, Args &&...args)
     {
@@ -398,6 +431,17 @@ class ParticleMethodContainer : public BaseMethodContainer
             InteractionDynamicsCK<
                 ExecutionPolicy, InteractionType<RelationType<WithInitialization, ControlParameters..., RelationParameters...>>>>(
             relation, std::forward<Args>(args)...);
+    };
+
+    template <template <typename...> class InteractionType, typename... ControlParameters,
+              template <typename...> class RelationType, typename... RelationParameters, typename... Args>
+    auto &addInteractionDynamicsWithInitialization(
+        Interaction<RelationType<RelationParameters...>> &interaction, Args &&...args)
+    {
+        return *particle_dynamics_keeper_.createPtr<
+            InteractionDynamicsCK<
+                ExecutionPolicy, InteractionType<RelationType<WithInitialization, ControlParameters..., RelationParameters...>>>>(
+            interaction, std::forward<Args>(args)...);
     };
 
     template <template <typename...> class InteractionType, typename... ControlParameters,
@@ -411,6 +455,19 @@ class ParticleMethodContainer : public BaseMethodContainer
                 InteractionType<RelationType<OneLevel, RungeKutta1stStage, ControlParameters..., RelationParameters...>>,
                 InteractionType<RelationType<OneLevel, RungeKutta2ndStage, ControlParameters..., RelationParameters...>>>>>(
             relation, std::forward<Args>(args)...);
+    };
+
+    template <template <typename...> class InteractionType, typename... ControlParameters,
+              template <typename...> class RelationType, typename... RelationParameters, typename... Args>
+    auto &addRK2Sequence(
+        Interaction<RelationType<RelationParameters...>> &interaction, Args &&...args)
+    {
+        return *particle_dynamics_keeper_.createPtr<
+            RungeKuttaSequence<InteractionDynamicsCK<
+                ExecutionPolicy,
+                InteractionType<RelationType<OneLevel, RungeKutta1stStage, ControlParameters..., RelationParameters...>>,
+                InteractionType<RelationType<OneLevel, RungeKutta2ndStage, ControlParameters..., RelationParameters...>>>>>(
+            interaction, std::forward<Args>(args)...);
     };
 
     template <template <typename...> class RecorderType, typename... Args>

--- a/src/shared/shared_ck/particle_dynamics/particle_method_container.h
+++ b/src/shared/shared_ck/particle_dynamics/particle_method_container.h
@@ -370,7 +370,7 @@ class ParticleMethodContainer : public BaseMethodContainer
     template <template <typename...> class InteractionType, typename... ControlParameters,
               template <typename...> class RelationType, typename... RelationParameters, typename... Args>
     auto &addInteractionDynamics(
-        Interaction<RelationType<RelationParameters...>> &interaction, Args &&...args)
+        RelationView<RelationType<RelationParameters...>> &interaction, Args &&...args)
     {
         return *particle_dynamics_keeper_.createPtr<
             InteractionDynamicsCK<
@@ -392,7 +392,7 @@ class ParticleMethodContainer : public BaseMethodContainer
     template <template <typename...> class InteractionType, typename... ControlParameters,
               template <typename...> class RelationType, typename... RelationParameters, typename... Args>
     auto &addInteractionDynamicsOneLevel(
-        Interaction<RelationType<RelationParameters...>> &interaction, Args &&...args)
+        RelationView<RelationType<RelationParameters...>> &interaction, Args &&...args)
     {
         return *particle_dynamics_keeper_.createPtr<
             InteractionDynamicsCK<
@@ -414,7 +414,7 @@ class ParticleMethodContainer : public BaseMethodContainer
     template <template <typename...> class InteractionType, typename... ControlParameters,
               template <typename...> class RelationType, typename... RelationParameters, typename... Args>
     auto &addInteractionDynamicsWithUpdate(
-        Interaction<RelationType<RelationParameters...>> &interaction, Args &&...args)
+        RelationView<RelationType<RelationParameters...>> &interaction, Args &&...args)
     {
         return *particle_dynamics_keeper_.createPtr<
             InteractionDynamicsCK<
@@ -436,7 +436,7 @@ class ParticleMethodContainer : public BaseMethodContainer
     template <template <typename...> class InteractionType, typename... ControlParameters,
               template <typename...> class RelationType, typename... RelationParameters, typename... Args>
     auto &addInteractionDynamicsWithInitialization(
-        Interaction<RelationType<RelationParameters...>> &interaction, Args &&...args)
+        RelationView<RelationType<RelationParameters...>> &interaction, Args &&...args)
     {
         return *particle_dynamics_keeper_.createPtr<
             InteractionDynamicsCK<
@@ -460,7 +460,7 @@ class ParticleMethodContainer : public BaseMethodContainer
     template <template <typename...> class InteractionType, typename... ControlParameters,
               template <typename...> class RelationType, typename... RelationParameters, typename... Args>
     auto &addRK2Sequence(
-        Interaction<RelationType<RelationParameters...>> &interaction, Args &&...args)
+        RelationView<RelationType<RelationParameters...>> &interaction, Args &&...args)
     {
         return *particle_dynamics_keeper_.createPtr<
             RungeKuttaSequence<InteractionDynamicsCK<

--- a/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_factor.h
+++ b/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_factor.h
@@ -50,7 +50,7 @@ class RepulsionFactor<Base, Contact<Parameters...>> : public Interaction<Contact
   public:
     template <class DynamicsIdentifier>
     explicit RepulsionFactor(DynamicsIdentifier &identifier, const std::string &factor_name);
-    virtual ~RepulsionFactor() {};
+    virtual ~RepulsionFactor(){};
 
   protected:
     DiscreteVariable<Real> *dv_repulsion_factor_;
@@ -63,8 +63,9 @@ class RepulsionFactor<Contact<Parameters...>>
     using BaseInteractionType = RepulsionFactor<Base, Contact<Parameters...>>;
 
   public:
-    explicit RepulsionFactor(Contact<Parameters...> &contact_relation);
-    virtual ~RepulsionFactor() {};
+    template <class DynamicsIdentifier>
+    explicit RepulsionFactor(DynamicsIdentifier &identifier);
+    virtual ~RepulsionFactor(){};
 
     class InteractKernel : public BaseInteractionType::InteractKernel
     {

--- a/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_factor.hpp
+++ b/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_factor.hpp
@@ -18,9 +18,10 @@ RepulsionFactor<Base, Contact<Parameters...>>::RepulsionFactor(
       dv_repulsion_factor_(this->particles_->template registerStateVariable<Real>(factor_name)) {}
 //=================================================================================================//
 template <typename... Parameters>
+template <class DynamicsIdentifier>
 RepulsionFactor<Contact<Parameters...>>::
-    RepulsionFactor(Contact<Parameters...> &contact_relation)
-    : BaseInteractionType(contact_relation, "RepulsionFactor")
+    RepulsionFactor(DynamicsIdentifier &identifier)
+    : BaseInteractionType(identifier, "RepulsionFactor")
 {
     for (size_t k = 0; k != this->contact_particles_.size(); ++k)
     {

--- a/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_force.h
+++ b/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_force.h
@@ -45,8 +45,9 @@ class RepulsionForceCK<Base, Contact<Parameters...>>
     : public Interaction<Contact<Parameters...>>, public ForcePriorCK
 {
   public:
-    explicit RepulsionForceCK(Contact<Parameters...> &contact_relation, Real numerical_damping = 0.5);
-    virtual ~RepulsionForceCK() {};
+    template <class DynamicsIdentifier>
+    explicit RepulsionForceCK(DynamicsIdentifier &identifier, Real numerical_damping = 0.5);
+    virtual ~RepulsionForceCK(){};
 
   protected:
     SolidContact &solid_contact_;
@@ -65,9 +66,9 @@ class RepulsionForceCK<Contact<WithUpdate, Parameters...>>
     using BaseInteractionType = RepulsionForceCK<Base, Contact<Parameters...>>;
 
   public:
-    template <typename... Args>
-    RepulsionForceCK(Contact<Parameters...> &contact_relation, Args &&...args);
-    virtual ~RepulsionForceCK() {};
+    template <class DynamicsIdentifier, typename... Args>
+    RepulsionForceCK(DynamicsIdentifier &identifier, Args &&...args);
+    virtual ~RepulsionForceCK(){};
 
     class InteractKernel : public BaseInteractionType::InteractKernel
     {
@@ -100,9 +101,9 @@ class RepulsionForceCK<Contact<WithUpdate, Wall, Parameters...>>
     using BaseInteractionType = RepulsionForceCK<Base, Contact<Parameters...>>;
 
   public:
-    template <typename... Args>
-    RepulsionForceCK(Contact<Parameters...> &contact_relation, Args &&...args);
-    virtual ~RepulsionForceCK() {};
+    template <class DynamicsIdentifier, typename... Args>
+    RepulsionForceCK(DynamicsIdentifier &identifier, Args &&...args);
+    virtual ~RepulsionForceCK(){};
 
     class InteractKernel : public BaseInteractionType::InteractKernel
     {

--- a/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_force.hpp
+++ b/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_force.hpp
@@ -10,9 +10,10 @@ namespace solid_dynamics
 {
 //=================================================================================================//
 template <typename... Parameters>
+template <class DynamicsIdentifier>
 RepulsionForceCK<Base, Contact<Parameters...>>::
-    RepulsionForceCK(Contact<Parameters...> &contact_relation, Real numerical_damping)
-    : Interaction<Contact<Parameters...>>(contact_relation),
+    RepulsionForceCK(DynamicsIdentifier &identifier, Real numerical_damping)
+    : Interaction<Contact<Parameters...>>(identifier),
       ForcePriorCK(this->particles_, "RepulsionForce"),
       solid_contact_(DynamicCast<SolidContact>(this, this->sph_body_->getMatterMaterial())),
       numerical_damping_(numerical_damping),
@@ -24,10 +25,10 @@ RepulsionForceCK<Base, Contact<Parameters...>>::
       dv_repulsion_force_(ForcePriorCK::getCurrentForce()) {}
 //=================================================================================================//
 template <typename... Parameters>
-template <typename... Args>
+template <class DynamicsIdentifier, typename... Args>
 RepulsionForceCK<Contact<WithUpdate, Parameters...>>::
-    RepulsionForceCK(Contact<Parameters...> &contact_relation, Args &&...args)
-    : BaseInteractionType(contact_relation, std::forward<Args>(args)...),
+    RepulsionForceCK(DynamicsIdentifier &identifier, Args &&...args)
+    : BaseInteractionType(identifier, std::forward<Args>(args)...),
       dv_n_(this->particles_->template getVariableByName<Vecd>("NormalDirection"))
 {
     for (size_t k = 0; k != this->contact_particles_.size(); ++k)
@@ -86,11 +87,11 @@ void RepulsionForceCK<Contact<WithUpdate, Parameters...>>::
 }
 //=================================================================================================//
 template <typename... Parameters>
-template <typename... Args>
+template <class DynamicsIdentifier, typename... Args>
 RepulsionForceCK<Contact<WithUpdate, Wall, Parameters...>>::
-    RepulsionForceCK(Contact<Parameters...> &contact_relation, Args &&...args)
-    : BaseInteractionType(contact_relation, std::forward<Args>(args)...),
-      Interaction<Wall>(contact_relation) {}
+    RepulsionForceCK(DynamicsIdentifier &identifier, Args &&...args)
+    : BaseInteractionType(identifier, std::forward<Args>(args)...),
+      Interaction<Wall>(identifier) {}
 //=================================================================================================//
 template <typename... Parameters>
 template <class ExecutionPolicy, class EncloserType>

--- a/src/shared/shared_ck/particle_dynamics/solid_dynamics/structure_dynamics.h
+++ b/src/shared/shared_ck/particle_dynamics/solid_dynamics/structure_dynamics.h
@@ -42,7 +42,7 @@ class AcousticTimeStepCK : public LocalDynamicsReduce<ReduceMax>
 {
   public:
     explicit AcousticTimeStepCK(SPHBody &sph_body, Real acousticCFL = 0.6);
-    virtual ~AcousticTimeStepCK() {};
+    virtual ~AcousticTimeStepCK(){};
 
     class FinishDynamics
     {
@@ -78,7 +78,7 @@ class StructureDynamicsVariables
 {
   public:
     explicit StructureDynamicsVariables(BaseParticles *particles);
-    virtual ~StructureDynamicsVariables() {};
+    virtual ~StructureDynamicsVariables(){};
 
   protected:
     DiscreteVariable<Real> *dv_rho_, *dv_mass_;
@@ -91,7 +91,7 @@ class BaseStructureIntegration1stHalf : public StructureDynamicsVariables
 {
   public:
     explicit BaseStructureIntegration1stHalf(BaseParticles *particles);
-    virtual ~BaseStructureIntegration1stHalf() {};
+    virtual ~BaseStructureIntegration1stHalf(){};
 
     class UpdateKernel
     {
@@ -123,8 +123,9 @@ class StructureIntegration1stHalf<Inner<OneLevel, MaterialType, KernelCorrection
     using CorrectionKernel = typename KernelCorrectionType::ComputingKernel;
 
   public:
-    explicit StructureIntegration1stHalf(Inner<Parameters...> &inner_relation, Real numerical_damping_factor = 0.125);
-    virtual ~StructureIntegration1stHalf() {};
+    template <class DynamicsIdentifier>
+    explicit StructureIntegration1stHalf(DynamicsIdentifier &identifier, Real numerical_damping_factor = 0.125);
+    virtual ~StructureIntegration1stHalf(){};
 
     class InitializeKernel
     {
@@ -176,8 +177,9 @@ class StructureIntegration1stHalfPK2<Inner<OneLevel, MaterialType, Parameters...
     using ConstituteKernel = typename MaterialType::ConstituteKernel;
 
   public:
-    explicit StructureIntegration1stHalfPK2(Inner<Parameters...> &inner_relation);
-    virtual ~StructureIntegration1stHalfPK2() {};
+    template <class DynamicsIdentifier>
+    explicit StructureIntegration1stHalfPK2(DynamicsIdentifier &identifier);
+    virtual ~StructureIntegration1stHalfPK2(){};
 
     class InitializeKernel
     {
@@ -222,8 +224,9 @@ class StructureIntegration2ndHalf<Inner<OneLevel, Parameters...>>
     using BaseInteraction = Interaction<Inner<Parameters...>>;
 
   public:
-    explicit StructureIntegration2ndHalf(Inner<Parameters...> &inner_relation);
-    virtual ~StructureIntegration2ndHalf() {};
+    template <class DynamicsIdentifier>
+    explicit StructureIntegration2ndHalf(DynamicsIdentifier &identifier);
+    virtual ~StructureIntegration2ndHalf(){};
 
     class InitializeKernel
     {
@@ -276,8 +279,9 @@ class StructureNumericalDamping<Inner<WithUpdate, MaterialType, Parameters...>>
     using ConstituteKernel = typename MaterialType::ConstituteKernel;
 
   public:
-    explicit StructureNumericalDamping(Inner<Parameters...> &inner_relation, Real numerical_damping_factor = 0.25);
-    virtual ~StructureNumericalDamping() {};
+    template <class DynamicsIdentifier>
+    explicit StructureNumericalDamping(DynamicsIdentifier &identifier, Real numerical_damping_factor = 0.25);
+    virtual ~StructureNumericalDamping(){};
 
     class InteractKernel : public BaseInteraction::InteractKernel
     {
@@ -307,7 +311,7 @@ class UpdateElasticNormalDirectionCK : public LocalDynamics
 {
   public:
     explicit UpdateElasticNormalDirectionCK(SPHBody &sph_body);
-    virtual ~UpdateElasticNormalDirectionCK() {};
+    virtual ~UpdateElasticNormalDirectionCK(){};
     class UpdateKernel
     {
       public:
@@ -331,7 +335,7 @@ class UpdateAnisotropicMeasure : public LocalDynamics
 {
   public:
     explicit UpdateAnisotropicMeasure(SPHBody &sph_body);
-    virtual ~UpdateAnisotropicMeasure() {};
+    virtual ~UpdateAnisotropicMeasure(){};
     class UpdateKernel
     {
       public:

--- a/src/shared/shared_ck/particle_dynamics/solid_dynamics/structure_dynamics.hpp
+++ b/src/shared/shared_ck/particle_dynamics/solid_dynamics/structure_dynamics.hpp
@@ -38,9 +38,10 @@ inline void BaseStructureIntegration1stHalf::UpdateKernel::update(size_t index_i
 }
 //=================================================================================================//
 template <class MaterialType, typename KernelCorrectionType, typename... Parameters>
+template <class DynamicsIdentifier>
 StructureIntegration1stHalf<Inner<OneLevel, MaterialType, KernelCorrectionType, Parameters...>>::
-    StructureIntegration1stHalf(Inner<Parameters...> &inner_relation, Real numerical_damping_factor)
-    : BaseInteraction(inner_relation), BaseStructureIntegration1stHalf(this->particles_),
+    StructureIntegration1stHalf(DynamicsIdentifier &identifier, Real numerical_damping_factor)
+    : BaseInteraction(identifier), BaseStructureIntegration1stHalf(this->particles_),
       material_(DynamicCast<MaterialType>(this, this->sph_body_->getMatterMaterial())),
       adaptation_(DynamicCast<Adaptation>(this, this->sph_body_->getSPHAdaptation())),
       kernel_correction_(this->particles_), h_ref_(adaptation_.ReferenceSmoothingLength()),
@@ -125,9 +126,10 @@ void StructureIntegration1stHalf<Inner<OneLevel, MaterialType, KernelCorrectionT
 };
 //=================================================================================================//
 template <class MaterialType, typename... Parameters>
+template <class DynamicsIdentifier>
 StructureIntegration1stHalfPK2<Inner<OneLevel, MaterialType, Parameters...>>::
-    StructureIntegration1stHalfPK2(Inner<Parameters...> &inner_relation)
-    : BaseInteraction(inner_relation), BaseStructureIntegration1stHalf(this->particles_),
+    StructureIntegration1stHalfPK2(DynamicsIdentifier &identifier)
+    : BaseInteraction(identifier), BaseStructureIntegration1stHalf(this->particles_),
       material_(DynamicCast<MaterialType>(this, this->sph_body_->getMatterMaterial())),
       adaptation_(DynamicCast<Adaptation>(this, this->sph_body_->getSPHAdaptation())) {}
 //=================================================================================================//
@@ -181,9 +183,10 @@ void StructureIntegration1stHalfPK2<Inner<OneLevel, MaterialType, Parameters...>
 }
 //=================================================================================================//
 template <typename... Parameters>
+template <class DynamicsIdentifier>
 StructureIntegration2ndHalf<Inner<OneLevel, Parameters...>>::StructureIntegration2ndHalf(
-    Inner<Parameters...> &inner_relation)
-    : BaseInteraction(inner_relation), StructureDynamicsVariables(this->particles_) {}
+    DynamicsIdentifier &identifier)
+    : BaseInteraction(identifier), StructureDynamicsVariables(this->particles_) {}
 //=================================================================================================//
 template <typename... Parameters>
 template <class ExecutionPolicy, class EncloserType>
@@ -238,9 +241,10 @@ void StructureIntegration2ndHalf<Inner<OneLevel, Parameters...>>::UpdateKernel::
 }
 //=================================================================================================//
 template <class MaterialType, typename... Parameters>
+template <class DynamicsIdentifier>
 StructureNumericalDamping<Inner<WithUpdate, MaterialType, Parameters...>>::
-    StructureNumericalDamping(Inner<Parameters...> &inner_relation, Real numerical_damping_factor)
-    : BaseInteraction(inner_relation), StructureDynamicsVariables(this->particles_),
+    StructureNumericalDamping(DynamicsIdentifier &identifier, Real numerical_damping_factor)
+    : BaseInteraction(identifier), StructureDynamicsVariables(this->particles_),
       ForcePriorCK(this->particles_, "NumericalDampingForce"),
       material_(DynamicCast<MaterialType>(this, this->sph_body_->getMatterMaterial())),
       adaptation_(DynamicCast<Adaptation>(this, this->sph_body_->getSPHAdaptation())),

--- a/tests/tests_sycl/2d_examples/test_2d_diffusion_NeumannBC_sycl/diffusion_NeumannBC.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_diffusion_NeumannBC_sycl/diffusion_NeumannBC.cpp
@@ -135,8 +135,7 @@ int main(int ac, char *av[])
     //  Generally, we first define all the inner relations, then the contact relations.
     //----------------------------------------------------------------------
     Inner<> diffusion_body_inner(diffusion_body);
-    Contact<> diffusion_body_contact_Dirichlet(diffusion_body, {&wall_Dirichlet});
-    Contact<> diffusion_body_contact_Neumann(diffusion_body, {&wall_Neumann});
+    Contact<> diffusion_body_contact(diffusion_body, {&wall_Dirichlet, &wall_Neumann});
     Contact<> temperature_observer_contact(temperature_observer, {&diffusion_body});
     //----------------------------------------------------------------------
     // Define the numerical methods used in the simulation.
@@ -155,12 +154,14 @@ int main(int ac, char *av[])
     UpdateCellLinkedList<MainExecutionPolicy, RealBody> wall_Dirichlet_cell_linked_list(wall_Dirichlet);
     UpdateCellLinkedList<MainExecutionPolicy, RealBody> wall_Neumann_cell_linked_list(wall_Neumann);
 
-    UpdateRelation<MainExecutionPolicy, Inner<>, Contact<>, Contact<>>
-        diffusion_body_update_complex_relation(
-            diffusion_body_inner, diffusion_body_contact_Dirichlet, diffusion_body_contact_Neumann);
+    UpdateRelation<MainExecutionPolicy, Inner<>, Contact<>>
+        diffusion_body_update_complex_relation(diffusion_body_inner, diffusion_body_contact);
     UpdateRelation<MainExecutionPolicy, Contact<>> observer_contact_relation(temperature_observer_contact);
 
     IsotropicDiffusion isotropic_diffusion(species_name, diffusion_coeff);
+    auto interaction_dirichlet = makeInteraction(diffusion_body_contact, wall_Dirichlet);
+    auto interaction_neumann = makeInteraction(diffusion_body_contact, wall_Neumann);
+
     GetDiffusionTimeStepSize get_time_step_size(diffusion_body, &isotropic_diffusion);
     RungeKuttaSequence<InteractionDynamicsCK<
         MainExecutionPolicy,
@@ -173,8 +174,8 @@ int main(int ac, char *av[])
             Contact<InteractionOnly, Dirichlet<IsotropicDiffusion>, NoKernelCorrectionCK>,
             Contact<InteractionOnly, Neumann<IsotropicDiffusion>, NoKernelCorrectionCK>>>>
         diffusion_relaxation_rk2(DynamicsArgs(diffusion_body_inner, &isotropic_diffusion),
-                                 DynamicsArgs(diffusion_body_contact_Dirichlet, &isotropic_diffusion),
-                                 DynamicsArgs(diffusion_body_contact_Neumann, &isotropic_diffusion));
+                                 DynamicsArgs(interaction_dirichlet, &isotropic_diffusion),
+                                 DynamicsArgs(interaction_neumann, &isotropic_diffusion));
     //----------------------------------------------------------------------
     //	Specify initial condition if necessary.
     //----------------------------------------------------------------------

--- a/tests/tests_sycl/2d_examples/test_2d_diffusion_NeumannBC_sycl/diffusion_NeumannBC.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_diffusion_NeumannBC_sycl/diffusion_NeumannBC.cpp
@@ -159,8 +159,8 @@ int main(int ac, char *av[])
     UpdateRelation<MainExecutionPolicy, Contact<>> observer_contact_relation(temperature_observer_contact);
 
     IsotropicDiffusion isotropic_diffusion(species_name, diffusion_coeff);
-    auto interaction_dirichlet = makeInteraction(diffusion_body_contact, wall_Dirichlet);
-    auto interaction_neumann = makeInteraction(diffusion_body_contact, wall_Neumann);
+    auto contact_dirichlet_view = makeRelationView(diffusion_body_contact, wall_Dirichlet);
+    auto contact_neumann_view = makeRelationView(diffusion_body_contact, wall_Neumann);
 
     GetDiffusionTimeStepSize get_time_step_size(diffusion_body, &isotropic_diffusion);
     RungeKuttaSequence<InteractionDynamicsCK<
@@ -174,8 +174,8 @@ int main(int ac, char *av[])
             Contact<InteractionOnly, Dirichlet<IsotropicDiffusion>, NoKernelCorrectionCK>,
             Contact<InteractionOnly, Neumann<IsotropicDiffusion>, NoKernelCorrectionCK>>>>
         diffusion_relaxation_rk2(DynamicsArgs(diffusion_body_inner, &isotropic_diffusion),
-                                 DynamicsArgs(interaction_dirichlet, &isotropic_diffusion),
-                                 DynamicsArgs(interaction_neumann, &isotropic_diffusion));
+                                 DynamicsArgs(contact_dirichlet_view, &isotropic_diffusion),
+                                 DynamicsArgs(contact_neumann_view, &isotropic_diffusion));
     //----------------------------------------------------------------------
     //	Specify initial condition if necessary.
     //----------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces a new `RelationView` abstraction for handling contact relations in SPH simulations and refactors several continuum and fluid dynamics classes to accept more generic identifiers, improving flexibility and code reuse. The most significant changes are the addition of the `RelationView` class and the generalization of constructors for key dynamics classes, allowing them to accept a broader range of input types.

### Major API Additions

**RelationView abstraction:**
- Introduced the `RelationView` template class for flexible access and management of `Contact` relations, including constructors for different identifier types and utility methods for kernel registration and neighbor access. Also added a `makeRelationView` factory function. (`src/shared/shared_ck/body_relation/relation_ck.h`, `src/shared/shared_ck/body_relation/relation_ck.hpp`) [[1]](diffhunk://#diff-1feda2692671d445a908cd64c22c98196e76dcf7a02e7ba35418e92a1b1b4f35R175-R224) [[2]](diffhunk://#diff-6ee5fac6e05901569f3a48d8ea3af4b5a1c6931d31f2195d7abfffe398e4511dR110-R167)

### Refactoring for Generalized Constructors

**Continuum dynamics classes:**
- Refactored the constructors of `PlasticAcousticStep1stHalf`, `PlasticAcousticStep2ndHalf`, `ShearIntegration`, and `StressDiffusionCK` to accept any `DynamicsIdentifier` type using templated constructors, replacing the previous fixed-type constructors. This enables these classes to be instantiated with a wider variety of relation or identifier types. (`src/shared/shared_ck/particle_dynamics/continum_dynamics/continuum_integration_1st_ck.h`, `continuum_integration_1st_ck.hpp`, `continuum_integration_2nd_ck.h`, `continuum_integration_2nd_ck.hpp`, `shear_integration.h`, `shear_integration.hpp`, `stress_diffusion_ck.h`, `stress_diffusion_ck.hpp`) [[1]](diffhunk://#diff-fcd8cb14e4a5c4a4130e53bc0f8c0ad019a0e33faabdb7c82f44400eee1d2796L66-R67) [[2]](diffhunk://#diff-fcd8cb14e4a5c4a4130e53bc0f8c0ad019a0e33faabdb7c82f44400eee1d2796L122-R124) [[3]](diffhunk://#diff-f43d8ebed4a0b2c9091efbc13b11aff86e9587ea0eaf6075d71a32f72522034dR29-R32) [[4]](diffhunk://#diff-f43d8ebed4a0b2c9091efbc13b11aff86e9587ea0eaf6075d71a32f72522034dR114-R117) [[5]](diffhunk://#diff-f672e6d281e7739ba589eab7e20427180dfbe0a5a3582d53118a10cf08608b61L51-R52) [[6]](diffhunk://#diff-f672e6d281e7739ba589eab7e20427180dfbe0a5a3582d53118a10cf08608b61L107-R109) [[7]](diffhunk://#diff-36547f6442d0c11a3e19d5f94937cdceac4929435b353bd98ea572330db747f4R12-R15) [[8]](diffhunk://#diff-36547f6442d0c11a3e19d5f94937cdceac4929435b353bd98ea572330db747f4R103-R106) [[9]](diffhunk://#diff-79797a6ef3f0e61812e5b1af2e1f01599aa52ea5f10f9453374a38f3cc26d3afL55-R56) [[10]](diffhunk://#diff-2cb2c30053a0a888a182206f18ad710d207cac4a08e4dd8bf3abd3b2dfaa4526R14-R17) [[11]](diffhunk://#diff-798097173cc315151c664220f83e9f597dfb17adff0f5144d0d470e2262d0f33L52-R53) [[12]](diffhunk://#diff-8f3cfce0d19bc83ab4e05e0f3c36d76d618f247022ebcae56b6ce03fb26ea1c1L12-R14)

**Fluid dynamics classes:**
- Similarly updated constructors for `AcousticStep1stHalf` (and its contact specializations) to use templated `DynamicsIdentifier` arguments, improving flexibility in how these classes are instantiated. (`src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.h`, `acoustic_step_1st_half.hpp`) [[1]](diffhunk://#diff-dc5e8b1b5adf3af50bdc3f32e8d0501405cd176bf50fe2db14fa812e8cc7d221L71-R72) [[2]](diffhunk://#diff-dc5e8b1b5adf3af50bdc3f32e8d0501405cd176bf50fe2db14fa812e8cc7d221L128-R130) [[3]](diffhunk://#diff-dc5e8b1b5adf3af50bdc3f32e8d0501405cd176bf50fe2db14fa812e8cc7d221L164-R167) [[4]](diffhunk://#diff-b03a2803d7bd272a902e26875759f82f575df65cdb79deeb3783c1627518bdc3R40-R43) [[5]](diffhunk://#diff-b03a2803d7bd272a902e26875759f82f575df65cdb79deeb3783c1627518bdc3R125-R128) [[6]](diffhunk://#diff-b03a2803d7bd272a902e26875759f82f575df65cdb79deeb3783c1627518bdc3R174-R177)