### PR TITLE
Improve SYCL/CUDA compatibility for device-side math functions

### DIFF
--- a/src/shared/materials/elastic_solid.cpp
+++ b/src/shared/materials/elastic_solid.cpp
@@ -136,7 +136,7 @@ Matd NeoHookeanSolidIncompressible::StressPK2(Matd &F, size_t index_i)
     Matd right_cauchy = F.transpose() * F;
     Real I_1 = right_cauchy.trace();       // first strain invariant
     Real I_3 = right_cauchy.determinant(); // first strain invariant
-    return G0_ * math::pow(I_3, Real(-1.0f / 3.0f)) * (Matd::Identity() - 1.0 / 3.0 * I_1 * right_cauchy.inverse());
+    return G0_ * math::pow(I_3, -Real(1) / Real(3)) * (Matd::Identity() - (Real(1) / Real(3)) * I_1 * right_cauchy.inverse());
 }
 //=================================================================================================//
 Matd NeoHookeanSolidIncompressible::

--- a/src/shared/materials/elastic_solid.cpp
+++ b/src/shared/materials/elastic_solid.cpp
@@ -121,7 +121,7 @@ Matd NeoHookeanSolid::StressCauchy(Matd &almansi_strain, size_t index_i)
     Matd B = (-2.0 * almansi_strain + Matd::Identity()).inverse();
     Real J = sqrt(B.determinant());
     Matd cauchy_stress = 0.5 * K0_ * (J - 1.0 / J) * Matd::Identity() +
-                         G0_ * pow(J, -2.0 * OneOverDimensions - 1.0) *
+                         G0_ * math::pow(J, Real(-2.0 * OneOverDimensions - 1.0)) *
                              (B - OneOverDimensions * B.trace() * Matd::Identity());
     return cauchy_stress;
 }
@@ -136,7 +136,7 @@ Matd NeoHookeanSolidIncompressible::StressPK2(Matd &F, size_t index_i)
     Matd right_cauchy = F.transpose() * F;
     Real I_1 = right_cauchy.trace();       // first strain invariant
     Real I_3 = right_cauchy.determinant(); // first strain invariant
-    return G0_ * pow(I_3, -1.0 / 3.0) * (Matd::Identity() - 1.0 / 3.0 * I_1 * right_cauchy.inverse());
+    return G0_ * math::pow(I_3, Real(-1.0f / 3.0f)) * (Matd::Identity() - 1.0 / 3.0 * I_1 * right_cauchy.inverse());
 }
 //=================================================================================================//
 Matd NeoHookeanSolidIncompressible::

--- a/src/shared/materials/elastic_solid.hpp
+++ b/src/shared/materials/elastic_solid.hpp
@@ -17,7 +17,7 @@ inline Matd LinearElasticSolid::ConstituteKernel::ElasticLeftCauchy(
     const Matd &F, size_t index_i, Real dt)
 {
     Matd be = F * F.transpose();
-    return be * pow(be.determinant(), -OneOverDimensions);
+    return be * math::pow(be.determinant(), -Real(OneOverDimensions));
 }
 //=================================================================================================//
 inline Real LinearElasticSolid::ConstituteKernel::VolumetricKirchhoff(Real J)

--- a/src/shared/materials/inelastic_solid.cpp
+++ b/src/shared/materials/inelastic_solid.cpp
@@ -31,7 +31,7 @@ void HardeningPlasticSolid::initializeLocalParameters(BaseParticles *base_partic
 Matd HardeningPlasticSolid::ElasticLeftCauchy(const Matd &F, size_t index_i, Real dt)
 {
     Matd be = F * inverse_plastic_strain_[index_i] * F.transpose();
-    Matd normalized_be = be * pow(be.determinant(), -OneOverDimensions);
+    Matd normalized_be = be * math::pow(be.determinant(), -Real(OneOverDimensions));
     Real normalized_be_isentropic = normalized_be.trace() * OneOverDimensions;
     Matd deviatoric_Kirchhoff = DeviatoricKirchhoff(normalized_be - normalized_be_isentropic * Matd::Identity());
     Real deviatoric_Kirchhoff_norm = deviatoric_Kirchhoff.norm();
@@ -44,7 +44,7 @@ Matd HardeningPlasticSolid::ElasticLeftCauchy(const Matd &F, size_t index_i, Rea
         hardening_parameter_[index_i] += sqrt_2_over_3_ * relax_increment;
         deviatoric_Kirchhoff -= 2.0 * renormalized_shear_modulus * relax_increment * deviatoric_Kirchhoff / deviatoric_Kirchhoff_norm;
         Matd relaxed_be = deviatoric_Kirchhoff / G0_ + normalized_be_isentropic * Matd::Identity();
-        normalized_be = relaxed_be * pow(relaxed_be.determinant(), -OneOverDimensions);
+        normalized_be = relaxed_be * math::pow(relaxed_be.determinant(), -Real(OneOverDimensions));
     }
     Matd inverse_F = F.inverse();
     Matd inverse_F_T = inverse_F.transpose();
@@ -55,7 +55,7 @@ Matd HardeningPlasticSolid::ElasticLeftCauchy(const Matd &F, size_t index_i, Rea
 //=================================================================================================//
 Matd NonLinearHardeningPlasticSolid::ElasticLeftCauchy(const Matd &F, size_t index_i, Real dt)
 {
-    Matd normalized_F = F * pow(F.determinant(), -OneOverDimensions);
+    Matd normalized_F = F * math::pow(F.determinant(), -Real(OneOverDimensions));
     Matd normalized_be = normalized_F * inverse_plastic_strain_[index_i] * normalized_F.transpose();
     Real normalized_be_isentropic = normalized_be.trace() * OneOverDimensions;
     Matd deviatoric_Kirchhoff = DeviatoricKirchhoff(normalized_be - normalized_be_isentropic * Matd::Identity());
@@ -79,7 +79,7 @@ Matd NonLinearHardeningPlasticSolid::ElasticLeftCauchy(const Matd &F, size_t ind
         hardening_parameter_[index_i] += sqrt_2_over_3_ * relax_increment;
         deviatoric_Kirchhoff -= 2.0 * renormalized_shear_modulus * relax_increment * deviatoric_Kirchhoff / deviatoric_Kirchhoff_norm;
         Matd relaxed_be = deviatoric_Kirchhoff / G0_ + normalized_be_isentropic * Matd::Identity();
-        normalized_be = relaxed_be * pow(relaxed_be.determinant(), -OneOverDimensions);
+        normalized_be = relaxed_be * math::pow(relaxed_be.determinant(), -Real(OneOverDimensions));
     }
 
     Matd inverse_normalized_F = normalized_F.inverse();
@@ -102,7 +102,7 @@ void ViscousPlasticSolid::initializeLocalParameters(BaseParticles *base_particle
 Matd ViscousPlasticSolid::ElasticLeftCauchy(const Matd &F, size_t index_i, Real dt)
 {
     Matd be = F * inverse_plastic_strain_[index_i] * F.transpose();
-    Matd normalized_be = be * pow(be.determinant(), -OneOverDimensions);
+    Matd normalized_be = be * math::pow(be.determinant(), -Real(OneOverDimensions));
     Real normalized_be_isentropic = normalized_be.trace() * OneOverDimensions;
     Matd deviatoric_Kirchhoff = DeviatoricKirchhoff(normalized_be - normalized_be_isentropic * Matd::Identity());
     Real deviatoric_Kirchhoff_norm = deviatoric_Kirchhoff.norm();
@@ -116,11 +116,12 @@ Matd ViscousPlasticSolid::ElasticLeftCauchy(const Matd &F, size_t index_i, Real 
         Real predicted_func = 0.0;
         Real Precision = 1.0e-6;
         Real Relative_Error;
+        Real inverse_power = Real(1.0f) / Real(Herschel_Bulkley_power_);
         do
         {
             deviatoric_Kirchhoff_norm_Mid = (deviatoric_Kirchhoff_norm_Max + deviatoric_Kirchhoff_norm_Min) / 2.0;
-            predicted_func = pow(viscous_modulus_, 1.0 / Herschel_Bulkley_power_) * (deviatoric_Kirchhoff_norm_Mid - deviatoric_Kirchhoff_norm) +
-                             2.0 * renormalized_shear_modulus * dt * pow((deviatoric_Kirchhoff_norm_Mid - sqrt_2_over_3_ * yield_stress_), 1.0 / Herschel_Bulkley_power_);
+            predicted_func = math::pow(viscous_modulus_, inverse_power) * (deviatoric_Kirchhoff_norm_Mid - deviatoric_Kirchhoff_norm) +
+                             2.0 * renormalized_shear_modulus * dt * math::pow((deviatoric_Kirchhoff_norm_Mid - sqrt_2_over_3_ * yield_stress_), inverse_power);
             if (predicted_func < 0.0)
             {
                 deviatoric_Kirchhoff_norm_Min = deviatoric_Kirchhoff_norm_Mid;
@@ -134,7 +135,7 @@ Matd ViscousPlasticSolid::ElasticLeftCauchy(const Matd &F, size_t index_i, Real 
 
         deviatoric_Kirchhoff = deviatoric_Kirchhoff_norm_Mid * deviatoric_Kirchhoff / deviatoric_Kirchhoff_norm;
         Matd relaxed_be = deviatoric_Kirchhoff / G0_ + normalized_be_isentropic * Matd::Identity();
-        normalized_be = relaxed_be * pow(relaxed_be.determinant(), -OneOverDimensions);
+        normalized_be = relaxed_be * math::pow(relaxed_be.determinant(), -Real(OneOverDimensions));
     }
 
     Matd inverse_F = F.inverse();

--- a/src/shared/materials/inelastic_solid.hpp
+++ b/src/shared/materials/inelastic_solid.hpp
@@ -20,7 +20,7 @@ inline Matd HardeningPlasticSolid::ConstituteKernel::ElasticLeftCauchy(
     const Matd &F, size_t index_i, Real dt)
 {
     Matd be = F * inverse_plastic_strain_[index_i] * F.transpose();
-    Matd normalized_be = be * pow(be.determinant(), -OneOverDimensions);
+    Matd normalized_be = be * math::pow(be.determinant(), -Real(OneOverDimensions));
     Real normalized_be_isentropic = normalized_be.trace() * OneOverDimensions;
     Matd deviatoric_Kirchhoff = DeviatoricKirchhoff(normalized_be - normalized_be_isentropic * Matd::Identity());
     Real deviatoric_Kirchhoff_norm = deviatoric_Kirchhoff.norm();
@@ -33,7 +33,7 @@ inline Matd HardeningPlasticSolid::ConstituteKernel::ElasticLeftCauchy(
         hardening_parameter_[index_i] += sqrt_2_over_3_ * relax_increment;
         deviatoric_Kirchhoff -= 2.0 * renormalized_shear_modulus * relax_increment * deviatoric_Kirchhoff / deviatoric_Kirchhoff_norm;
         Matd relaxed_be = deviatoric_Kirchhoff / G0_ + normalized_be_isentropic * Matd::Identity();
-        normalized_be = relaxed_be * pow(relaxed_be.determinant(), -OneOverDimensions);
+        normalized_be = relaxed_be * math::pow(relaxed_be.determinant(), -Real(OneOverDimensions));
     }
     Matd inverse_F = F.inverse();
     Matd inverse_F_T = inverse_F.transpose();

--- a/src/shared/materials/riemann_solver.h
+++ b/src/shared/materials/riemann_solver.h
@@ -86,7 +86,7 @@ class BaseAcousticRiemannSolver : public NoRiemannSolver
     template <class FluidI, class FluidJ>
     BaseAcousticRiemannSolver(FluidI &fluid_i, FluidJ &fluid_j, Real limiter_coeff = 3.0)
         : NoRiemannSolver(fluid_i, fluid_j),
-          inv_rho0c0_ave_((rho0c0_i_ + rho0c0_j_) / (math::pow(rho0c0_i_, 2) + math::pow(rho0c0_j_, 2))),
+          inv_rho0c0_ave_((rho0c0_i_ + rho0c0_j_) / (math::pow(rho0c0_i_, Real(2)) + math::pow(rho0c0_j_, Real(2)))),
           rho0c0_geo_ave_(2.0 * rho0c0_i_ * rho0c0_j_ * inv_rho0c0_sum_),
           inv_c0_ave_(0.5 * (rho0_i_ + rho0_j_) * inv_rho0c0_ave_),
           limiter_(limiter_coeff){};

--- a/src/shared/mesh_dynamics/level_set_dynamics/level_set_transformation.hpp
+++ b/src/shared/mesh_dynamics/level_set_dynamics/level_set_transformation.hpp
@@ -43,7 +43,7 @@ UpdateKernelIntegrals::UpdateKernel::
       kernel_second_gradient_(encloser.pmv_kernel_second_gradient_.DelegatedData(ex_policy)),
       kernel_(encloser.neighbor_method_),
       data_spacing_(encloser.index_handler_.DataSpacing()),
-      data_cell_volume_(math::pow(data_spacing_, Dimensions)),
+      data_cell_volume_(math::pow(data_spacing_, static_cast<Real>(Dimensions))),
       cell_neighborhood_(encloser.dv_cell_neighborhood_.DelegatedData(ex_policy)),
       cutoff_radius_(kernel_.CutOffRadius()),
       bounding_box_(BoundingBoxi(Arrayi::Constant(

--- a/src/shared/particle_dynamics/external_force/external_force.h
+++ b/src/shared/particle_dynamics/external_force/external_force.h
@@ -67,7 +67,7 @@ class StartupAcceleration : public Gravity
     Vecd InducedAcceleration(const Vecd &position, Real physical_time) const
     {
         Real time_factor = physical_time / target_time_;
-        Vecd acceleration = 0.5 * Pi * sin(Pi * time_factor) * Gravity::InducedAcceleration();
+        Vecd acceleration = 0.5 * Pi * math::sin(Pi * time_factor) * Gravity::InducedAcceleration();
         return time_factor < 1.0 ? acceleration : Vecd::Zero();
     };
 };

--- a/src/shared/shared_ck/body_relation/neighbor_method.hpp
+++ b/src/shared/shared_ck/body_relation/neighbor_method.hpp
@@ -146,7 +146,7 @@ Neighbor<SPHAdaptation, SPHAdaptation>::NeighborCriterion::NeighborCriterion(
     const ExecutionPolicy &ex_policy, EncloserType &encloser)
     : src_pos_(encloser.dv_src_pos_->DelegatedData(ex_policy)),
       tar_pos_(encloser.dv_tar_pos_->DelegatedData(ex_policy)),
-      kernel_size_squared_(math::pow(encloser.base_kernel_->KernelSize(), 2)),
+      kernel_size_squared_(math::pow(encloser.base_kernel_->KernelSize(), Real(2))),
       inv_h_(encloser.inv_h_) {}
 //=================================================================================================//
 inline bool Neighbor<SPHAdaptation, SPHAdaptation>::NeighborCriterion::operator()(
@@ -241,7 +241,7 @@ Real Neighbor<SourceAdaptationType, TargetAdaptationType>::SmoothingKernel::
     W0(UnsignedInt i, const Vec2d &zero) const
 {
     Real inv_h_i = src_h_ratio_(i) * src_inv_h_ref_;
-    return src_h_ratio_.KernelTransform(i) * BaseKernel::W02D(math::pow(inv_h_i, 2));
+    return src_h_ratio_.KernelTransform(i) * BaseKernel::W02D(math::pow(inv_h_i, Real(2)));
 }
 //=================================================================================================//
 template <class SourceAdaptationType, class TargetAdaptationType>
@@ -249,49 +249,49 @@ Real Neighbor<SourceAdaptationType, TargetAdaptationType>::SmoothingKernel::
     W0(UnsignedInt i, const Vec3d &zero) const
 {
     Real inv_h_i = src_h_ratio_(i) * src_inv_h_ref_;
-    return src_h_ratio_.KernelTransform(i) * BaseKernel::W03D(math::pow(inv_h_i, 3));
+    return src_h_ratio_.KernelTransform(i) * BaseKernel::W03D(math::pow(inv_h_i, Real(3)));
 }
 //=================================================================================================//
 template <class SourceAdaptationType, class TargetAdaptationType>
 Real Neighbor<SourceAdaptationType, TargetAdaptationType>::SmoothingKernel::
     W(const Vec2d &disp_transform, Real inv_h) const
 {
-    return BaseKernel::W2D(math::pow(inv_h, 2), disp_transform.norm() * inv_h);
+    return BaseKernel::W2D(math::pow(inv_h, Real(2)), disp_transform.norm() * inv_h);
 }
 //=================================================================================================//
 template <class SourceAdaptationType, class TargetAdaptationType>
 Real Neighbor<SourceAdaptationType, TargetAdaptationType>::SmoothingKernel::
     W(const Vec3d &disp_transform, Real inv_h) const
 {
-    return BaseKernel::W3D(math::pow(inv_h, 3), disp_transform.norm() * inv_h);
+    return BaseKernel::W3D(math::pow(inv_h, Real(3)), disp_transform.norm() * inv_h);
 }
 //=================================================================================================//
 template <class SourceAdaptationType, class TargetAdaptationType>
 Real Neighbor<SourceAdaptationType, TargetAdaptationType>::SmoothingKernel::
     dW(const Vec2d &disp_transform, Real inv_h) const
 {
-    return BaseKernel::dW2D(math::pow(inv_h, 3), disp_transform.norm() * inv_h);
+    return BaseKernel::dW2D(math::pow(inv_h, Real(3)), disp_transform.norm() * inv_h);
 }
 //=================================================================================================//
 template <class SourceAdaptationType, class TargetAdaptationType>
 Real Neighbor<SourceAdaptationType, TargetAdaptationType>::SmoothingKernel::
     dW(const Vec3d &disp_transform, Real inv_h) const
 {
-    return BaseKernel::dW3D(math::pow(inv_h, 4), disp_transform.norm() * inv_h);
+    return BaseKernel::dW3D(math::pow(inv_h, Real(4)), disp_transform.norm() * inv_h);
 }
 //=================================================================================================//
 template <class SourceAdaptationType, class TargetAdaptationType>
 Real Neighbor<SourceAdaptationType, TargetAdaptationType>::SmoothingKernel::
     d2W(const Vec2d &disp_transform, Real inv_h) const
 {
-    return BaseKernel::d2W2D(math::pow(inv_h, 4), disp_transform.norm() * inv_h);
+    return BaseKernel::d2W2D(math::pow(inv_h, Real(4)), disp_transform.norm() * inv_h);
 }
 //=================================================================================================//
 template <class SourceAdaptationType, class TargetAdaptationType>
 Real Neighbor<SourceAdaptationType, TargetAdaptationType>::SmoothingKernel::
     d2W(const Vec3d &disp_transform, Real inv_h) const
 {
-    return BaseKernel::d2W3D(math::pow(inv_h, 5), disp_transform.norm() * inv_h);
+    return BaseKernel::d2W3D(math::pow(inv_h, Real(5)), disp_transform.norm() * inv_h);
 }
 //=================================================================================================//
 template <class SourceAdaptationType, class TargetAdaptationType>
@@ -327,7 +327,7 @@ Neighbor<SourceAdaptationType, TargetAdaptationType>::NeighborCriterion::
     NeighborCriterion(const ExecutionPolicy &ex_policy, EncloserType &encloser)
     : src_pos_(encloser.dv_src_pos_->DelegatedData(ex_policy)),
       tar_pos_(encloser.dv_tar_pos_->DelegatedData(ex_policy)),
-      kernel_size_squared_(math::pow(encloser.base_kernel_->KernelSize(), 2)),
+      kernel_size_squared_(math::pow(encloser.base_kernel_->KernelSize(), Real(2))),
       src_inv_h_ref_(encloser.src_inv_h_ref_),
       src_h_ratio_(ex_policy, encloser.src_adaptation_) {}
 //=================================================================================================//
@@ -346,7 +346,7 @@ Neighbor<SourceAdaptationType, TargetAdaptationType>::ReverseNeighborCriterion::
     ReverseNeighborCriterion(const ExecutionPolicy &ex_policy, EncloserType &encloser)
     : src_pos_(encloser.dv_src_pos_->DelegatedData(ex_policy)),
       tar_pos_(encloser.dv_tar_pos_->DelegatedData(ex_policy)),
-      kernel_size_squared_(math::pow(encloser.base_kernel_->KernelSize(), 2)),
+      kernel_size_squared_(math::pow(encloser.base_kernel_->KernelSize(), Real(2))),
       tar_inv_h_ref_(encloser.tar_inv_h_ref_),
       tar_h_ratio_(ex_policy, encloser.tar_adaptation_) {}
 //=================================================================================================//

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary_state.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/fluid_boundary_state.h
@@ -98,7 +98,7 @@ struct StartupToConstantInflowSpeed
     Real getAxisVelocity(const Vecd &, const Real &, Real time)
     {
         return time < startup_time_
-                   ? 0.5 * speed_ * (1.0 - cos(Pi * time / startup_time_))
+                   ? 0.5 * speed_ * (1.0 - math::cos(Pi * time / startup_time_))
                    : speed_;
     };
 };

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/riemann_solver/riemann_solver_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/riemann_solver/riemann_solver_ck.hpp
@@ -62,7 +62,7 @@ ImpedanceModel<FluidI, FluidJ>::ImpedanceModel(
       rho0c0_i_(rho0_i_ * fluid_i.ReferenceSoundSpeed()),
       rho0c0_j_(rho0_j_ * fluid_j.ReferenceSoundSpeed()),
       inv_rho0c0_sum_(1.0 / (rho0c0_i_ + rho0c0_j_)),
-      inv_rho0c0_ave_((rho0c0_i_ + rho0c0_j_) / (math::pow(rho0c0_i_, 2) + math::pow(rho0c0_j_, 2))),
+      inv_rho0c0_ave_((rho0c0_i_ + rho0c0_j_) / (math::pow(rho0c0_i_, Real(2)) + math::pow(rho0c0_j_, Real(2)))),
       rho0c0_geo_ave_(2.0 * rho0c0_i_ * rho0c0_j_ * inv_rho0c0_sum_),
       inv_c0_ave_(0.5 * (rho0_i_ + rho0_j_) * inv_rho0c0_ave_) {}
 //=================================================================================================//

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.hpp
@@ -108,7 +108,7 @@ void Hessian<Inner<DataType, Parameters...>>::
                                   (this->B_[index_i] * this->e_ij(index_i, index_j)).dot(r_ij);
         DataType corrected_difference = this->variable_[index_i] - this->variable_[index_j] -
                                         this->gradient_[index_i].dot(r_ij);
-        summation += 2.0 * corrected_dW_ijV_j / math::pow(r_ij.squaredNorm(), 2) *
+        summation += 2.0 * corrected_dW_ijV_j / math::pow(r_ij.squaredNorm(), Real(2)) *
                      tensorProduct(vectorizeTensorSquare(r_ij), corrected_difference);
     }
     this->hessian_[index_i] = this->M_[index_i] * summation;
@@ -147,7 +147,7 @@ void Hessian<Contact<DataType, Parameters...>>::
                                   (this->B_[index_i] * this->e_ij(index_i, index_j)).dot(r_ij);
         DataType corrected_difference = this->variable_[index_i] - contact_variable_[index_j] -
                                         this->gradient_[index_i].dot(r_ij);
-        summation += 2.0 * corrected_dW_ijV_j / math::pow(r_ij.squaredNorm(), 2) *
+        summation += 2.0 * corrected_dW_ijV_j / math::pow(r_ij.squaredNorm(), Real(2)) *
                      tensorProduct(vectorizeTensorSquare(r_ij), corrected_difference);
     }
     this->hessian_[index_i] += this->M_[index_i] * summation;

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.hpp
@@ -84,7 +84,7 @@ void HessianCorrectionMatrix<Inner<WithUpdate, Parameters...>>::
         VecMatd displacement_matrix = vectorizeTensorSquare(r_ij);
         VecMatd linearly_corrected_matrix =
             displacement_matrix + this->displacement_matrix_grad_[index_i] * r_ij;
-        summation -= r_ij.dot(corrected_gradW_ij) / math::pow(r_ij.squaredNorm(), 2) *
+        summation -= r_ij.dot(corrected_gradW_ij) / math::pow(r_ij.squaredNorm(), Real(2)) *
                      displacement_matrix * linearly_corrected_matrix.transpose();
     }
     this->M_[index_i] = summation;
@@ -94,7 +94,7 @@ template <typename... Parameters>
 void HessianCorrectionMatrix<Inner<WithUpdate, Parameters...>>::
     UpdateKernel::update(size_t index_i, Real dt)
 {
-    Real det_sqr = math::pow(this->M_[index_i].determinant(), 2);
+    Real det_sqr = math::pow(this->M_[index_i].determinant(), Real(2));
     Real min_det_sqr = SMAX(alpha_ - det_sqr, Real(0));
     MatTend M_T = this->M_[index_i].transpose(); // for Tikhonov regularization
     MatTend inverse = (M_T * this->M_[index_i] + TinyReal * MatTend::Identity()).inverse() * M_T;
@@ -123,7 +123,7 @@ void HessianCorrectionMatrix<Contact<Parameters...>>::
         VecMatd displacement_matrix = vectorizeTensorSquare(r_ij);
         VecMatd linearly_corrected_matrix =
             displacement_matrix + this->displacement_matrix_grad_[index_i] * r_ij;
-        summation -= r_ij.dot(corrected_gradW_ij) / math::pow(r_ij.squaredNorm(), 2) *
+        summation -= r_ij.dot(corrected_gradW_ij) / math::pow(r_ij.squaredNorm(), Real(2)) *
                      displacement_matrix * linearly_corrected_matrix.transpose();
     }
     this->M_[index_i] += summation;

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_stepping_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_stepping_ck.h
@@ -143,7 +143,7 @@ class UpdateSmoothingLengthRatio : public BaseLocalDynamics<DynamicIdentifier>
         {
             Real local_spacing = local_spacing_(pos_[index_i]);
             h_ratio_[index_i] = reference_spacing_ / local_spacing;
-            Vol_[index_i] = math::pow(local_spacing, Dimensions);
+            Vol_[index_i] = math::pow(local_spacing, static_cast<Real>(Dimensions));
         };
 
       protected:

--- a/tests/tests_sycl/2d_examples/test_2d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -74,7 +74,7 @@ class InflowVelocityPrescribed : public VelocityPrescribed<WeaklyCompressibleFlu
     Real getAxisVelocity(const Vecd &input_position, const Real &input_axis_velocity, Real time)
     {
         Real y_centered = input_position[1];
-        Real u_steady = U_f_ * (1.0 - math::pow((2.0 * y_centered / DH_), 2));
+        Real u_steady = U_f_ * (1.0 - math::pow((Real(2) * y_centered / DH_), Real(2)));
         Real transient_factor = 1.0 - math::exp(-time / tau_);
         return u_steady * transient_factor;
     };

--- a/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -76,8 +76,8 @@ class InflowVelocityPrescribed : public VelocityPrescribed<WeaklyCompressibleFlu
         Real y_centered = input_position[1];
         Real z_centered = input_position[2];
         Real r = std::sqrt(y_centered * y_centered + z_centered * z_centered);
-        Real u_steady = U_f_ * (1.0 - math::pow((Real(2) * r / DH_), Real(2)));
-        Real transient_factor = 1.0 - math::exp(-time / tau_);
+        Real u_steady = U_f_ * (Real(1) - math::pow((Real(2) * r / DH_), Real(2)));
+        Real transient_factor = Real(1) - math::exp(-time / tau_);
         return u_steady * transient_factor;
     };
 

--- a/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -76,7 +76,7 @@ class InflowVelocityPrescribed : public VelocityPrescribed<WeaklyCompressibleFlu
         Real y_centered = input_position[1];
         Real z_centered = input_position[2];
         Real r = std::sqrt(y_centered * y_centered + z_centered * z_centered);
-        Real u_steady = U_f_ * (1.0 - math::pow((2.0 * r / DH_), 2));
+        Real u_steady = U_f_ * (1.0 - math::pow((Real(2) * r / DH_), Real(2)));
         Real transient_factor = 1.0 - math::exp(-time / tau_);
         return u_steady * transient_factor;
     };


### PR DESCRIPTION
# Summary

This PR improves the compatibility of SPHinXsys with the SYCL/CUDA backend by making device-side math function calls more type-consistent and backend-friendly.

When building SYCL examples with the Intel oneAPI DPC++ compiler and the CUDA backend for NVIDIA GPUs, several device compilation and linking issues were encountered. The main issues were related to mixed floating-point types in `math::pow` calls and trigonometric functions used in code paths instantiated by SYCL device kernels.

This PR addresses these issues while preserving the original mathematical formulations.

# Changes

## 1. Make `math::pow` arguments type-consistent

Several `math::pow` calls used `Real` values together with integer or double exponent expressions, such as:

- integer exponents such as `2`
- dimension-dependent exponents such as `Dimensions`
- negative fractional exponents such as `-OneOverDimensions`
- expressions such as `1.0 / Herschel_Bulkley_power_`

In SYCL builds, `math` is aliased to `sycl`, and SYCL math builtins generally require both arguments of `pow(T, T)` to have the same floating-point type. Mixed `Real`/`double` or `Real`/`int` arguments can therefore lead to template deduction failures or unstable device-code generation.

This PR explicitly casts the affected exponents to `Real`, so that the base and exponent types match in device code.

## 2. Avoid implicit double promotion in negative fractional powers

Some solid material models used negative fractional powers, for example in normalization terms involving determinants and dimension-dependent exponents. Under the CUDA SYCL backend, these expressions could be promoted to double precision and trigger NVPTX backend failures involving `f64 fpow`.

This PR rewrites the affected expressions to keep the exponent in `Real` precision, avoiding unintended double promotion while preserving the original formulas.

## 3. Use the existing `math` namespace for trigonometric functions

SPHinXsys already defines the math namespace as:

```cpp
#if SPHINXSYS_USE_SYCL
namespace math = sycl;
#else
namespace math = std;
#endif
```

This PR therefore uses math::sin and math::cos in affected shared code paths instead of directly using std::sin, std::cos, sycl::sin, or sycl::cos.

This keeps the code portable across both CPU-only and SYCL builds:

in CPU-only builds, math::sin/cos resolves to `std::sin/cos`;
in SYCL builds, math::sin/cos resolves to `sycl::sin/cos`.

This also avoids CUDA device-linking failures such as unresolved sinpif symbols when these functions are instantiated inside SYCL device kernels.

# Motivation

These changes were motivated by build failures observed when compiling SYCL examples for NVIDIA GPUs using the oneAPI CUDA backend. Typical errors included:

no matching function for call to 'pow' due to mixed Real and double arguments;
NVPTX backend failures involving f64 fpow for negative fractional exponents;
CUDA device-linking errors such as ptxas fatal: Unresolved extern function 'sinpif'.

The affected code paths are shared by CPU and SYCL builds, so the fix uses the existing math namespace abstraction instead of introducing SYCL-only calls into common headers.

# Validation

Locally verified that the updated code builds in both configurations:

CPU-only build
SYCL/CUDA build targeting an NVIDIA GPU

The SYCL example `test_2d_flow_stream_around_fish_sycl` was also successfully built and run on an NVIDIA GPU after the changes.

# Notes

The intent of this PR is not to change the numerical models or physical formulations. The changes only make existing math expressions more explicit and portable across the CPU and SYCL/CUDA code paths.