### PR TITLE
add restart to fish SYCL case

### DIFF
--- a/tests/tests_sycl/2d_examples/test_2d_flow_stream_around_fish_sycl/2d_flow_stream_around_fish.h
+++ b/tests/tests_sycl/2d_examples/test_2d_flow_stream_around_fish_sycl/2d_flow_stream_around_fish.h
@@ -348,8 +348,14 @@ class ImposingActiveStrain : public LocalDynamics
         : LocalDynamics(solid_body),
           sv_physical_time_(&sph_system_->svPhysicalTime()),
           dv_material_id_(particles_->getVariableByName<int>("MaterialID")),
-          dv_pos0_(particles_->getVariableByName<Vecd>("InitialPosition")),
-          dv_active_strain_(particles_->getVariableByName<Matd>("ActiveStrain")) {}
+          dv_pos0_(particles_->registerStateVariableFrom<Vecd>("InitialPosition", "Position")),
+          dv_active_strain_(particles_->getVariableByName<Matd>("ActiveStrain"))
+    {
+        // pos0 must be undeformed reference, not the deformed position at restart time
+        // material ID is assigned from undeformed geometry at t=0, needs to survive restart
+        particles_->addEvolvingVariable<Vecd>("InitialPosition");
+        particles_->addEvolvingVariable<int>("MaterialID");
+    }
 
     struct UpdateKernel
     {

--- a/tests/tests_sycl/2d_examples/test_2d_flow_stream_around_fish_sycl/2d_flow_stream_around_fish_sycl.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_flow_stream_around_fish_sycl/2d_flow_stream_around_fish_sycl.cpp
@@ -201,6 +201,8 @@ int main(int ac, char *av[])
     body_state_recorder.addToWrite<int>(fish_body, "MaterialID");
     body_state_recorder.addToWrite<Matd>(fish_body, "ActiveStrain");
 
+    auto &restart_io = main_methods.addIODynamics<RestartIOCK>(sph_system);
+
     Gravity gravity(Vecd::Zero());
     ReducedQuantityRecording<MainExecutionPolicy, TotalMechanicalEnergyCK>
         write_water_mechanical_energy(water_block, gravity);
@@ -229,6 +231,28 @@ int main(int ac, char *av[])
     fish_inner_build.exec();
     fish_contact_relation.exec();
     fish_body_corrected_configuration.exec();
+
+    //----------------------------------------------------------------------
+    //	Load restart file if necessary.
+    //----------------------------------------------------------------------
+    if (sph_system.RestartStep() != 0)
+    {
+        restart_io.readRestartFiles(sph_system.RestartStep());
+        // rebuild spatial hash from restored positions
+        update_fish_cell_linked_list.exec();
+        update_water_cell_linked_list.exec();
+        // re-sort water particles for cache locality, then rebuild CLL
+        particle_sort.exec();
+        update_water_cell_linked_list.exec();
+        // reconstruct neighbor lists
+        water_body_update_complex_relation.exec();
+        fish_contact_relation.exec();
+        // rebuild B-matrix from restored fish positions
+        fish_body_corrected_configuration.exec();
+        // repopulate density from restored positions
+        fluid_density_regularization.exec();
+        number_of_iterations = sph_system.RestartStep();
+    }
 
     apply_gravity_force.exec();
     fluid_boundary_indicator.exec();
@@ -326,6 +350,11 @@ int main(int ac, char *av[])
                 TickCount t2 = TickCount::now();
                 body_state_recorder.writeToFile();
                 interval += TickCount::now() - t2;
+            }
+
+            if (number_of_iterations % 500 == 0)
+            {
+                restart_io.writeToFile(number_of_iterations);
             }
 
             //	Particle injection, deletion, sort, relation update.


### PR DESCRIPTION
- RestartIOCK declared for WaterBody and FishBody
- InitialPosition registered via registerStateVariableFrom and marked evolving; undeformed muscle reference must survive restart since deformed positions at reload time differ from the reference geometry
- MaterialID marked evolving; assigned once from undeformed geometry at t=0, cannot be re-derived from deformed positions on reload
- Validated on CUDA (RTX 4060) and OpenCL CPU (i7-14650HX): time values match to 6 significant figures between full and restarted runs, energy traces are continuous across the restart

**GPU restart validation:**
<img width="1600" height="800" alt="fish_restart_gpu" src="https://github.com/user-attachments/assets/e09ab994-9bb7-4550-ad6f-4120d9b7feff" />

**CPU backend restart validation:**
<img width="1600" height="800" alt="fish_restart_cpu" src="https://github.com/user-attachments/assets/084d9b40-5eed-4fd0-938e-aa4fc336534f" />