### PR TITLE
:bug: Fix SYCL particle-sorting failures caused by excessive register…

### DIFF
--- a/src/src_sycl/shared/common/algorithm_primitive_sycl.cpp
+++ b/src/src_sycl/shared/common/algorithm_primitive_sycl.cpp
@@ -2,7 +2,7 @@
 
 #include "sphinxsys_variable_sycl.hpp"
 
-#ifdef SPHINXSYS_USE_ONEDPL_SORTING
+#if SPHINXSYS_USE_ONEDPL_SORTING
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/execution>
 #endif
@@ -15,9 +15,9 @@ void RadixSort::sort(const ParallelDevicePolicy &ex_policy, UnsignedInt size, Un
     UnsignedInt *index_permutation = dv_index_permutation_->DelegatedData(ex_policy);
     UnsignedInt *begin = dv_sequence_->DelegatedData(ex_policy) + start_index;
 
-#ifndef SPHINXSYS_USE_ONEDPL_SORTING
+#if !SPHINXSYS_USE_ONEDPL_SORTING
     auto &sycl_queue = execution_instance.getQueue();
-    device_radix_sorting.sort_by_key(begin, index_permutation, size, sycl_queue, sycl_queue.getWorkGroupSize(), 4).wait();
+    device_radix_sorting.sort_by_key(begin, index_permutation, size, sycl_queue, execution_instance.getWorkGroupSize(), 4).wait();
 #else
     oneapi::dpl::sort_by_key(oneapi::dpl::execution::make_device_policy(execution_instance.getQueue()),
                              begin, begin + size, index_permutation);

--- a/src/src_sycl/shared/common/algorithm_primitive_sycl.cpp
+++ b/src/src_sycl/shared/common/algorithm_primitive_sycl.cpp
@@ -17,7 +17,7 @@ void RadixSort::sort(const ParallelDevicePolicy &ex_policy, UnsignedInt size, Un
 
 #if !SPHINXSYS_USE_ONEDPL_SORTING
     auto &sycl_queue = execution_instance.getQueue();
-    device_radix_sorting.sort_by_key(begin, index_permutation, size, sycl_queue, execution_instance.getWorkGroupSize(), 4).wait();
+    device_radix_sorting.sort_by_key(begin, index_permutation, size, sycl_queue, execution_instance.getWorkGroupSize(), 4).wait_and_throw();
 #else
     oneapi::dpl::sort_by_key(oneapi::dpl::execution::make_device_policy(execution_instance.getQueue()),
                              begin, begin + size, index_permutation);


### PR DESCRIPTION
## Description

This PR fixes a SYCL radix sort compatibility issue on NVIDIA GPUs.

The previous implementation used `sycl_queue.getWorkGroupSize()` in

https://github.com/Xiangyu-Hu/SPHinXsys/blob/0a037901d0bebb54e5fd055fb1f0b6b9fa50dd72/src/src_sycl/shared/common/algorithm_primitive_sycl.cpp#L20

However, `sycl::queue` does not provide this API in standard SYCL implementations. Using the device maximum work-group size as a replacement is also inappropriate because the maximum supported size does not consider kernel resource requirements, such as register usage.

For example, on NVIDIA RTX 3090, a work-group size of 512 for the radix sort kernel exceeds the available register budget and causes:

```cpp
sycl::_V1::nd_range_error:
Exceeded the number of registers available on the hardware.
```

## Changes

- Replace `sycl_queue.getWorkGroupSize()` with `execution_instance.getWorkGroupSize()`.
- Use the work-group size managed by the SPHinXsys execution framework.
- Fix the conditional compilation logic for `SPHINXSYS_USE_ONEDPL_SORTING`.

## Validation
Tested with:
- NVIDIA GeForce RTX 3090
- Intel oneAPI DPC++ 2024.0
- SYCL CUDA backend

The following test runs successfully:

```bash
tests/tests_sycl/3d_examples/test_3d_dambreak_sycl/bin/test_3d_dambreak_sycl --regression=yes
```