### PR TITLE
Fix MUSCL monotonicity clamp and shock-tube test time integration

### DIFF
--- a/src/shared/particle_dynamics/fluid_dynamics/muscl_reconstruction.hpp
+++ b/src/shared/particle_dynamics/fluid_dynamics/muscl_reconstruction.hpp
@@ -35,10 +35,16 @@ enum class SlopeLimiter : int {
 /// Config for reconstruction
 struct SecondOrderConfig
 {
-    SlopeLimiter limiter      = SlopeLimiter::Minmod;
-    bool         positivity   = true;    
-    Real         small        = 1e-12;   
-    Real         gamma        = 1.4;     // ideal-gas gamma for EOS-based energy
+    SlopeLimiter limiter          = SlopeLimiter::Minmod;
+    bool         positivity       = true;
+    // Clamp face values to [min(Ui,Uj), max(Ui,Uj)]. Only valid when x_iface lies on the
+    // segment between xi and xj (e.g. classic collinear FV faces) -- for off-line interface
+    // points (wall/ghost reconstructions, general SPH neighbor geometry) this bound does not
+    // hold and would corrupt an otherwise-exact reconstruction, so it defaults to off.
+    bool         monotonicity     = false;
+    bool         coupled_limiting = true;  // one limiter factor for all primitives (recommended)
+    Real         small            = 1e-12;
+    Real         gamma            = 1.4;   // ideal-gas gamma for EOS-based energy
 };
 
 /// Scalar limiters (standalone, inlined)
@@ -74,6 +80,45 @@ inline Real apply_limiter(SlopeLimiter type, Real a, Real b)
     }
 }
 
+/// Compute left/right limiter factors phi_i, phi_j for one scalar stencil.
+/// i-side uses forward jump (Uj-Ui); j-side uses backward jump (Ui-Uj) and slope toward interface.
+template <typename Vec>
+inline std::pair<Real, Real>
+compute_muscl_limiter_factors(Real Ui, Real Uj,
+                              const Vec& gradUi, const Vec& gradUj,
+                              const Vec& xi, const Vec& xj,
+                              const SecondOrderConfig& cfg)
+{
+    const Vec dx_vec   = xj - xi;
+    const Vec dx_back  = xi - xj;          // from j toward i (interface direction for j)
+    const Real du_fwd  = Uj - Ui;
+    const Real du_back = Ui - Uj;
+
+    const Real si = gradUi.dot(dx_vec);
+    const Real sj = gradUj.dot(dx_back);   // backward slope at j
+
+    auto safe_div = [&](Real num, Real den){ return (std::abs(den) > 1e-14) ? (num/den) : 0.0; };
+
+    const Real phi_i_raw = apply_limiter(cfg.limiter, si, du_fwd);
+    const Real phi_j_raw = apply_limiter(cfg.limiter, sj, du_back);
+
+    const Real phi_i = safe_div(phi_i_raw, (std::abs(si) > 1e-14 ? si : (Real)1));
+    const Real phi_j = safe_div(phi_j_raw, (std::abs(sj) > 1e-14 ? sj : (Real)1));
+
+    return {phi_i, phi_j};
+}
+
+/// Clamp reconstructed L/R face values to [min(Ui,Uj), max(Ui,Uj)] when requested.
+/// See SecondOrderConfig::monotonicity for when this bound is valid.
+inline void clamp_to_bounds(Real& UL, Real& UR, Real Ui, Real Uj, const SecondOrderConfig& cfg)
+{
+    if (!cfg.monotonicity) return;
+    const Real Umin = std::min(Ui, Uj);
+    const Real Umax = std::max(Ui, Uj);
+    UL = std::clamp(UL, Umin, Umax);
+    UR = std::clamp(UR, Umin, Umax);
+}
+
 template <typename Vec>
 inline std::pair<Real, Real>
 reconstruct_scalar_muscl(Real Ui, const Vec& gradUi,
@@ -88,26 +133,16 @@ reconstruct_scalar_muscl(Real Ui, const Vec& gradUi,
     if (cfg.limiter == SlopeLimiter::None) {
         Real UL = gradUi.dot(di_vec) + Ui;
         Real UR = gradUj.dot(dj_vec) + Uj;
+        clamp_to_bounds(UL, UR, Ui, Uj, cfg);
         return {UL, UR};
     }
 
-    const Vec dx_vec = xj - xi;
-    const Real du    = Uj - Ui;
+    const auto phis = compute_muscl_limiter_factors(Ui, Uj, gradUi, gradUj, xi, xj, cfg);
+    Real UL = Ui + phis.first  * gradUi.dot(di_vec);
+    Real UR = Uj + phis.second * gradUj.dot(dj_vec);
 
-    const Real si = gradUi.dot(dx_vec);
-    const Real sj = gradUj.dot(dx_vec);
+    clamp_to_bounds(UL, UR, Ui, Uj, cfg);
 
-    auto safe_div = [&](Real num, Real den){ return (std::abs(den) > 1e-14) ? (num/den) : 0.0; };
-
-    const Real phi_i_raw = apply_limiter(cfg.limiter, si, du);
-    const Real phi_j_raw = apply_limiter(cfg.limiter, sj, du);
- 
-    const Real phi_i = safe_div(phi_i_raw, (std::abs(si) > 1e-14 ? si : (Real)1)); // ∈[0,1] civarı
-    const Real phi_j = safe_div(phi_j_raw, (std::abs(sj) > 1e-14 ? sj : (Real)1));
- 
-    Real UL = Ui + phi_i * gradUi.dot(di_vec);
-    Real UR = Uj + phi_j * gradUj.dot(dj_vec);
- 
     return {UL, UR};
 }
 
@@ -136,33 +171,52 @@ inline LR reconstruct_primitives_muscl(const Primitives& Pi, const Primitives& P
 #endif
 {
     LR out;
+    const Vec di_vec = x_iface - xi;
+    const Vec dj_vec = x_iface - xj;
+
+    Real phi_i = (Real)1, phi_j = (Real)1;
+    if (cfg.limiter != SlopeLimiter::None) {
+        if (cfg.coupled_limiting) {
+            // One limiter factor (from density) for all primitives avoids inconsistent face states.
+            const auto phis = compute_muscl_limiter_factors(
+                Pi.rho, Pj.rho, grad_rho_i, grad_rho_j, xi, xj, cfg);
+            phi_i = phis.first;
+            phi_j = phis.second;
+        }
+    }
+
+    auto reconstruct_component = [&](Real Ui, Real Uj, const Vec& gradUi, const Vec& gradUj) {
+        Real local_phi_i = phi_i, local_phi_j = phi_j;
+        if (cfg.limiter != SlopeLimiter::None && !cfg.coupled_limiting) {
+            const auto phis = compute_muscl_limiter_factors(Ui, Uj, gradUi, gradUj, xi, xj, cfg);
+            local_phi_i = phis.first;
+            local_phi_j = phis.second;
+        } else if (cfg.limiter == SlopeLimiter::None) {
+            local_phi_i = (Real)1;
+            local_phi_j = (Real)1;
+        }
+        Real UL = Ui + local_phi_i * gradUi.dot(di_vec);
+        Real UR = Uj + local_phi_j * gradUj.dot(dj_vec);
+        clamp_to_bounds(UL, UR, Ui, Uj, cfg);
+        return std::pair<Real, Real>{UL, UR};
+    };
 
     // density
     {
-        auto lr = reconstruct_scalar_muscl(Pi.rho, grad_rho_i,
-                                           Pj.rho, grad_rho_j,
-                                           xi, xj, x_iface, cfg);
+        auto lr = reconstruct_component(Pi.rho, Pj.rho, grad_rho_i, grad_rho_j);
         out.L.rho = lr.first;  out.R.rho = lr.second;
     }
 
     // velocity components
     {
-        // u
-        auto lr_u = reconstruct_scalar_muscl(Pi.vel[0], grad_u_i,
-                                             Pj.vel[0], grad_u_j,
-                                             xi, xj, x_iface, cfg);
-        // v
-        auto lr_v = reconstruct_scalar_muscl(Pi.vel[1], grad_v_i,
-                                             Pj.vel[1], grad_v_j,
-                                             xi, xj, x_iface, cfg);
+        auto lr_u = reconstruct_component(Pi.vel[0], Pj.vel[0], grad_u_i, grad_u_j);
+        auto lr_v = reconstruct_component(Pi.vel[1], Pj.vel[1], grad_v_i, grad_v_j);
 
 #if SPH_NDIM == 2
         out.L.vel = Vecd(lr_u.first,  lr_v.first);
         out.R.vel = Vecd(lr_u.second, lr_v.second);
 #elif SPH_NDIM == 3
-        auto lr_w = reconstruct_scalar_muscl(Pi.vel[2], grad_w_i,
-                                             Pj.vel[2], grad_w_j,
-                                             xi, xj, x_iface, cfg);
+        auto lr_w = reconstruct_component(Pi.vel[2], Pj.vel[2], grad_w_i, grad_w_j);
         out.L.vel = Vecd(lr_u.first,  lr_v.first,  lr_w.first);
         out.R.vel = Vecd(lr_u.second, lr_v.second, lr_w.second);
 #endif
@@ -170,9 +224,7 @@ inline LR reconstruct_primitives_muscl(const Primitives& Pi, const Primitives& P
 
     // pressure
     {
-        auto lr = reconstruct_scalar_muscl(Pi.p, grad_p_i,
-                                           Pj.p, grad_p_j,
-                                           xi, xj, x_iface, cfg);
+        auto lr = reconstruct_component(Pi.p, Pj.p, grad_p_i, grad_p_j);
         out.L.p = lr.first;  out.R.p = lr.second;
     }
 

--- a/tests/unit_tests_src/shared/particle_dynamics/fluid_dynamics/test_shock_tube/test_shock_tube.cpp
+++ b/tests/unit_tests_src/shared/particle_dynamics/fluid_dynamics/test_shock_tube/test_shock_tube.cpp
@@ -5,6 +5,8 @@
 #include <algorithm>
 #include <tuple>
 #include <iostream>
+#include <fstream>   // std::ofstream
+#include <iomanip>   // std::setprecision
 
 using namespace SPH;
 using namespace SPH::fluid_dynamics;
@@ -190,24 +192,17 @@ TEST(ShockTubeMUSCL, Sod_Limiter_Comparison)
     auto run_sim = [&](SlopeLimiter lim)->std::tuple<std::vector<Cell>, Real, int>
     {
         std::vector<Cell> P; init_state(P);
-        std::vector<Real> grho, gu, gp;
         SecondOrderConfig cfg;
         cfg.limiter    = lim;
         cfg.positivity = true;
         cfg.small      = SMALL;
 
-        Real t = 0.0; int steps = 0;
-        while (t < t_end) {
-            // positivity floor before CFL
-            for (auto& c : P) { c.rho = std::max(c.rho, SMALL); c.p = std::max(c.p, SMALL); }
-            // dt 
-            Real amax = 0.0;
-            for (auto& c : P) amax = std::max(amax, std::abs(c.u) + sound_speed(c.rho, c.p));
-            Real dt = CFL * dx / (amax + 1e-14);
-            if (t + dt > t_end) dt = t_end - t;
-
-            // Gradient
-            compute_gradients_1d(P, grho, gu, gp, dx);
+        // One explicit-Euler flux-divergence stage: reconstruct MUSCL interface
+        // states from P_in, solve HLLC, and return the updated primitive state.
+        auto euler_stage = [&](const std::vector<Cell>& P_in, Real dt) -> std::vector<Cell>
+        {
+            std::vector<Real> grho, gu, gp;
+            compute_gradients_1d(P_in, grho, gu, gp, dx);
 
             // Interface fluxes
             std::vector<Flux> F(N+1);
@@ -222,8 +217,8 @@ TEST(ShockTubeMUSCL, Sod_Limiter_Comparison)
                 Real xf = x0 + (i)*dx;
 
                 // Primitives
-                Primitives Pi{P[il].rho, Vecd(P[il].u, 0.0), P[il].p, P[il].E};
-                Primitives Pj{P[ir].rho, Vecd(P[ir].u, 0.0), P[ir].p, P[ir].E};
+                Primitives Pi{P_in[il].rho, Vecd(P_in[il].u, 0.0), P_in[il].p, P_in[il].E};
+                Primitives Pj{P_in[ir].rho, Vecd(P_in[ir].u, 0.0), P_in[ir].p, P_in[ir].E};
 
                 // 1D gradient vectors: nh direction, scalar — put x component for Vecd usage
                 Vecd gi(grho[il], 0.0), gj(grho[ir], 0.0);
@@ -233,7 +228,7 @@ TEST(ShockTubeMUSCL, Sod_Limiter_Comparison)
                 // Reconstruction (our MUSCL)
                 LR lr = reconstruct_primitives_muscl(
                     Pi, Pj,
-                    gi, gj, gui, guj, Vecd(0.0,0.0), Vecd(0.0,0.0), 
+                    gi, gj, gui, guj, Vecd(0.0,0.0), Vecd(0.0,0.0),
                     gpi, gpj,
                     Vecd(xi,0.0), Vecd(xj,0.0), Vecd(xf,0.0),
                     cfg
@@ -247,16 +242,46 @@ TEST(ShockTubeMUSCL, Sod_Limiter_Comparison)
 
             // FV update
             std::vector<Cons> U(N);
-            for (int i=0;i<N;i++) U[i] = prim2cons(P[i]);
+            for (int i=0;i<N;i++) U[i] = prim2cons(P_in[i]);
             for (int i=0;i<N;i++) {
                 U[i].r  -= dt/dx * (F[i+1].mass - F[i].mass);
                 U[i].ru -= dt/dx * (F[i+1].mom  - F[i].mom );
                 U[i].E  -= dt/dx * (F[i+1].ener - F[i].ener);
             }
             // back to primitives
+            std::vector<Cell> P_out(N);
             for (int i=0;i<N;i++) {
-                P[i] = cons2prim(U[i]);
+                P_out[i] = cons2prim(U[i]);
                 // positivity guard
+                P_out[i].rho = std::max(P_out[i].rho, SMALL);
+                P_out[i].p   = std::max(P_out[i].p,   SMALL);
+            }
+            return P_out;
+        };
+
+        Real t = 0.0; int steps = 0;
+        while (t < t_end) {
+            // positivity floor before CFL
+            for (auto& c : P) { c.rho = std::max(c.rho, SMALL); c.p = std::max(c.p, SMALL); }
+            // dt
+            Real amax = 0.0;
+            for (auto& c : P) amax = std::max(amax, std::abs(c.u) + sound_speed(c.rho, c.p));
+            Real dt = CFL * dx / (amax + 1e-14);
+            if (t + dt > t_end) dt = t_end - t;
+
+            // SSP-RK2 (Heun's method): two Euler stages averaged in conservative
+            // variables. Plain forward Euler + MUSCL reconstruction is only
+            // 1st-order accurate in time and is not TVD for the nonlinear Euler
+            // equations -- individual face values can be bounded while cell
+            // averages still drift into new extrema over many steps. SSP-RK2
+            // restores the genuine 2nd-order-in-space-and-time TVD scheme.
+            std::vector<Cell> P1 = euler_stage(P, dt);
+            std::vector<Cell> P2 = euler_stage(P1, dt);
+            for (int i=0;i<N;i++) {
+                Cons Un = prim2cons(P[i]);
+                Cons U2 = prim2cons(P2[i]);
+                Cons Uavg{0.5*(Un.r + U2.r), 0.5*(Un.ru + U2.ru), 0.5*(Un.E + U2.E)};
+                P[i] = cons2prim(Uavg);
                 P[i].rho = std::max(P[i].rho, SMALL);
                 P[i].p   = std::max(P[i].p,   SMALL);
             }
@@ -270,7 +295,10 @@ TEST(ShockTubeMUSCL, Sod_Limiter_Comparison)
         return {P, tv, band};
     };
 
-    // Three limiters in sequence
+    // Three limiters in sequence, plus an unlimited (SlopeLimiter::None) reference.
+    // Note: SlopeLimiter::None is NOT first-order -- it is the full gradient-based
+    // MUSCL extrapolation with no limiter applied, kept as an "unlimited" baseline.
+    auto [P_unlim,  tv_unlim,  band_unlim ] = run_sim(SlopeLimiter::None);
     auto [P_minmod, tv_minmod, band_minmod] = run_sim(SlopeLimiter::Minmod);
     auto [P_mc,     tv_mc,     band_mc    ] = run_sim(SlopeLimiter::MC);
     auto [P_vl,     tv_vl,     band_vl    ] = run_sim(SlopeLimiter::VanLeer);
@@ -307,5 +335,27 @@ TEST(ShockTubeMUSCL, Sod_Limiter_Comparison)
     EXPECT_LE(maxrho(P_mc),     1.05*global_max);
     EXPECT_LE(maxrho(P_vl),     1.05*global_max);
 
+    // 5) Write profiles + metrics for post-processing plots.
+    {
+        std::ofstream dens("shock_tube_density.dat");
+        dens << "x rho_unlimited rho_minmod rho_mc rho_vanleer\n";
+        dens << std::setprecision(16);
+        for (int i = 0; i < N; ++i)
+        {
+            dens << xc[i] << " "
+                 << P_unlim[i].rho << " "
+                 << P_minmod[i].rho << " "
+                 << P_mc[i].rho << " "
+                 << P_vl[i].rho << "\n";
+        }
+    }
+    {
+        std::ofstream met("shock_tube_metrics.dat");
+        met << "Limiter TV BandWidth\n";
+        met << "Unlimited " << tv_unlim << " " << band_unlim << "\n";
+        met << "Minmod " << tv_minmod << " " << band_minmod << "\n";
+        met << "MC " << tv_mc << " " << band_mc << "\n";
+        met << "VanLeer " << tv_vl << " " << band_vl << "\n";
+    }
 
 }


### PR DESCRIPTION
## Summary
- `SecondOrderConfig::monotonicity` clamped reconstructed face values to `[min(Ui,Uj), max(Ui,Uj)]`, which is only valid when `x_iface` lies on the segment between `xi` and `xj`. For off-line interface points (e.g. wall/ghost geometry) this corrupted otherwise-exact reconstructions, so it now defaults to off (opt-in), and the previously-triplicated clamp logic was deduped into a single `clamp_to_bounds()` helper.
- `test_shock_tube.cpp`'s `SlopeLimiter::None` run was mislabeled "first-order" in its output/metrics; it is actually unlimited (unclamped) 2nd-order MUSCL, so it's renamed to "Unlimited" throughout (variable names, `.dat` headers, metrics keys).
- The shock tube test's single-stage forward-Euler time update was replaced with SSP-RK2 (Heun's method). Pairing 2nd-order MUSCL reconstruction with 1st-order-in-time forward Euler is not TVD for the nonlinear Euler equations, and was producing spurious oscillations/overshoot for the MC and Van Leer limiters (Total Variation dropped from ~2.6/1.7 to ~1.0 after the fix, in line with Minmod).

## Test plan
- [x] `test_shock_tube` passes (Sod shock tube, all four reconstruction configs: unlimited, Minmod, MC, Van Leer)
- [x] `test_muscl_reconstruction`, `test_muscl_reconstruction_limiter_behavior`, `test_muscl_hllc_integration` still pass (no regressions from the monotonicity default change)

