### PR TITLE
Fix SYCL radix sort work-group sizing

### DIFF
--- a/src/src_sycl/shared/common/algorithm_primitive_sycl.cpp
+++ b/src/src_sycl/shared/common/algorithm_primitive_sycl.cpp
@@ -10,9 +10,9 @@ void RadixSort::sort(const ParallelDevicePolicy &ex_policy, UnsignedInt size, Un
     UnsignedInt *index_permutation = dv_index_permutation_->DelegatedData(ex_policy);
     UnsignedInt *begin = dv_sequence_->DelegatedData(ex_policy) + start_index;
 
-#ifndef SPHINXSYS_USE_ONEDPL
+#if !SPHINXSYS_USE_ONEDPL
     auto &sycl_queue = execution_instance.getQueue();
-    device_radix_sorting.sort_by_key(begin, index_permutation, size, sycl_queue, sycl_queue.getWorkGroupSize(), 4).wait();
+    device_radix_sorting.sort_by_key(begin, index_permutation, size, sycl_queue, execution_instance.getWorkGroupSize(), 4).wait_and_throw();
 #else
     oneapi::dpl::execution::device_policy<> policy(execution_instance.getQueue());
     oneapi::dpl::sort_by_key(policy, begin, begin + size, index_permutation);


### PR DESCRIPTION
## Description

This PR applies the SYCL radix-sort fix on top of #1082 , as suggested in #1088 .

The previous implementation uses `sycl_queue.getWorkGroupSize()`, which is not a standard `sycl::queue` API. This change instead uses the work-group size managed by the SPHinXsys execution framework:

```cpp
execution_instance.getWorkGroupSize()
```

It also changes:

```
#ifndef SPHINXSYS_USE_ONEDPL
```

to:

```
#if !SPHINXSYS_USE_ONEDPL
```

because SPHINXSYS_USE_ONEDPL is defined as a 0/1 compile-time value.

Finally, `wait()` is replaced with `wait_and_throw()` for proper propagation of asynchronous SYCL exceptions.