### PR TITLE
add scoped linear kernel correction for SYCL open boundaries

### DIFF
--- a/src/shared/particle_dynamics/particle_functors.h
+++ b/src/shared/particle_dynamics/particle_functors.h
@@ -111,6 +111,10 @@ class ParameterFixed : public ParticleParameter
     {
         return parameter_;
     };
+    T &operator()(size_t /*index_j*/, size_t /*index_i*/)
+    {
+        return parameter_;
+    }
 };
 
 template <typename T>
@@ -124,6 +128,10 @@ class ParameterVariable : public ParticleParameter
     {
         return v_[index_i];
     };
+    T &operator()(size_t index_j, size_t /*index_i*/)
+    {
+        return v_[index_j];
+    }
 };
 //----------------------------------------------------------------------
 // Particle average functors

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.h
@@ -199,6 +199,9 @@ using AcousticStep1stHalfWithWallRiemannCK =
 using AcousticStep1stHalfWithWallRiemannCorrectionCK =
     AcousticStep1stHalf<Inner<OneLevel, AcousticRiemannSolverCK, LinearCorrectionCK>,
                         Contact<Wall, AcousticRiemannSolverCK, LinearCorrectionCK>>;
+using AcousticStep1stHalfWithWallRiemannCorrectionForOpenBoundaryFlowCK =
+    AcousticStep1stHalf<Inner<OneLevel, AcousticRiemannSolverCK, LinearCorrectionWithinScopeCK<BulkParticles>>,
+                        Contact<Wall, AcousticRiemannSolverCK, LinearCorrectionCK>>;
 } // namespace fluid_dynamics
 } // namespace SPH
 #endif // ACOUSTIC_STEP_1ST_HALF_H

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.hpp
@@ -100,7 +100,7 @@ void AcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType
 
         force_sum -= riemann_.AverageP(
                          index_i, index_j,
-                         static_cast<CorrectionDataType>(correction_(index_j) * p_[index_i]),
+                         static_cast<CorrectionDataType>(correction_(index_j, index_i) * p_[index_i]),
                          static_cast<CorrectionDataType>(correction_(index_i) * p_[index_j])) *
                      2.0 * dW_ijV_j * e_ij;
         compression_dissipation +=

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.h
@@ -186,5 +186,60 @@ class LinearCorrectionCK : public KernelCorrection
     DiscreteVariable<Matd> *dv_B_;
 };
 
+template <typename... ParticleScopes>
+class LinearCorrectionWithinScopeCK : public KernelCorrection
+{
+    using ScopeMethod = ParticleScopeTypeCK<ParticleScopes...>;
+    using ScopeKernel = typename ScopeMethod::ComputingKernel;
+    using BaseParameter = ParameterVariable<Matd>;
+
+  public:
+    using CorrectionDataType = Matd;
+
+    explicit LinearCorrectionWithinScopeCK(BaseParticles *particles)
+        : KernelCorrection(),
+          dv_B_(particles->getVariableByName<Matd>(
+              "LinearCorrectionMatrix")),
+          within_scope_method_(particles)
+    {
+        static_assert(
+            std::is_base_of<WithinScope, ScopeMethod>::value,
+            "WithinScope is not the base of ParticleScope!");
+    }
+
+    class ComputingKernel : public BaseParameter
+    {
+      public:
+        template <class ExecutionPolicy, class EncloserType>
+        ComputingKernel(const ExecutionPolicy &ex_policy,
+                        EncloserType &encloser)
+            : BaseParameter(
+                  encloser.dv_B_->DelegatedData(ex_policy)),
+              within_scope_(
+                  ex_policy, encloser.within_scope_method_)
+        {
+        }
+
+        Matd operator()(size_t index_j, size_t index_i)
+        {
+            return within_scope_(index_j)
+                       ? BaseParameter::operator()(index_j)
+                       : BaseParameter::operator()(index_i);
+        }
+
+        Matd &operator()(size_t index_i)
+        {
+            return BaseParameter::operator()(index_i);
+        }
+
+      protected:
+        ScopeKernel within_scope_;
+    };
+
+  protected:
+    DiscreteVariable<Matd> *dv_B_;
+    ScopeMethod within_scope_method_;
+};
+
 } // namespace SPH
 #endif // KERNEL_CORRECTION_CK_H

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_gradient_integral.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_gradient_integral.h
@@ -112,6 +112,8 @@ using KernelGradientIntegralComplex =
 
 using KernelGradientIntegralCorrectedComplex =
     KernelGradientIntegral<Inner<LinearCorrectionCK>, Contact<Boundary, LinearCorrectionCK>>;
+using KernelGradientIntegralCorrectedForOpenBoundaryFlowComplex =
+    KernelGradientIntegral<Inner<LinearCorrectionWithinScopeCK<BulkParticles>>, Contact<Boundary, LinearCorrectionCK>>;
 
 } // namespace SPH
 #endif // KERNEL_GRADIENT_RESIDUAL_H

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_gradient_integral.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_gradient_integral.hpp
@@ -43,7 +43,7 @@ void KernelGradientIntegral<Inner<KernelCorrectionType, Parameters...>>::
         UnsignedInt index_j = this->neighbor_index_[n];
         const Real dW_ijV_j = this->dW_ij(index_i, index_j) * Vol_[index_j];
         const Vecd e_ij = this->e_ij(index_i, index_j);
-        inconsistency -= (correction_(index_i) + correction_(index_j)) * dW_ijV_j * e_ij;
+        inconsistency -= (correction_(index_i) + correction_(index_j, index_i)) * dW_ijV_j * e_ij;
     }
     kernel_gradient_integral_[index_i] = inconsistency;
 }

--- a/tests/tests_sycl/2d_examples/test_2d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_mixed_poiseuille_flow_sycl/mixed_poiseuille_flow.cpp
@@ -22,35 +22,18 @@ BoundingBoxd system_domain_bounds(
 //----------------------------------------------------------------------
 //  Material parameters.
 //----------------------------------------------------------------------
-const Real Inlet_pressure = 0.5;
-const Real Outlet_pressure = -0.5;
+Real Inlet_pressure = 0.2;
+Real Outlet_pressure = 0.1;
 Real rho0_f = 1000.0;
 Real Re = 50.0;
-Real mu_f = std::sqrt(rho0_f * std::pow(0.5 * DH, 3.0) *
-                      std::abs(Inlet_pressure - Outlet_pressure) / (Re * DL));
-
-/**
- * Analytical solution for a laminar Poiseuille flow in a 2D channel:
- *
- *    U_f = Δp * DH^2 / (8 * μ * L)
- *
- *  where:
- *    Δp = |p_in - p_out|
- *    DH  = channel height
- *    μ   = dynamic viscosity
- *    L   = channel length
- */
-Real U_f = (DH * DH * std::abs(Inlet_pressure - Outlet_pressure)) /
-           (8.0 * mu_f * DL);
-
-// Compute speed of sound (c0) based on the pressure difference between inlet and outlet boundaries.
-// Ensures density variations are limited to ~1% (WCSPH criterion), multiplied by 4 as a safety factor.
-Real c_f = std::max(10.0 * U_f, sqrt(4 * (Inlet_pressure - Outlet_pressure) / (rho0_f * 0.01))); //
+Real mu_f = sqrt(rho0_f * pow(0.5 * DH, 3.0) * fabs(Inlet_pressure - Outlet_pressure) / (Re * DL));
+Real U_f = pow(0.5 * DH, 2.0) * fabs(Inlet_pressure - Outlet_pressure) / (2.0 * mu_f * DL);
+Real c_f = 10.0 * U_f;
 
 //----------------------------------------------------------------------
 //  Geometric shapes for the channel and boundaries.
 //----------------------------------------------------------------------
-Real bidirectional_buffer_length = 3.0 * global_resolution;
+Real bidirectional_buffer_length = 5.0 * global_resolution;
 Vec2d bidirectional_buffer_halfsize(
     0.5 * bidirectional_buffer_length, 0.5 * DH);
 Vec2d left_bidirectional_translation = bidirectional_buffer_halfsize;
@@ -299,10 +282,8 @@ int main(int ac, char *av[])
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::FreeSurfaceIndicationComplexSpatialTemporalCK>
         fluid_boundary_indicator(water_body_inner, water_wall_contact);
     InteractionDynamicsCK<MainExecutionPolicy, LinearCorrectionMatrixComplex>
-        fluid_linear_correction_matrix(DynamicsArgs(water_body_inner, 0.5), water_wall_contact);
-    StateDynamics<MainExecutionPolicy, LinearCorrectionMatrixScope<SPHBody, BulkParticles>>
-        fluid_linear_correction_scope(water_body);    
-    InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticStep1stHalfWithWallRiemannCorrectionCK>
+        fluid_linear_correction_matrix(DynamicsArgs(water_body_inner, 0.5), water_wall_contact);   
+    InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticStep1stHalfWithWallRiemannCorrectionForOpenBoundaryFlowCK>
         fluid_acoustic_step_1st_half(water_body_inner, water_wall_contact);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticStep2ndHalfWithWallNoRiemannCK>
         fluid_acoustic_step_2nd_half(water_body_inner, water_wall_contact);
@@ -310,9 +291,9 @@ int main(int ac, char *av[])
         fluid_density_summation(water_body_inner, water_wall_contact);
     StateDynamics<MainExecutionPolicy, fluid_dynamics::DensityRegularization<SPHBody, WeaklyCompressibleFluid, Internal, ExcludeBufferParticles>>
         fluid_density_regularization(water_body);
-    InteractionDynamicsCK<MainExecutionPolicy, KernelGradientIntegralCorrectedComplex> kernel_gradient_integral(water_body_inner, water_wall_contact);
+    InteractionDynamicsCK<MainExecutionPolicy, KernelGradientIntegralCorrectedForOpenBoundaryFlowComplex> kernel_gradient_integral(water_body_inner, water_wall_contact);
     StateDynamics<MainExecutionPolicy, fluid_dynamics::TransportVelocityCorrectionCK<SPHBody, TruncatedLinear, BulkParticles>> transport_correction(water_body);
-    ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AdvectionTimeStepCK> fluid_advection_time_step(water_body, U_f);
+    ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AdvectionViscousTimeStepCK> fluid_advection_time_step(water_body, U_f);
     ReduceDynamicsCK<MainExecutionPolicy, fluid_dynamics::AcousticTimeStepCK<WeaklyCompressibleFluid>> fluid_acoustic_time_step(water_body);
     InteractionDynamicsCK<MainExecutionPolicy, fluid_dynamics::ViscousForceWithWallCK>
         fluid_viscous_force(water_body_inner, water_wall_contact);
@@ -377,7 +358,6 @@ int main(int ac, char *av[])
             fluid_density_regularization.exec();
             water_advection_step_setup.exec();
             fluid_linear_correction_matrix.exec();
-            fluid_linear_correction_scope.exec();
             kernel_gradient_integral.exec();
             transport_correction.exec();
             fluid_viscous_force.exec();


### PR DESCRIPTION
Introduce a neighbor-aware kernel correction so correction matrices are selected per neighbor when computing averages and gradients at open/buffer boundaries. Add LinearCorrectionWithinScopeCK and overloads for parameter functors, switch acoustic averaging and kernel‑gradient integral to use correction_(index_j, index_i), and update the SYCL mixed Poiseuille test (pressures, buffer size, timestep reducer) to exercise the fix.

Key changes:

New: LinearCorrectionWithinScopeCK (within-scope neighbor-aware correction).
New overloads: ParameterFixed/ParameterVariable operator()(index_j, index_i).
Use neighbor-aware correction in acoustic averaging and kernel-gradient integral.
Test updated: tests/.../mixed_poiseuille_flow.cpp (params, buffer, AdvectionViscousTimeStepCK).
Testing Build and run the updated SYCL mixed Poiseuille test; expect corrected open-boundary behavior.