### PR TITLE
revised

### DIFF
--- a/src/shared/common/algorithm_primitive.h
+++ b/src/shared/common/algorithm_primitive.h
@@ -287,7 +287,7 @@ inline void generic_for(const SequencedPolicy &seq, const IndexRange &index_rang
 };
 
 template <class LocalDynamicsFunction>
-inline void generic_for(const ParallelPolicy &par_host, const IndexRange &particles_range,
+inline void generic_for(const ParallelPolicy &ex_policy, const IndexRange &particles_range,
                          const LocalDynamicsFunction &local_dynamics_function)
 {
     tbb::parallel_for(

--- a/src/shared/common/sphinxsys_constant.h
+++ b/src/shared/common/sphinxsys_constant.h
@@ -83,13 +83,13 @@ class ConstantArray : public Quantity
     DataType *Data() { return data_; };
     template <class ExecutionPolicy>
     DataType *DelegatedData(const ExecutionPolicy &ex_policy) { return delegated_; };
-    template <class PolicyType>
     DataType *DelegatedOnDevice(const SYCLDevicePolicy &ex_policy);
-    template <class PolicyType>
+
     DataType *DelegatedData(const SYCLDevicePolicy &ex_policy)
     {
         return DelegatedOnDevice(ex_policy);
     };
+
     template <class ExecutionPolicy>
     ArrayView<DataType> DelegatedArrayView(const ExecutionPolicy &ex_policy)
     {
@@ -108,7 +108,6 @@ template <typename DataType>
 class DeviceOnlyConstantArray : public Quantity
 {
   public:
-    template <class PolicyType>
     DeviceOnlyConstantArray(const SYCLDevicePolicy &ex_policy,
                             ConstantArray<DataType> *host_constant);
     ~DeviceOnlyConstantArray();
@@ -140,9 +139,7 @@ class ComputingKernelArray : public Quantity
     StdVec<GeneratorType *> getGenerators() { return generators_; }
     template <class ExecutionPolicy>
     ComputingKernelType *DelegatedData(const ExecutionPolicy &ex_policy) { return delegated_; };
-    template <class PolicyType>
     ComputingKernelType *DelegatedOnDevice(const SYCLDevicePolicy &ex_policy);
-    template <class PolicyType>
     ComputingKernelType *DelegatedData(const SYCLDevicePolicy &ex_policy)
     {
         return DelegatedOnDevice(ex_policy);
@@ -165,7 +162,6 @@ template <typename GeneratorType, typename ComputingKernelType>
 class DeviceOnlyComputingKernelArray : public Quantity
 {
   public:
-    template <class PolicyType>
     DeviceOnlyComputingKernelArray(
         const SYCLDevicePolicy &ex_policy,
         ComputingKernelArray<GeneratorType, ComputingKernelType> *host_constant);

--- a/src/shared/common/sphinxsys_constant.h
+++ b/src/shared/common/sphinxsys_constant.h
@@ -84,9 +84,9 @@ class ConstantArray : public Quantity
     template <class ExecutionPolicy>
     DataType *DelegatedData(const ExecutionPolicy &ex_policy) { return delegated_; };
     template <class PolicyType>
-    DataType *DelegatedOnDevice(const DeviceExecution<PolicyType> &ex_policy);
+    DataType *DelegatedOnDevice(const SYCLDevicePolicy &ex_policy);
     template <class PolicyType>
-    DataType *DelegatedData(const DeviceExecution<PolicyType> &ex_policy)
+    DataType *DelegatedData(const SYCLDevicePolicy &ex_policy)
     {
         return DelegatedOnDevice(ex_policy);
     };
@@ -109,7 +109,7 @@ class DeviceOnlyConstantArray : public Quantity
 {
   public:
     template <class PolicyType>
-    DeviceOnlyConstantArray(const DeviceExecution<PolicyType> &ex_policy,
+    DeviceOnlyConstantArray(const SYCLDevicePolicy &ex_policy,
                             ConstantArray<DataType> *host_constant);
     ~DeviceOnlyConstantArray();
 
@@ -141,9 +141,9 @@ class ComputingKernelArray : public Quantity
     template <class ExecutionPolicy>
     ComputingKernelType *DelegatedData(const ExecutionPolicy &ex_policy) { return delegated_; };
     template <class PolicyType>
-    ComputingKernelType *DelegatedOnDevice(const DeviceExecution<PolicyType> &ex_policy);
+    ComputingKernelType *DelegatedOnDevice(const SYCLDevicePolicy &ex_policy);
     template <class PolicyType>
-    ComputingKernelType *DelegatedData(const DeviceExecution<PolicyType> &ex_policy)
+    ComputingKernelType *DelegatedData(const SYCLDevicePolicy &ex_policy)
     {
         return DelegatedOnDevice(ex_policy);
     };
@@ -167,7 +167,7 @@ class DeviceOnlyComputingKernelArray : public Quantity
   public:
     template <class PolicyType>
     DeviceOnlyComputingKernelArray(
-        const DeviceExecution<PolicyType> &ex_policy,
+        const SYCLDevicePolicy &ex_policy,
         ComputingKernelArray<GeneratorType, ComputingKernelType> *host_constant);
     ~DeviceOnlyComputingKernelArray();
 

--- a/src/shared/common/sphinxsys_variable.h
+++ b/src/shared/common/sphinxsys_variable.h
@@ -154,7 +154,7 @@ class SingleVariable : public Quantity
     DataType *DelegatedData(const ExecutionPolicy &ex_policy) { return delegated_; };
 
     template <class PolicyType>
-    DataType *DelegatedData(const DeviceExecution<PolicyType> &ex_policy)
+    DataType *DelegatedData(const SYCLDevicePolicy &ex_policy)
     {
         return DelegatedOnDevice();
     };
@@ -284,7 +284,7 @@ class DiscreteVariable : public Quantity
     DataType *DelegatedData(const ExecutionPolicy &ex_policy) { return data_; };
 
     template <class PolicyType>
-    DataType *DelegatedData(const DeviceExecution<PolicyType> &ex_policy)
+    DataType *DelegatedData(const SYCLDevicePolicy &ex_policy)
     {
         return DelegatedOnDevice();
     };
@@ -340,7 +340,7 @@ class DiscreteVariable : public Quantity
         }
     };
 
-    void reallocateData(const ParallelDevicePolicy &par_device, UnsignedInt tentative_size)
+    void reallocateData(const SYCLDevicePolicy &sycl_device, UnsignedInt tentative_size)
     {
         if (size_ < tentative_size)
         {
@@ -350,11 +350,11 @@ class DiscreteVariable : public Quantity
 
     template <class ExecutionPolicy>
     void prepareForOutput(const ExecutionPolicy &ex_policy) {};
-    void prepareForOutput(const ParallelDevicePolicy &ex_policy) { synchronizeWithDevice(); };
+    void prepareForOutput(const SYCLDevicePolicy &ex_policy) { synchronizeWithDevice(); };
 
     template <class ExecutionPolicy>
     void finalizeLoadIn(const ExecutionPolicy &ex_policy) {};
-    void finalizeLoadIn(const ParallelDevicePolicy &ex_policy) { synchronizeToDevice(); };
+    void finalizeLoadIn(const SYCLDevicePolicy &ex_policy) { synchronizeToDevice(); };
 
   private:
     UnsignedInt size_, width_;

--- a/src/shared/common/sphinxsys_variable.h
+++ b/src/shared/common/sphinxsys_variable.h
@@ -153,7 +153,6 @@ class SingleVariable : public Quantity
     template <class ExecutionPolicy>
     DataType *DelegatedData(const ExecutionPolicy &ex_policy) { return delegated_; };
 
-    template <class PolicyType>
     DataType *DelegatedData(const SYCLDevicePolicy &ex_policy)
     {
         return DelegatedOnDevice();
@@ -282,8 +281,7 @@ class DiscreteVariable : public Quantity
 
     template <class ExecutionPolicy>
     DataType *DelegatedData(const ExecutionPolicy &ex_policy) { return data_; };
-
-    template <class PolicyType>
+    
     DataType *DelegatedData(const SYCLDevicePolicy &ex_policy)
     {
         return DelegatedOnDevice();

--- a/src/shared/common/sphinxsys_variable_array.h
+++ b/src/shared/common/sphinxsys_variable_array.h
@@ -60,7 +60,6 @@ template <typename DataType>
 class DeviceOnlyVariableArray : public Quantity
 {
   public:
-    template <class PolicyType>
     DeviceOnlyVariableArray(const SYCLDevicePolicy &ex_policy,
                             VariableArray<DataType> *host_variable_array);
     ~DeviceOnlyVariableArray();
@@ -100,10 +99,9 @@ class VariableArray : public Quantity
         return VariableArrayView<DataType>(multi_entry_view_, array_size_);
     };
 
-    template <class PolicyType>
     VariableArrayView<DataType> DelegatedVariableArrayView(const SYCLDevicePolicy &ex_policy)
     {
-        return VariableArrayView<DataType>(DelegatedOnDevice<PolicyType>(), array_size_);
+        return VariableArrayView<DataType>(DelegatedOnDevice(), array_size_);
     };
 
   protected:
@@ -113,7 +111,6 @@ class VariableArray : public Quantity
     DeviceOnlyVariableArray<DataType> *device_only_variable_array_ = nullptr;
     friend class DeviceOnlyVariableArray<DataType>;
 
-    template <class PolicyType>
     MultiEntryView<DataType> *DelegatedOnDevice();
     bool isVariableArrayViewDelegated() { return device_only_variable_array_ != nullptr; };
 };

--- a/src/shared/common/sphinxsys_variable_array.h
+++ b/src/shared/common/sphinxsys_variable_array.h
@@ -61,7 +61,7 @@ class DeviceOnlyVariableArray : public Quantity
 {
   public:
     template <class PolicyType>
-    DeviceOnlyVariableArray(const DeviceExecution<PolicyType> &ex_policy,
+    DeviceOnlyVariableArray(const SYCLDevicePolicy &ex_policy,
                             VariableArray<DataType> *host_variable_array);
     ~DeviceOnlyVariableArray();
     MultiEntryView<DataType> *DeviceOnlyMultiEntryView() { return device_only_multi_entry_view_; };
@@ -101,7 +101,7 @@ class VariableArray : public Quantity
     };
 
     template <class PolicyType>
-    VariableArrayView<DataType> DelegatedVariableArrayView(const DeviceExecution<PolicyType> &ex_policy)
+    VariableArrayView<DataType> DelegatedVariableArrayView(const SYCLDevicePolicy &ex_policy)
     {
         return VariableArrayView<DataType>(DelegatedOnDevice<PolicyType>(), array_size_);
     };

--- a/src/shared/meshes/mesh_iterators.h
+++ b/src/shared/meshes/mesh_iterators.h
@@ -67,7 +67,7 @@ void mesh_for(const execution::SequencedPolicy &seq, const MeshRange &mesh_range
 };
 
 template <typename LocalFunction, typename... Args>
-void mesh_for(const execution::ParallelPolicy &par_host, const MeshRange &mesh_range,
+void mesh_for(const execution::ParallelPolicy &ex_policy, const MeshRange &mesh_range,
               const LocalFunction &local_function, Args &&...args)
 {
     mesh_parallel_for(mesh_range, local_function, std::forward<Args>(args)...);
@@ -82,7 +82,7 @@ void package_for(const execution::SequencedPolicy &seq, UnsignedInt start_index,
 }
 
 template <typename FunctionOnData>
-void package_for(const execution::ParallelPolicy &par_host, UnsignedInt start_index,
+void package_for(const execution::ParallelPolicy &ex_policy, UnsignedInt start_index,
                  UnsignedInt end_index, const FunctionOnData &function)
 {
     tbb::parallel_for(IndexRange(start_index, end_index), [&](const IndexRange &r)
@@ -94,7 +94,7 @@ void package_for(const execution::ParallelPolicy &par_host, UnsignedInt start_in
 }
 
 template <typename FunctionOnData>
-void package_for(const execution::ParallelDevicePolicy &par_device,
+void package_for(const execution::SYCLDevicePolicy &sycl_device,
                  UnsignedInt start_index, UnsignedInt end_index,
                  const FunctionOnData &function);
 } // namespace SPH

--- a/src/shared/particle_dynamics/execution/execution_policy.h
+++ b/src/shared/particle_dynamics/execution/execution_policy.h
@@ -50,33 +50,18 @@ class ParallelUnsequencedPolicy
 {
 };
 
-template <typename...>
-class DeviceExecution;
-
-template <>
-class DeviceExecution<>
+class SYCLDevicePolicy
 {
 };
-
-template <typename PolicyType>
-class DeviceExecution<PolicyType>
-    : public DeviceExecution<>, public PolicyType
-{
-};
-
-using ParallelDevicePolicy = DeviceExecution<ParallelPolicy>;
-using SequencedDevicePolicy = DeviceExecution<SequencedPolicy>;
 
 inline constexpr auto seq = SequencedPolicy{};
 inline constexpr auto unseq = UnsequencedPolicy{};
 inline constexpr auto par_host = ParallelPolicy{};
 inline constexpr auto par_unseq = ParallelUnsequencedPolicy{};
-inline constexpr auto par_device = ParallelDevicePolicy{};
-inline constexpr auto seq_device = SequencedDevicePolicy{};
 
 #if SPHINXSYS_USE_SYCL
-using MainExecutionPolicy = ParallelDevicePolicy;
-inline constexpr auto par_ck = ParallelDevicePolicy{};
+using MainExecutionPolicy = SYCLDevicePolicy;
+inline constexpr auto par_ck = SYCLDevicePolicy{};
 #else
 using MainExecutionPolicy = ParallelPolicy;
 inline constexpr auto par_ck = ParallelPolicy{};

--- a/src/shared/particle_dynamics/execution/implementation.h
+++ b/src/shared/particle_dynamics/execution/implementation.h
@@ -73,13 +73,13 @@ template <class ComputingKernelType>
 inline void freeComputingKernelOnDevice(ComputingKernelType *device_kernel);
 
 template <class ComputingKernelType, class PolicyType>
-inline ComputingKernelType *allocateComputingKernel(const DeviceExecution<PolicyType> &ex_policy)
+inline ComputingKernelType *allocateComputingKernel(const SYCLDevicePolicy &ex_policy)
 {
     return allocateComputingKernelOnDevice<ComputingKernelType>();
 }
 
 template <class PolicyType, class ComputingKernelType>
-inline void copyComputingKernel(const DeviceExecution<PolicyType> &ex_policy,
+inline void copyComputingKernel(const SYCLDevicePolicy &ex_policy,
                                 ComputingKernelType *temp_kernel,
                                 ComputingKernelType *computing_kernel)
 {
@@ -87,7 +87,7 @@ inline void copyComputingKernel(const DeviceExecution<PolicyType> &ex_policy,
 }
 
 template <class PolicyType, class ComputingKernelType>
-inline void freeComputingKernel(const DeviceExecution<PolicyType> &ex_policy,
+inline void freeComputingKernel(const SYCLDevicePolicy &ex_policy,
                                 ComputingKernelType *computing_kernel)
 {
     freeComputingKernelOnDevice(computing_kernel);

--- a/src/shared/particle_dynamics/particle_iterators.h
+++ b/src/shared/particle_dynamics/particle_iterators.h
@@ -66,7 +66,7 @@ inline void particle_for(const SequencedPolicy &seq, const IndexRange &particles
 };
 
 template <class LocalDynamicsFunction>
-inline void particle_for(const ParallelPolicy &par_host, const IndexRange &particles_range,
+inline void particle_for(const ParallelPolicy &ex_policy, const IndexRange &particles_range,
                          const LocalDynamicsFunction &local_dynamics_function)
 {
     tbb::parallel_for(
@@ -93,7 +93,7 @@ inline void particle_for(const SequencedPolicy &seq, const IndexVector &body_par
 };
 
 template <class LocalDynamicsFunction>
-inline void particle_for(const ParallelPolicy &par_host, const IndexVector &body_part_particles,
+inline void particle_for(const ParallelPolicy &ex_policy, const IndexVector &body_part_particles,
                          const LocalDynamicsFunction &local_dynamics_function)
 {
     tbb::parallel_for(
@@ -125,7 +125,7 @@ inline void particle_for(const SequencedPolicy &seq, const ConcurrentCellLists &
 }
 
 template <class LocalDynamicsFunction>
-inline void particle_for(const ParallelPolicy &par_host, const ConcurrentCellLists &body_part_cells,
+inline void particle_for(const ParallelPolicy &ex_policy, const ConcurrentCellLists &body_part_cells,
                          const LocalDynamicsFunction &local_dynamics_function)
 {
     tbb::parallel_for(
@@ -155,7 +155,7 @@ inline void particle_for(const SequencedPolicy &seq, const DataListsInCells &bod
 };
 
 template <class LocalDynamicsFunction>
-inline void particle_for(const ParallelPolicy &par_host, const DataListsInCells &body_part_cells,
+inline void particle_for(const ParallelPolicy &ex_policy, const DataListsInCells &body_part_cells,
                          const LocalDynamicsFunction &local_dynamics_function)
 {
     tbb::parallel_for(
@@ -196,7 +196,7 @@ inline ReturnType particle_reduce(const SequencedPolicy &seq, const IndexRange &
 }
 
 template <class ReturnType, typename Operation, class LocalDynamicsFunction>
-inline ReturnType particle_reduce(const ParallelPolicy &par_host, const IndexRange &particles_range,
+inline ReturnType particle_reduce(const ParallelPolicy &ex_policy, const IndexRange &particles_range,
                                   ReturnType temp, Operation &&operation,
                                   const LocalDynamicsFunction &local_dynamics_function)
 {
@@ -230,7 +230,7 @@ inline ReturnType particle_reduce(const SequencedPolicy &seq, const IndexVector 
 }
 
 template <class ReturnType, typename Operation, class LocalDynamicsFunction>
-inline ReturnType particle_reduce(const ParallelPolicy &par_host, const IndexVector &body_part_particles,
+inline ReturnType particle_reduce(const ParallelPolicy &ex_policy, const IndexVector &body_part_particles,
                                   ReturnType temp, Operation &&operation,
                                   const LocalDynamicsFunction &local_dynamics_function)
 {
@@ -272,7 +272,7 @@ inline ReturnType particle_reduce(const SequencedPolicy &seq, const ConcurrentCe
 }
 
 template <class ReturnType, typename Operation, class LocalDynamicsFunction>
-inline ReturnType particle_reduce(const ParallelPolicy &par_host, const ConcurrentCellLists &body_part_cells,
+inline ReturnType particle_reduce(const ParallelPolicy &ex_policy, const ConcurrentCellLists &body_part_cells,
                                   ReturnType temp, Operation &&operation,
                                   const LocalDynamicsFunction &local_dynamics_function)
 {

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/geometric_dynamics.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/geometric_dynamics.h
@@ -44,7 +44,7 @@ class HostKernel
     {
         // not implemented for device policy due to virtual function call in initial_shape_,
         // which is not allowed in device code
-        static_assert(!std::is_base_of<execution::DeviceExecution<>, ExecutionPolicy>::value,
+        static_assert(!std::is_base_of<execution::SYCLDevicePolicy, ExecutionPolicy>::value,
                       "This compute kernel is not designed for execution on device!");
     }
 };

--- a/src/src_sycl/shared/common/algorithm_primitive_sycl.cpp
+++ b/src/src_sycl/shared/common/algorithm_primitive_sycl.cpp
@@ -5,7 +5,7 @@
 namespace SPH
 {
 //=================================================================================================//
-void RadixSort::sort(const ParallelDevicePolicy &ex_policy, UnsignedInt size, UnsignedInt start_index)
+void RadixSort::sort(const SYCLDevicePolicy &ex_policy, UnsignedInt size, UnsignedInt start_index)
 {
     UnsignedInt *index_permutation = dv_index_permutation_->DelegatedData(ex_policy);
     UnsignedInt *begin = dv_sequence_->DelegatedData(ex_policy) + start_index;

--- a/src/src_sycl/shared/common/algorithm_primitive_sycl.h
+++ b/src/src_sycl/shared/common/algorithm_primitive_sycl.h
@@ -85,7 +85,7 @@ class RadixSort
                        DiscreteVariable<UnsignedInt> *dv_sequence,
                        DiscreteVariable<UnsignedInt> *dv_index_permutation)
         : dv_sequence_(dv_sequence), dv_index_permutation_(dv_index_permutation) {};
-    void sort(const ParallelDevicePolicy &ex_policy, UnsignedInt size, UnsignedInt start_index = 0);
+    void sort(const SYCLDevicePolicy &ex_policy, UnsignedInt size, UnsignedInt start_index = 0);
 
   protected:
     DiscreteVariable<UnsignedInt> *dv_sequence_;
@@ -94,7 +94,7 @@ class RadixSort
 };
 
 template <typename T, typename Op>
-T exclusive_scan(const ParallelDevicePolicy &par_policy, T *first, T *d_first, UnsignedInt d_size, Op op)
+T exclusive_scan(const SYCLDevicePolicy &par_policy, T *first, T *d_first, UnsignedInt d_size, Op op)
 {
 #if !SPHINXSYS_USE_ONEDPL
     execution_instance.getQueue()
@@ -122,7 +122,7 @@ T exclusive_scan(const ParallelDevicePolicy &par_policy, T *first, T *d_first, U
 }
 
 template <class UnaryFunc>
-void generic_for(const ParallelDevicePolicy &par_device,
+void generic_for(const SYCLDevicePolicy &sycl_device,
                  const IndexRange &index_range,
                  const UnaryFunc &unary_func)
 {

--- a/src/src_sycl/shared/common/sphinxsys_constant_sycl.hpp
+++ b/src/src_sycl/shared/common/sphinxsys_constant_sycl.hpp
@@ -8,7 +8,6 @@ namespace SPH
 {
 //=================================================================================================//
 template <typename DataType>
-template <class PolicyType>
 DataType *ConstantArray<DataType>::DelegatedOnDevice(const SYCLDevicePolicy &ex_policy)
 {
     if (!isDataDelegated())
@@ -20,7 +19,6 @@ DataType *ConstantArray<DataType>::DelegatedOnDevice(const SYCLDevicePolicy &ex_
 };
 //=================================================================================================//
 template <typename DataType>
-template <class PolicyType>
 DeviceOnlyConstantArray<DataType>::DeviceOnlyConstantArray(
     const SYCLDevicePolicy &ex_policy, ConstantArray<DataType> *host_constant)
     : Quantity(host_constant->Name()), device_only_data_(nullptr)
@@ -39,7 +37,6 @@ DeviceOnlyConstantArray<DataType>::~DeviceOnlyConstantArray()
 }
 //=================================================================================================//
 template <typename GeneratorType, typename ComputingKernelType>
-template <class PolicyType>
 ComputingKernelType *ComputingKernelArray<GeneratorType, ComputingKernelType>::DelegatedOnDevice(
     const SYCLDevicePolicy &ex_policy)
 {
@@ -52,7 +49,6 @@ ComputingKernelType *ComputingKernelArray<GeneratorType, ComputingKernelType>::D
 }
 //=================================================================================================//
 template <typename GeneratorType, typename ComputingKernelType>
-template <class PolicyType>
 DeviceOnlyComputingKernelArray<GeneratorType, ComputingKernelType>::DeviceOnlyComputingKernelArray(
     const SYCLDevicePolicy &ex_policy,
     ComputingKernelArray<GeneratorType, ComputingKernelType> *host_constant)

--- a/src/src_sycl/shared/common/sphinxsys_constant_sycl.hpp
+++ b/src/src_sycl/shared/common/sphinxsys_constant_sycl.hpp
@@ -9,12 +9,12 @@ namespace SPH
 //=================================================================================================//
 template <typename DataType>
 template <class PolicyType>
-DataType *ConstantArray<DataType>::DelegatedOnDevice(const DeviceExecution<PolicyType> &ex_policy)
+DataType *ConstantArray<DataType>::DelegatedOnDevice(const SYCLDevicePolicy &ex_policy)
 {
     if (!isDataDelegated())
     {
         device_only_constant_array_keeper_
-            .createPtr<DeviceOnlyConstantArray<DataType>>(DeviceExecution<PolicyType>{}, this);
+            .createPtr<DeviceOnlyConstantArray<DataType>>(SYCLDevicePolicy{}, this);
     }
     return delegated_;
 };
@@ -22,7 +22,7 @@ DataType *ConstantArray<DataType>::DelegatedOnDevice(const DeviceExecution<Polic
 template <typename DataType>
 template <class PolicyType>
 DeviceOnlyConstantArray<DataType>::DeviceOnlyConstantArray(
-    const DeviceExecution<PolicyType> &ex_policy, ConstantArray<DataType> *host_constant)
+    const SYCLDevicePolicy &ex_policy, ConstantArray<DataType> *host_constant)
     : Quantity(host_constant->Name()), device_only_data_(nullptr)
 {
     size_t data_size = host_constant->getSize();
@@ -41,12 +41,12 @@ DeviceOnlyConstantArray<DataType>::~DeviceOnlyConstantArray()
 template <typename GeneratorType, typename ComputingKernelType>
 template <class PolicyType>
 ComputingKernelType *ComputingKernelArray<GeneratorType, ComputingKernelType>::DelegatedOnDevice(
-    const DeviceExecution<PolicyType> &ex_policy)
+    const SYCLDevicePolicy &ex_policy)
 {
     if (!isDataDelegated())
     {
         device_only_kernel_array_keeper_.createPtr<DeviceOnlyComputingKernelArray<
-            GeneratorType, ComputingKernelType>>(DeviceExecution<PolicyType>{}, this);
+            GeneratorType, ComputingKernelType>>(SYCLDevicePolicy{}, this);
     }
     return delegated_;
 }
@@ -54,7 +54,7 @@ ComputingKernelType *ComputingKernelArray<GeneratorType, ComputingKernelType>::D
 template <typename GeneratorType, typename ComputingKernelType>
 template <class PolicyType>
 DeviceOnlyComputingKernelArray<GeneratorType, ComputingKernelType>::DeviceOnlyComputingKernelArray(
-    const DeviceExecution<PolicyType> &ex_policy,
+    const SYCLDevicePolicy &ex_policy,
     ComputingKernelArray<GeneratorType, ComputingKernelType> *host_constant)
     : Quantity(host_constant->Name()), device_only_data_(nullptr)
 {

--- a/src/src_sycl/shared/common/sphinxsys_variable_array_sycl.hpp
+++ b/src/src_sycl/shared/common/sphinxsys_variable_array_sycl.hpp
@@ -8,7 +8,6 @@ namespace SPH
 {
 //=================================================================================================//
 template <typename DataType>
-template <class PolicyType>
 MultiEntryView<DataType> *VariableArray<DataType>::DelegatedOnDevice()
 {
     if (!isVariableArrayViewDelegated())
@@ -20,7 +19,6 @@ MultiEntryView<DataType> *VariableArray<DataType>::DelegatedOnDevice()
 }
 //=================================================================================================//
 template <typename DataType>
-template <class PolicyType>
 DeviceOnlyVariableArray<DataType>::
     DeviceOnlyVariableArray(const SYCLDevicePolicy &ex_policy,
                             VariableArray<DataType> *host_variable_array)

--- a/src/src_sycl/shared/common/sphinxsys_variable_array_sycl.hpp
+++ b/src/src_sycl/shared/common/sphinxsys_variable_array_sycl.hpp
@@ -14,7 +14,7 @@ MultiEntryView<DataType> *VariableArray<DataType>::DelegatedOnDevice()
     if (!isVariableArrayViewDelegated())
     {
         device_only_variable_array_ = device_only_variable_array_keeper_.createPtr<
-            DeviceOnlyVariableArray<DataType>>(DeviceExecution<PolicyType>{}, this);
+            DeviceOnlyVariableArray<DataType>>(SYCLDevicePolicy{}, this);
     }
     return device_only_variable_array_->DeviceOnlyMultiEntryView();
 }
@@ -22,7 +22,7 @@ MultiEntryView<DataType> *VariableArray<DataType>::DelegatedOnDevice()
 template <typename DataType>
 template <class PolicyType>
 DeviceOnlyVariableArray<DataType>::
-    DeviceOnlyVariableArray(const DeviceExecution<PolicyType> &ex_policy,
+    DeviceOnlyVariableArray(const SYCLDevicePolicy &ex_policy,
                             VariableArray<DataType> *host_variable_array)
     : Quantity(host_variable_array->Name()), device_only_multi_entry_view_(nullptr)
 {

--- a/src/src_sycl/shared/mesh_dynamics/mesh_iterators_sycl.hpp
+++ b/src/src_sycl/shared/mesh_dynamics/mesh_iterators_sycl.hpp
@@ -8,7 +8,7 @@ namespace SPH
 {
 //=================================================================================================//
 template <typename FunctionOnData>
-void package_for(const ParallelDevicePolicy &par_device, UnsignedInt start_index,
+void package_for(const SYCLDevicePolicy &sycl_device, UnsignedInt start_index,
                  UnsignedInt end_index, const FunctionOnData &function)
 {
     UnsignedInt operations = end_index - start_index;

--- a/src/src_sycl/shared/particle_dynamics/configuration_dynamics/base_configuration_dynamics_sycl.h
+++ b/src/src_sycl/shared/particle_dynamics/configuration_dynamics/base_configuration_dynamics_sycl.h
@@ -36,13 +36,13 @@ namespace SPH
 
 class RadixSort;
 template <>
-struct SortMethod<ParallelDevicePolicy>
+struct SortMethod<SYCLDevicePolicy>
 {
     typedef RadixSort type;
 };
 
 template <>
-struct PlusUnsignedInt<ParallelDevicePolicy>
+struct PlusUnsignedInt<SYCLDevicePolicy>
 {
     typedef sycl::plus<UnsignedInt> type;
 };

--- a/src/src_sycl/shared/particle_dynamics/particle_iterators_sycl.h
+++ b/src/src_sycl/shared/particle_dynamics/particle_iterators_sycl.h
@@ -35,7 +35,7 @@
 namespace SPH
 {
 template <class UnaryFunc>
-void particle_for(const ParallelDevicePolicy &par_device,
+void particle_for(const SYCLDevicePolicy &sycl_device,
                   const IndexRange &particles_range,
                   const UnaryFunc &unary_func)
 {
@@ -50,21 +50,7 @@ void particle_for(const ParallelDevicePolicy &par_device,
 }
 
 template <class Identifier, class UnaryFunc>
-void particle_for(const LoopRangeCK<SequencedDevicePolicy, Identifier> &loop_range,
-                  const UnaryFunc &unary_func)
-{
-    auto &sycl_queue = execution_instance.getQueue();
-    const size_t loop_bound = loop_range.LoopBound();
-    sycl_queue.submit([&](sycl::handler &cgh)
-                      { cgh.single_task([=]()
-                                        {
-                                for (int i = 0; i != loop_bound; i++)
-                                    loop_range.computeUnit(unary_func, i); }); })
-        .wait_and_throw();
-}
-
-template <class Identifier, class UnaryFunc>
-void particle_for(const LoopRangeCK<ParallelDevicePolicy, Identifier> &loop_range,
+void particle_for(const LoopRangeCK<SYCLDevicePolicy, Identifier> &loop_range,
                   const UnaryFunc &unary_func)
 {
     auto &sycl_queue = execution_instance.getQueue();
@@ -78,7 +64,7 @@ void particle_for(const LoopRangeCK<ParallelDevicePolicy, Identifier> &loop_rang
 }
 
 template <typename Operation, class Identifier, class ReturnType, class UnaryFunc>
-ReturnType particle_reduce(const LoopRangeCK<ParallelDevicePolicy, Identifier> &loop_range,
+ReturnType particle_reduce(const LoopRangeCK<SYCLDevicePolicy, Identifier> &loop_range,
                            ReturnType temp, const UnaryFunc &unary_func)
 {
     auto &sycl_queue = execution_instance.getQueue();

--- a/tests/tests_sycl/unit_test_src/shared/particle_dynamics/configuration_dynamics/test_exclusive_scan_sycl/test_exclusive_scan.cpp
+++ b/tests/tests_sycl/unit_test_src/shared/particle_dynamics/configuration_dynamics/test_exclusive_scan_sycl/test_exclusive_scan.cpp
@@ -22,7 +22,7 @@ TEST(exclusive_scan, test_sycl)
     UnsignedInt *device_list_data = allocateDeviceOnly<UnsignedInt>(list_size);
     UnsignedInt *device_result = allocateDeviceOnly<UnsignedInt>(list_size);
     copyToDevice(list_data, device_list_data, list_size);
-    UnsignedInt sycl_sum = exclusive_scan(ParallelDevicePolicy{}, device_list_data, device_result, list_size, PlusUnsignedInt<ParallelDevicePolicy>::type());
+    UnsignedInt sycl_sum = exclusive_scan(SYCLDevicePolicy{}, device_list_data, device_result, list_size, PlusUnsignedInt<SYCLDevicePolicy>::type());
     copyFromDevice(sycl_result.data(), device_result, list_size);
 
     freeDeviceData(device_list_data);

--- a/tests/tests_sycl/unit_test_src/shared/particle_dynamics/test_particle_reduce_sycl/test_particle_reduce.cpp
+++ b/tests/tests_sycl/unit_test_src/shared/particle_dynamics/test_particle_reduce_sycl/test_particle_reduce.cpp
@@ -55,10 +55,10 @@ TEST(particle_reduce, test_sycl)
             return SimTK::SpatialVec(a, force_ck[i]);
         });
 
-    SimTKVec3 *torque_sycl = dv_torque.DelegatedData(ParallelDevicePolicy{});
-    SimTKVec3 *force_sycl = dv_force.DelegatedData(ParallelDevicePolicy{});
+    SimTKVec3 *torque_sycl = dv_torque.DelegatedData(SYCLDevicePolicy{});
+    SimTKVec3 *force_sycl = dv_force.DelegatedData(SYCLDevicePolicy{});
     SimTK::SpatialVec sum_sycl = particle_reduce<ReduceSum<SimTK::SpatialVec>>(
-        LoopRangeCK<ParallelDevicePolicy, SPHBody>(&sv_total_particles),
+        LoopRangeCK<SYCLDevicePolicy, SPHBody>(&sv_total_particles),
         ReduceReference<ReduceSum<SimTK::SpatialVec>>::value,
         [=](size_t i)
         {


### PR DESCRIPTION
This pull request refactors the execution policy abstraction for device (SYCL) parallelism throughout the codebase. The main change is the replacement of the old templated `DeviceExecution<PolicyType>` and related types with a single, unified `SYCLDevicePolicy`. This results in a clearer, more maintainable execution policy interface for device-side code, and updates all relevant function signatures and class methods to use the new policy type.

Key changes include:

**Execution Policy Refactoring:**

* Removed the `DeviceExecution` template class and its specializations, replacing them with the new `SYCLDevicePolicy` class. All device-related execution policies now use `SYCLDevicePolicy` directly, simplifying the policy hierarchy and usage.

* Updated all function and method signatures that previously accepted `DeviceExecution<PolicyType>` or `ParallelDevicePolicy` to use `SYCLDevicePolicy` instead, including constructors, member functions, and free functions across the codebase. [[1]](diffhunk://#diff-626afb5c87620384b2b0db239c529ef4925994c70f74191dee1a9d01a4a38da6L87-R89) [[2]](diffhunk://#diff-626afb5c87620384b2b0db239c529ef4925994c70f74191dee1a9d01a4a38da6L112-R112) [[3]](diffhunk://#diff-626afb5c87620384b2b0db239c529ef4925994c70f74191dee1a9d01a4a38da6L144-R146) [[4]](diffhunk://#diff-626afb5c87620384b2b0db239c529ef4925994c70f74191dee1a9d01a4a38da6L170-R170) [[5]](diffhunk://#diff-f13847e73cef33d9c9f381e692f69aa72993c8e5b77709c1a1fc098cfcbbc587L157-R157) [[6]](diffhunk://#diff-f13847e73cef33d9c9f381e692f69aa72993c8e5b77709c1a1fc098cfcbbc587L287-R287) [[7]](diffhunk://#diff-f13847e73cef33d9c9f381e692f69aa72993c8e5b77709c1a1fc098cfcbbc587L343-R343) [[8]](diffhunk://#diff-f13847e73cef33d9c9f381e692f69aa72993c8e5b77709c1a1fc098cfcbbc587L353-R357) [[9]](diffhunk://#diff-2ee8328598207abab08b86f9b674c26d4164672ba9716f8a46bc26526837882bL64-R64) [[10]](diffhunk://#diff-2ee8328598207abab08b86f9b674c26d4164672ba9716f8a46bc26526837882bL104-R104) [[11]](diffhunk://#diff-0bdf796ceaaa19ca30779d4ba8f087ca8f65620603abd7e61cfdffc7d597aa9cL76-R90) [[12]](diffhunk://#diff-146ed64eb37c7bbdf6173101b7eae023c6d8320ea221a8f9981382290faf43e0L8-R8) [[13]](diffhunk://#diff-b1ebaea1a5cb4cd1d9fd5b1b0f74742355680427e690c9cb4b8cc6c9be790ff9L88-R88) [[14]](diffhunk://#diff-b1ebaea1a5cb4cd1d9fd5b1b0f74742355680427e690c9cb4b8cc6c9be790ff9L97-R97) [[15]](diffhunk://#diff-b1ebaea1a5cb4cd1d9fd5b1b0f74742355680427e690c9cb4b8cc6c9be790ff9L125-R125)

**API Consistency and Clean-up:**

* Standardized naming for parallel policy parameters in function signatures (e.g., replacing `par_host` and `par_device` with `ex_policy` or `sycl_device` for clarity and consistency). [[1]](diffhunk://#diff-7ecb06cce8571e4ae18ef35d875d66016ed3aad4be6b46a5dff962e07d5a6ddfL290-R290) [[2]](diffhunk://#diff-a7de0f90381a90e37e4a4d792300b6819c68a68b7487b6aca488dccc1d81864eL70-R70) [[3]](diffhunk://#diff-a7de0f90381a90e37e4a4d792300b6819c68a68b7487b6aca488dccc1d81864eL85-R85) [[4]](diffhunk://#diff-a7de0f90381a90e37e4a4d792300b6819c68a68b7487b6aca488dccc1d81864eL97-R97) [[5]](diffhunk://#diff-33ae062ca63edfec2462b6d477b1fdaa8ced55c070fd0e435706ba767bb0cab9L69-R69) [[6]](diffhunk://#diff-33ae062ca63edfec2462b6d477b1fdaa8ced55c070fd0e435706ba767bb0cab9L96-R96) [[7]](diffhunk://#diff-33ae062ca63edfec2462b6d477b1fdaa8ced55c070fd0e435706ba767bb0cab9L128-R128) [[8]](diffhunk://#diff-33ae062ca63edfec2462b6d477b1fdaa8ced55c070fd0e435706ba767bb0cab9L158-R158) [[9]](diffhunk://#diff-33ae062ca63edfec2462b6d477b1fdaa8ced55c070fd0e435706ba767bb0cab9L199-R199) [[10]](diffhunk://#diff-33ae062ca63edfec2462b6d477b1fdaa8ced55c070fd0e435706ba767bb0cab9L233-R233) [[11]](diffhunk://#diff-33ae062ca63edfec2462b6d477b1fdaa8ced55c070fd0e435706ba767bb0cab9L275-R275)

* Updated static assertions and checks to reference the new `SYCLDevicePolicy` type instead of the old `DeviceExecution` base.

These changes improve code clarity, reduce template complexity, and make it easier to maintain and extend device execution policies in the future.