### PR TITLE
Xiangyu/unitfied computing kernel interface

### DIFF
--- a/src/shared/common/algorithm_primitive.h
+++ b/src/shared/common/algorithm_primitive.h
@@ -287,7 +287,7 @@ inline void generic_for(const SequencedPolicy &seq, const IndexRange &index_rang
 };
 
 template <class LocalDynamicsFunction>
-inline void generic_for(const ParallelPolicy &par_host, const IndexRange &particles_range,
+inline void generic_for(const ParallelPolicy &ex_policy, const IndexRange &particles_range,
                          const LocalDynamicsFunction &local_dynamics_function)
 {
     tbb::parallel_for(

--- a/src/shared/common/sphinxsys_constant.h
+++ b/src/shared/common/sphinxsys_constant.h
@@ -83,13 +83,13 @@ class ConstantArray : public Quantity
     DataType *Data() { return data_; };
     template <class ExecutionPolicy>
     DataType *DelegatedData(const ExecutionPolicy &ex_policy) { return delegated_; };
-    template <class PolicyType>
     DataType *DelegatedOnDevice(const SYCLDevicePolicy &ex_policy);
-    template <class PolicyType>
+
     DataType *DelegatedData(const SYCLDevicePolicy &ex_policy)
     {
         return DelegatedOnDevice(ex_policy);
     };
+
     template <class ExecutionPolicy>
     ArrayView<DataType> DelegatedArrayView(const ExecutionPolicy &ex_policy)
     {
@@ -108,7 +108,6 @@ template <typename DataType>
 class DeviceOnlyConstantArray : public Quantity
 {
   public:
-    template <class PolicyType>
     DeviceOnlyConstantArray(const SYCLDevicePolicy &ex_policy,
                             ConstantArray<DataType> *host_constant);
     ~DeviceOnlyConstantArray();
@@ -140,9 +139,7 @@ class ComputingKernelArray : public Quantity
     StdVec<GeneratorType *> getGenerators() { return generators_; }
     template <class ExecutionPolicy>
     ComputingKernelType *DelegatedData(const ExecutionPolicy &ex_policy) { return delegated_; };
-    template <class PolicyType>
     ComputingKernelType *DelegatedOnDevice(const SYCLDevicePolicy &ex_policy);
-    template <class PolicyType>
     ComputingKernelType *DelegatedData(const SYCLDevicePolicy &ex_policy)
     {
         return DelegatedOnDevice(ex_policy);
@@ -165,7 +162,6 @@ template <typename GeneratorType, typename ComputingKernelType>
 class DeviceOnlyComputingKernelArray : public Quantity
 {
   public:
-    template <class PolicyType>
     DeviceOnlyComputingKernelArray(
         const SYCLDevicePolicy &ex_policy,
         ComputingKernelArray<GeneratorType, ComputingKernelType> *host_constant);

--- a/src/shared/common/sphinxsys_constant.h
+++ b/src/shared/common/sphinxsys_constant.h
@@ -84,9 +84,9 @@ class ConstantArray : public Quantity
     template <class ExecutionPolicy>
     DataType *DelegatedData(const ExecutionPolicy &ex_policy) { return delegated_; };
     template <class PolicyType>
-    DataType *DelegatedOnDevice(const DeviceExecution<PolicyType> &ex_policy);
+    DataType *DelegatedOnDevice(const SYCLDevicePolicy &ex_policy);
     template <class PolicyType>
-    DataType *DelegatedData(const DeviceExecution<PolicyType> &ex_policy)
+    DataType *DelegatedData(const SYCLDevicePolicy &ex_policy)
     {
         return DelegatedOnDevice(ex_policy);
     };
@@ -109,7 +109,7 @@ class DeviceOnlyConstantArray : public Quantity
 {
   public:
     template <class PolicyType>
-    DeviceOnlyConstantArray(const DeviceExecution<PolicyType> &ex_policy,
+    DeviceOnlyConstantArray(const SYCLDevicePolicy &ex_policy,
                             ConstantArray<DataType> *host_constant);
     ~DeviceOnlyConstantArray();
 
@@ -141,9 +141,9 @@ class ComputingKernelArray : public Quantity
     template <class ExecutionPolicy>
     ComputingKernelType *DelegatedData(const ExecutionPolicy &ex_policy) { return delegated_; };
     template <class PolicyType>
-    ComputingKernelType *DelegatedOnDevice(const DeviceExecution<PolicyType> &ex_policy);
+    ComputingKernelType *DelegatedOnDevice(const SYCLDevicePolicy &ex_policy);
     template <class PolicyType>
-    ComputingKernelType *DelegatedData(const DeviceExecution<PolicyType> &ex_policy)
+    ComputingKernelType *DelegatedData(const SYCLDevicePolicy &ex_policy)
     {
         return DelegatedOnDevice(ex_policy);
     };
@@ -167,7 +167,7 @@ class DeviceOnlyComputingKernelArray : public Quantity
   public:
     template <class PolicyType>
     DeviceOnlyComputingKernelArray(
-        const DeviceExecution<PolicyType> &ex_policy,
+        const SYCLDevicePolicy &ex_policy,
         ComputingKernelArray<GeneratorType, ComputingKernelType> *host_constant);
     ~DeviceOnlyComputingKernelArray();
 

--- a/src/shared/common/sphinxsys_variable.h
+++ b/src/shared/common/sphinxsys_variable.h
@@ -154,7 +154,7 @@ class SingleVariable : public Quantity
     DataType *DelegatedData(const ExecutionPolicy &ex_policy) { return delegated_; };
 
     template <class PolicyType>
-    DataType *DelegatedData(const DeviceExecution<PolicyType> &ex_policy)
+    DataType *DelegatedData(const SYCLDevicePolicy &ex_policy)
     {
         return DelegatedOnDevice();
     };
@@ -284,7 +284,7 @@ class DiscreteVariable : public Quantity
     DataType *DelegatedData(const ExecutionPolicy &ex_policy) { return data_; };
 
     template <class PolicyType>
-    DataType *DelegatedData(const DeviceExecution<PolicyType> &ex_policy)
+    DataType *DelegatedData(const SYCLDevicePolicy &ex_policy)
     {
         return DelegatedOnDevice();
     };
@@ -340,7 +340,7 @@ class DiscreteVariable : public Quantity
         }
     };
 
-    void reallocateData(const ParallelDevicePolicy &par_device, UnsignedInt tentative_size)
+    void reallocateData(const SYCLDevicePolicy &sycl_device, UnsignedInt tentative_size)
     {
         if (size_ < tentative_size)
         {
@@ -350,11 +350,11 @@ class DiscreteVariable : public Quantity
 
     template <class ExecutionPolicy>
     void prepareForOutput(const ExecutionPolicy &ex_policy) {};
-    void prepareForOutput(const ParallelDevicePolicy &ex_policy) { synchronizeWithDevice(); };
+    void prepareForOutput(const SYCLDevicePolicy &ex_policy) { synchronizeWithDevice(); };
 
     template <class ExecutionPolicy>
     void finalizeLoadIn(const ExecutionPolicy &ex_policy) {};
-    void finalizeLoadIn(const ParallelDevicePolicy &ex_policy) { synchronizeToDevice(); };
+    void finalizeLoadIn(const SYCLDevicePolicy &ex_policy) { synchronizeToDevice(); };
 
   private:
     UnsignedInt size_, width_;

--- a/src/shared/common/sphinxsys_variable.h
+++ b/src/shared/common/sphinxsys_variable.h
@@ -153,7 +153,6 @@ class SingleVariable : public Quantity
     template <class ExecutionPolicy>
     DataType *DelegatedData(const ExecutionPolicy &ex_policy) { return delegated_; };
 
-    template <class PolicyType>
     DataType *DelegatedData(const SYCLDevicePolicy &ex_policy)
     {
         return DelegatedOnDevice();
@@ -282,8 +281,7 @@ class DiscreteVariable : public Quantity
 
     template <class ExecutionPolicy>
     DataType *DelegatedData(const ExecutionPolicy &ex_policy) { return data_; };
-
-    template <class PolicyType>
+    
     DataType *DelegatedData(const SYCLDevicePolicy &ex_policy)
     {
         return DelegatedOnDevice();

--- a/src/shared/common/sphinxsys_variable_array.h
+++ b/src/shared/common/sphinxsys_variable_array.h
@@ -60,7 +60,6 @@ template <typename DataType>
 class DeviceOnlyVariableArray : public Quantity
 {
   public:
-    template <class PolicyType>
     DeviceOnlyVariableArray(const SYCLDevicePolicy &ex_policy,
                             VariableArray<DataType> *host_variable_array);
     ~DeviceOnlyVariableArray();
@@ -100,10 +99,9 @@ class VariableArray : public Quantity
         return VariableArrayView<DataType>(multi_entry_view_, array_size_);
     };
 
-    template <class PolicyType>
     VariableArrayView<DataType> DelegatedVariableArrayView(const SYCLDevicePolicy &ex_policy)
     {
-        return VariableArrayView<DataType>(DelegatedOnDevice<PolicyType>(), array_size_);
+        return VariableArrayView<DataType>(DelegatedOnDevice(), array_size_);
     };
 
   protected:
@@ -113,7 +111,6 @@ class VariableArray : public Quantity
     DeviceOnlyVariableArray<DataType> *device_only_variable_array_ = nullptr;
     friend class DeviceOnlyVariableArray<DataType>;
 
-    template <class PolicyType>
     MultiEntryView<DataType> *DelegatedOnDevice();
     bool isVariableArrayViewDelegated() { return device_only_variable_array_ != nullptr; };
 };

--- a/src/shared/common/sphinxsys_variable_array.h
+++ b/src/shared/common/sphinxsys_variable_array.h
@@ -61,7 +61,7 @@ class DeviceOnlyVariableArray : public Quantity
 {
   public:
     template <class PolicyType>
-    DeviceOnlyVariableArray(const DeviceExecution<PolicyType> &ex_policy,
+    DeviceOnlyVariableArray(const SYCLDevicePolicy &ex_policy,
                             VariableArray<DataType> *host_variable_array);
     ~DeviceOnlyVariableArray();
     MultiEntryView<DataType> *DeviceOnlyMultiEntryView() { return device_only_multi_entry_view_; };
@@ -101,7 +101,7 @@ class VariableArray : public Quantity
     };
 
     template <class PolicyType>
-    VariableArrayView<DataType> DelegatedVariableArrayView(const DeviceExecution<PolicyType> &ex_policy)
+    VariableArrayView<DataType> DelegatedVariableArrayView(const SYCLDevicePolicy &ex_policy)
     {
         return VariableArrayView<DataType>(DelegatedOnDevice<PolicyType>(), array_size_);
     };

--- a/src/shared/meshes/mesh_iterators.h
+++ b/src/shared/meshes/mesh_iterators.h
@@ -67,7 +67,7 @@ void mesh_for(const execution::SequencedPolicy &seq, const MeshRange &mesh_range
 };
 
 template <typename LocalFunction, typename... Args>
-void mesh_for(const execution::ParallelPolicy &par_host, const MeshRange &mesh_range,
+void mesh_for(const execution::ParallelPolicy &ex_policy, const MeshRange &mesh_range,
               const LocalFunction &local_function, Args &&...args)
 {
     mesh_parallel_for(mesh_range, local_function, std::forward<Args>(args)...);
@@ -82,7 +82,7 @@ void package_for(const execution::SequencedPolicy &seq, UnsignedInt start_index,
 }
 
 template <typename FunctionOnData>
-void package_for(const execution::ParallelPolicy &par_host, UnsignedInt start_index,
+void package_for(const execution::ParallelPolicy &ex_policy, UnsignedInt start_index,
                  UnsignedInt end_index, const FunctionOnData &function)
 {
     tbb::parallel_for(IndexRange(start_index, end_index), [&](const IndexRange &r)
@@ -94,7 +94,7 @@ void package_for(const execution::ParallelPolicy &par_host, UnsignedInt start_in
 }
 
 template <typename FunctionOnData>
-void package_for(const execution::ParallelDevicePolicy &par_device,
+void package_for(const execution::SYCLDevicePolicy &sycl_device,
                  UnsignedInt start_index, UnsignedInt end_index,
                  const FunctionOnData &function);
 } // namespace SPH

--- a/src/shared/particle_dynamics/execution/execution_policy.h
+++ b/src/shared/particle_dynamics/execution/execution_policy.h
@@ -50,33 +50,18 @@ class ParallelUnsequencedPolicy
 {
 };
 
-template <typename...>
-class DeviceExecution;
-
-template <>
-class DeviceExecution<>
+class SYCLDevicePolicy
 {
 };
-
-template <typename PolicyType>
-class DeviceExecution<PolicyType>
-    : public DeviceExecution<>, public PolicyType
-{
-};
-
-using ParallelDevicePolicy = DeviceExecution<ParallelPolicy>;
-using SequencedDevicePolicy = DeviceExecution<SequencedPolicy>;
 
 inline constexpr auto seq = SequencedPolicy{};
 inline constexpr auto unseq = UnsequencedPolicy{};
 inline constexpr auto par_host = ParallelPolicy{};
 inline constexpr auto par_unseq = ParallelUnsequencedPolicy{};
-inline constexpr auto par_device = ParallelDevicePolicy{};
-inline constexpr auto seq_device = SequencedDevicePolicy{};
 
 #if SPHINXSYS_USE_SYCL
-using MainExecutionPolicy = ParallelDevicePolicy;
-inline constexpr auto par_ck = ParallelDevicePolicy{};
+using MainExecutionPolicy = SYCLDevicePolicy;
+inline constexpr auto par_ck = SYCLDevicePolicy{};
 #else
 using MainExecutionPolicy = ParallelPolicy;
 inline constexpr auto par_ck = ParallelPolicy{};

--- a/src/shared/particle_dynamics/execution/implementation.h
+++ b/src/shared/particle_dynamics/execution/implementation.h
@@ -73,13 +73,13 @@ template <class ComputingKernelType>
 inline void freeComputingKernelOnDevice(ComputingKernelType *device_kernel);
 
 template <class ComputingKernelType, class PolicyType>
-inline ComputingKernelType *allocateComputingKernel(const DeviceExecution<PolicyType> &ex_policy)
+inline ComputingKernelType *allocateComputingKernel(const SYCLDevicePolicy &ex_policy)
 {
     return allocateComputingKernelOnDevice<ComputingKernelType>();
 }
 
 template <class PolicyType, class ComputingKernelType>
-inline void copyComputingKernel(const DeviceExecution<PolicyType> &ex_policy,
+inline void copyComputingKernel(const SYCLDevicePolicy &ex_policy,
                                 ComputingKernelType *temp_kernel,
                                 ComputingKernelType *computing_kernel)
 {
@@ -87,7 +87,7 @@ inline void copyComputingKernel(const DeviceExecution<PolicyType> &ex_policy,
 }
 
 template <class PolicyType, class ComputingKernelType>
-inline void freeComputingKernel(const DeviceExecution<PolicyType> &ex_policy,
+inline void freeComputingKernel(const SYCLDevicePolicy &ex_policy,
                                 ComputingKernelType *computing_kernel)
 {
     freeComputingKernelOnDevice(computing_kernel);

--- a/src/shared/particle_dynamics/particle_iterators.h
+++ b/src/shared/particle_dynamics/particle_iterators.h
@@ -66,7 +66,7 @@ inline void particle_for(const SequencedPolicy &seq, const IndexRange &particles
 };
 
 template <class LocalDynamicsFunction>
-inline void particle_for(const ParallelPolicy &par_host, const IndexRange &particles_range,
+inline void particle_for(const ParallelPolicy &ex_policy, const IndexRange &particles_range,
                          const LocalDynamicsFunction &local_dynamics_function)
 {
     tbb::parallel_for(
@@ -93,7 +93,7 @@ inline void particle_for(const SequencedPolicy &seq, const IndexVector &body_par
 };
 
 template <class LocalDynamicsFunction>
-inline void particle_for(const ParallelPolicy &par_host, const IndexVector &body_part_particles,
+inline void particle_for(const ParallelPolicy &ex_policy, const IndexVector &body_part_particles,
                          const LocalDynamicsFunction &local_dynamics_function)
 {
     tbb::parallel_for(
@@ -125,7 +125,7 @@ inline void particle_for(const SequencedPolicy &seq, const ConcurrentCellLists &
 }
 
 template <class LocalDynamicsFunction>
-inline void particle_for(const ParallelPolicy &par_host, const ConcurrentCellLists &body_part_cells,
+inline void particle_for(const ParallelPolicy &ex_policy, const ConcurrentCellLists &body_part_cells,
                          const LocalDynamicsFunction &local_dynamics_function)
 {
     tbb::parallel_for(
@@ -155,7 +155,7 @@ inline void particle_for(const SequencedPolicy &seq, const DataListsInCells &bod
 };
 
 template <class LocalDynamicsFunction>
-inline void particle_for(const ParallelPolicy &par_host, const DataListsInCells &body_part_cells,
+inline void particle_for(const ParallelPolicy &ex_policy, const DataListsInCells &body_part_cells,
                          const LocalDynamicsFunction &local_dynamics_function)
 {
     tbb::parallel_for(
@@ -196,7 +196,7 @@ inline ReturnType particle_reduce(const SequencedPolicy &seq, const IndexRange &
 }
 
 template <class ReturnType, typename Operation, class LocalDynamicsFunction>
-inline ReturnType particle_reduce(const ParallelPolicy &par_host, const IndexRange &particles_range,
+inline ReturnType particle_reduce(const ParallelPolicy &ex_policy, const IndexRange &particles_range,
                                   ReturnType temp, Operation &&operation,
                                   const LocalDynamicsFunction &local_dynamics_function)
 {
@@ -230,7 +230,7 @@ inline ReturnType particle_reduce(const SequencedPolicy &seq, const IndexVector 
 }
 
 template <class ReturnType, typename Operation, class LocalDynamicsFunction>
-inline ReturnType particle_reduce(const ParallelPolicy &par_host, const IndexVector &body_part_particles,
+inline ReturnType particle_reduce(const ParallelPolicy &ex_policy, const IndexVector &body_part_particles,
                                   ReturnType temp, Operation &&operation,
                                   const LocalDynamicsFunction &local_dynamics_function)
 {
@@ -272,7 +272,7 @@ inline ReturnType particle_reduce(const SequencedPolicy &seq, const ConcurrentCe
 }
 
 template <class ReturnType, typename Operation, class LocalDynamicsFunction>
-inline ReturnType particle_reduce(const ParallelPolicy &par_host, const ConcurrentCellLists &body_part_cells,
+inline ReturnType particle_reduce(const ParallelPolicy &ex_policy, const ConcurrentCellLists &body_part_cells,
                                   ReturnType temp, Operation &&operation,
                                   const LocalDynamicsFunction &local_dynamics_function)
 {

--- a/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.h
@@ -70,7 +70,7 @@ class ParticleSortCK : public LocalDynamics, public BaseDynamics<void>
         template <class EncloserType>
         UpdateBodyPartByParticle(const ExecutionPolicy &ex_policy,
                                  EncloserType &encloser, UnsignedInt body_part_i);
-        void update(UnsignedInt index_i);
+        void compute(UnsignedInt index_i);
 
       protected:
         UnsignedInt *particle_list_, *original_id_list_;

--- a/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/configuration_dynamics/particle_sort_ck.hpp
@@ -99,7 +99,7 @@ void ParticleSortCK<ExecutionPolicy>::exec(Real dt)
 
         particle_for(ex_policy_, IndexRange(0, total_particles),
                      [=](size_t i)
-                     { update_body_part_by_particle->update(i); });
+                     { update_body_part_by_particle->compute(i); });
     }
 }
 //=================================================================================================//
@@ -114,7 +114,7 @@ ParticleSortCK<ExecutionPolicy>::UpdateBodyPartByParticle::
 //=================================================================================================//
 template <class ExecutionPolicy>
 void ParticleSortCK<ExecutionPolicy>::UpdateBodyPartByParticle::
-    update(UnsignedInt index_i)
+    compute(UnsignedInt index_i)
 {
     particle_list_[index_i] = sorted_id_[original_id_list_[index_i]];
 }

--- a/src/shared/shared_ck/particle_dynamics/continuum_dynamics/continuum_dynamics_variable_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/continuum_dynamics/continuum_dynamics_variable_ck.h
@@ -47,7 +47,7 @@ class VonMisesStressCK : public BaseDerivedVariable<Real>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real *p_, *derived_variable_;
@@ -69,7 +69,7 @@ class VerticalStressCK : public BaseDerivedVariable<Real>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Mat3d *stress_tensor_3D_;
@@ -97,7 +97,7 @@ class AccDeviatoricPlasticStrainCK : public BaseDerivedVariable<Real>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         ConstituteKernel constitute_;

--- a/src/shared/shared_ck/particle_dynamics/continuum_dynamics/continuum_dynamics_variable_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/continuum_dynamics/continuum_dynamics_variable_ck.hpp
@@ -14,7 +14,7 @@ VonMisesStressCK::UpdateKernel::UpdateKernel(const ExecutionPolicy &ex_policy, E
       derived_variable_(encloser.dv_derived_variable_->DelegatedData(ex_policy)),
       shear_stress_(encloser.dv_shear_stress_->DelegatedData(ex_policy)) {}
 //=============================================================================================//
-inline void VonMisesStressCK::UpdateKernel::update(size_t index_i, Real dt)
+inline void VonMisesStressCK::UpdateKernel::compute(size_t index_i, Real dt)
 {
     Matd stress_tensor = shear_stress_[index_i] - p_[index_i] * Matd::Identity();
     derived_variable_[index_i] = getVonMisesStressFromMatrix(stress_tensor);
@@ -25,7 +25,7 @@ VerticalStressCK::UpdateKernel::UpdateKernel(const ExecutionPolicy &ex_policy, E
     : stress_tensor_3D_(encloser.dv_stress_tensor_3D_->DelegatedData(ex_policy)),
       derived_variable_(encloser.dv_derived_variable_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
-inline void VerticalStressCK::UpdateKernel::update(size_t index_i, Real dt)
+inline void VerticalStressCK::UpdateKernel::compute(size_t index_i, Real dt)
 {
     derived_variable_[index_i] = stress_tensor_3D_[index_i](1, 1);
 }
@@ -38,7 +38,7 @@ AccDeviatoricPlasticStrainCK::UpdateKernel::UpdateKernel(const ExecutionPolicy &
       derived_variable_(encloser.dv_derived_variable_->DelegatedData(ex_policy)),
       E_(encloser.E_), nu_(encloser.nu_) {}
 //=================================================================================================//
-inline void AccDeviatoricPlasticStrainCK::UpdateKernel::update(size_t index_i, Real dt)
+inline void AccDeviatoricPlasticStrainCK::UpdateKernel::compute(size_t index_i, Real dt)
 {
     Mat3d deviatoric_stress = stress_tensor_3D_[index_i] - (1.0 / 3.0) * stress_tensor_3D_[index_i].trace() * Mat3d::Identity();
     Real hydrostatic_pressure = (1.0 / 3.0) * stress_tensor_3D_[index_i].trace();

--- a/src/shared/shared_ck/particle_dynamics/continuum_dynamics/continuum_integration_1st_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/continuum_dynamics/continuum_integration_1st_ck.h
@@ -79,7 +79,7 @@ class PlasticAcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrec
       public:
         template <class ExecutionPolicy, class EncloserType>
         InitializeKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void initialize(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         EosKernel eos_;
@@ -93,7 +93,7 @@ class PlasticAcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrec
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         CorrectionKernel correction_;
@@ -108,7 +108,7 @@ class PlasticAcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrec
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real *mass_;
@@ -139,7 +139,7 @@ class PlasticAcousticStep1stHalf<Contact<Wall, RiemannSolverType, KernelCorrecti
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         CorrectionKernel correction_;

--- a/src/shared/shared_ck/particle_dynamics/continuum_dynamics/continuum_integration_1st_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/continuum_dynamics/continuum_integration_1st_ck.hpp
@@ -74,7 +74,7 @@ PlasticAcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionTy
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void PlasticAcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    InitializeKernel::initialize(size_t index_i, Real dt)
+    InitializeKernel::compute(size_t index_i, Real dt)
 {
     compression_[index_i] += 0.5 * dt * compression_rate_[index_i];
     rho_[index_i] = compression_[index_i] * eos_.getReferenceDensity(index_i);
@@ -100,7 +100,7 @@ PlasticAcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionTy
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void PlasticAcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Vecd force = Vecd::Zero();
     Real compression_dissipation(0);
@@ -129,7 +129,7 @@ PlasticAcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionTy
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void PlasticAcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    UpdateKernel::update(size_t index_i, Real dt)
+    UpdateKernel::compute(size_t index_i, Real dt)
 {
     vel_[index_i] += (force_prior_[index_i] + force_[index_i]) / mass_[index_i] * dt;
 }
@@ -164,7 +164,7 @@ PlasticAcousticStep1stHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void PlasticAcousticStep1stHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Vecd force = Vecd::Zero();
     Real compression_dissipation(0);

--- a/src/shared/shared_ck/particle_dynamics/continuum_dynamics/continuum_integration_2nd_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/continuum_dynamics/continuum_integration_2nd_ck.h
@@ -61,7 +61,7 @@ class PlasticAcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrec
       public:
         template <class ExecutionPolicy, class EncloserType>
         InitializeKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void initialize(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Vecd *vel_, *dpos_;
@@ -72,7 +72,7 @@ class PlasticAcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrec
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         CorrectionKernel correction_;
@@ -87,7 +87,7 @@ class PlasticAcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrec
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         ConstituteKernel constitute_;
@@ -121,7 +121,7 @@ class PlasticAcousticStep2ndHalf<Contact<Wall, RiemannSolverType, KernelCorrecti
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         CorrectionKernel correction_;

--- a/src/shared/shared_ck/particle_dynamics/continuum_dynamics/continuum_integration_2nd_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/continuum_dynamics/continuum_integration_2nd_ck.hpp
@@ -30,7 +30,7 @@ PlasticAcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionTy
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void PlasticAcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    InitializeKernel::initialize(size_t index_i, Real dt)
+    InitializeKernel::compute(size_t index_i, Real dt)
 {
     dpos_[index_i] += vel_[index_i] * dt * 0.5;
 }
@@ -51,7 +51,7 @@ PlasticAcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionTy
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void PlasticAcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Real divergence_sum(0);
     Vecd p_dissipation = Vecd::Zero();
@@ -88,7 +88,7 @@ PlasticAcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionTy
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void PlasticAcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    UpdateKernel::update(size_t index_i, Real dt)
+    UpdateKernel::compute(size_t index_i, Real dt)
 {
     compression_[index_i] += 0.5 * dt * compression_rate_[index_i];
     rho_[index_i] = compression_[index_i] * eos_.getReferenceDensity(index_i);
@@ -130,7 +130,7 @@ PlasticAcousticStep2ndHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void PlasticAcousticStep2ndHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Real divergence_sum = 0.0;
     Vecd p_dissipation = Vecd::Zero();

--- a/src/shared/shared_ck/particle_dynamics/continuum_dynamics/initialization_dynamics_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/continuum_dynamics/initialization_dynamics_ck.h
@@ -49,7 +49,7 @@ class ContinuumInitialConditionCK : public LocalDynamics
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(UnsignedInt index_i, Real dt = 0.0) {};
+        void compute(UnsignedInt index_i, Real dt = 0.0) {};
 
       protected:
         Vecd *pos_, *vel_;

--- a/src/shared/shared_ck/particle_dynamics/continuum_dynamics/shear_integration.h
+++ b/src/shared/shared_ck/particle_dynamics/continuum_dynamics/shear_integration.h
@@ -60,7 +60,7 @@ class ShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         InitializeKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void initialize(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         ConstituteKernel constitute_;
@@ -75,7 +75,7 @@ class ShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real G_;
@@ -115,7 +115,7 @@ class InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         InitializeKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void initialize(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         ConstituteKernel constitute_;
@@ -130,7 +130,7 @@ class InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         ConstituteKernel constitute_;
@@ -145,7 +145,7 @@ class InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Vecd *shear_force_, *hourglass_div_;

--- a/src/shared/shared_ck/particle_dynamics/continuum_dynamics/shear_integration.hpp
+++ b/src/shared/shared_ck/particle_dynamics/continuum_dynamics/shear_integration.hpp
@@ -46,7 +46,7 @@ ShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::InitializeKernel
 //====================================================================================//
 template <class MaterialType, typename... Parameters>
 void ShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::
-    InitializeKernel::initialize(size_t index_i, Real dt)
+    InitializeKernel::compute(size_t index_i, Real dt)
 {
     Matd strain_rate = 0.5 * (vel_gradient_[index_i] + vel_gradient_[index_i].transpose());
     strain_tensor_[index_i] += strain_rate * dt;
@@ -79,7 +79,7 @@ ShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::InteractKernel::
 //====================================================================================//
 template <class MaterialType, typename... Parameters>
 void ShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Vecd sum_shear = Vecd::Zero();
     Vecd sum_hourglass = Vecd::Zero();
@@ -137,7 +137,7 @@ InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::Initial
 //====================================================================================//
 template <class MaterialType, typename... Parameters>
 void InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::
-    InitializeKernel::initialize(size_t index_i, Real dt)
+    InitializeKernel::compute(size_t index_i, Real dt)
 {
     Matd strain_rate = 0.5 * (vel_gradient_[index_i] + vel_gradient_[index_i].transpose());
     strain_tensor_[index_i] += strain_rate * dt;
@@ -171,7 +171,7 @@ InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::Interac
 //====================================================================================//
 template <class MaterialType, typename... Parameters>
 void InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Vecd sum_shear = Vecd::Zero();
     Vecd sum_hourglass = Vecd::Zero();
@@ -206,7 +206,7 @@ InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::UpdateK
 //====================================================================================//
 template <class MaterialType, typename... Parameters>
 void InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::
-    UpdateKernel::update(size_t index_i, Real dt)
+    UpdateKernel::compute(size_t index_i, Real dt)
 {
     Vecd conservative_force = Vecd::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -220,7 +220,7 @@ void InelasticShearIntegration<Inner<OneLevel, MaterialType, Parameters...>>::
                               vec_r_ij.transpose() * dW_ijV_j * e_ij;
     }
     shear_force_[index_i] += conservative_force * Vol_[index_i];
-    ForcePriorCK::UpdateKernel::update(index_i, dt);
+    ForcePriorCK::UpdateKernel::compute(index_i, dt);
 }
 //=================================================================================================//
 } // namespace continuum_dynamics

--- a/src/shared/shared_ck/particle_dynamics/continuum_dynamics/stress_diffusion_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/continuum_dynamics/stress_diffusion_ck.h
@@ -58,7 +58,7 @@ class StressDiffusionCK<Inner<Parameters...>> : public PlasticAcousticStep<Inter
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         ConstituteKernel constitute_;

--- a/src/shared/shared_ck/particle_dynamics/continuum_dynamics/stress_diffusion_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/continuum_dynamics/stress_diffusion_ck.hpp
@@ -33,7 +33,7 @@ StressDiffusionCK<Inner<Parameters...>>::
 //=================================================================================================//
 template <typename... Parameters>
 void StressDiffusionCK<Inner<Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Vecd acc_prior_i = force_prior_[index_i] / this->mass_[index_i];
     Real gravity = abs(acc_prior_i(1, 0));

--- a/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.h
@@ -91,7 +91,7 @@ class DiffusionRelaxationCK<Inner<InteractionOnly, DiffusionType, KernelCorrecti
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(UnsignedInt index_i, Real dt = 0.0);
+        void compute(UnsignedInt index_i, Real dt = 0.0);
 
       protected:
         CorrectionKernel correction_;
@@ -127,7 +127,7 @@ class DiffusionRelaxationCK<Contact<InteractionOnly, BoundaryType<DiffusionType>
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(UnsignedInt index_i, Real dt = 0.0);
+        void compute(UnsignedInt index_i, Real dt = 0.0);
 
       protected:
         CorrectionKernel correction_;
@@ -161,7 +161,7 @@ class DiffusionRelaxationCK<RelationType<OneLevel, ForwardEuler, InteractionPara
       public:
         template <class ExecutionPolicy, class EncloserType>
         InitializeKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void initialize(UnsignedInt index_i, Real dt = 0.0);
+        void compute(UnsignedInt index_i, Real dt = 0.0);
 
       protected:
         MultiEntryView<Real> species_dt_;
@@ -172,7 +172,7 @@ class DiffusionRelaxationCK<RelationType<OneLevel, ForwardEuler, InteractionPara
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(UnsignedInt index_i, Real dt = 0.0);
+        void compute(UnsignedInt index_i, Real dt = 0.0);
 
       protected:
         MultiEntryView<Real> species_, species_dt_;
@@ -199,7 +199,7 @@ class DiffusionRelaxationCK<RelationType<OneLevel, RungeKutta1stStage, Interacti
       public:
         template <class ExecutionPolicy, class EncloserType>
         InitializeKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void initialize(UnsignedInt index_i, Real dt = 0.0);
+        void compute(UnsignedInt index_i, Real dt = 0.0);
 
       protected:
         MultiEntryView<Real> species_, species_s_;
@@ -225,7 +225,7 @@ class DiffusionRelaxationCK<RelationType<OneLevel, RungeKutta2ndStage, Interacti
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(UnsignedInt index_i, Real dt = 0.0);
+        void compute(UnsignedInt index_i, Real dt = 0.0);
 
       protected:
         MultiEntryView<Real> species_, species_s_;

--- a/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/diffusion_reaction_dynamics/diffusion_dynamics_ck.hpp
@@ -105,7 +105,7 @@ DiffusionRelaxationCK<Inner<InteractionOnly, DiffusionType, KernelCorrectionType
 //=================================================================================================//
 template <class DiffusionType, class KernelCorrectionType, class... Parameters>
 void DiffusionRelaxationCK<Inner<InteractionOnly, DiffusionType, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(UnsignedInt index_i, Real dt)
+    InteractKernel::compute(UnsignedInt index_i, Real dt)
 {
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
     {
@@ -154,7 +154,7 @@ DiffusionRelaxationCK<Contact<InteractionOnly, BoundaryType<DiffusionType>, Kern
 template <class DiffusionType, template <typename...> class BoundaryType,
           class KernelCorrectionType, class... Parameters>
 void DiffusionRelaxationCK<Contact<InteractionOnly, BoundaryType<DiffusionType>, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(UnsignedInt index_i, Real dt)
+    InteractKernel::compute(UnsignedInt index_i, Real dt)
 {
     for (UnsignedInt m = 0; m < contact_transfer_.Width(); ++m)
     {
@@ -192,7 +192,7 @@ DiffusionRelaxationCK<RelationType<OneLevel, ForwardEuler, InteractionParameters
 //=================================================================================================//
 template <template <typename...> class RelationType, class... InteractionParameters>
 void DiffusionRelaxationCK<RelationType<OneLevel, ForwardEuler, InteractionParameters...>>::
-    InitializeKernel::initialize(UnsignedInt index_i, Real dt)
+    InitializeKernel::compute(UnsignedInt index_i, Real dt)
 {
     for (UnsignedInt m = 0; m < species_dt_.Width(); ++m)
     {
@@ -210,7 +210,7 @@ DiffusionRelaxationCK<RelationType<OneLevel, ForwardEuler, InteractionParameters
 //=================================================================================================//
 template <template <typename...> class RelationType, class... InteractionParameters>
 void DiffusionRelaxationCK<RelationType<OneLevel, ForwardEuler, InteractionParameters...>>::
-    UpdateKernel::update(UnsignedInt index_i, Real dt)
+    UpdateKernel::compute(UnsignedInt index_i, Real dt)
 {
     for (UnsignedInt m = 0; m < species_.Width(); ++m)
     {
@@ -235,9 +235,9 @@ DiffusionRelaxationCK<RelationType<OneLevel, RungeKutta1stStage, InteractionPara
 //=================================================================================================//
 template <template <typename...> class RelationType, class... InteractionParameters>
 void DiffusionRelaxationCK<RelationType<OneLevel, RungeKutta1stStage, InteractionParameters...>>::
-    InitializeKernel::initialize(UnsignedInt index_i, Real dt)
+    InitializeKernel::compute(UnsignedInt index_i, Real dt)
 {
-    BaseDynamicsType::InitializeKernel::initialize(index_i, dt);
+    BaseDynamicsType::InitializeKernel::compute(index_i, dt);
 
     for (UnsignedInt m = 0; m < this->species_.Width(); ++m)
     {
@@ -262,9 +262,9 @@ DiffusionRelaxationCK<RelationType<OneLevel, RungeKutta2ndStage, InteractionPara
 //=================================================================================================//
 template <template <typename...> class RelationType, class... InteractionParameters>
 void DiffusionRelaxationCK<RelationType<OneLevel, RungeKutta2ndStage, InteractionParameters...>>::
-    UpdateKernel::update(UnsignedInt index_i, Real dt)
+    UpdateKernel::compute(UnsignedInt index_i, Real dt)
 {
-    BaseDynamicsType::UpdateKernel::update(index_i, dt);
+    BaseDynamicsType::UpdateKernel::compute(index_i, dt);
     for (UnsignedInt m = 0; m < this->species_.Width(); ++m)
     {
         species_[index_i][m] = 0.5 * species_s_[index_i][m] + 0.5 * species_[index_i][m];

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.h
@@ -78,7 +78,7 @@ class AcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionTyp
       public:
         template <class ExecutionPolicy, class EncloserType>
         InitializeKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void initialize(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         EosKernel eos_;
@@ -91,7 +91,7 @@ class AcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionTyp
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         CorrectionKernel correction_;
@@ -105,7 +105,7 @@ class AcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionTyp
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         DataView<Real> mass_;
@@ -137,7 +137,7 @@ class AcousticStep1stHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType,
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         CorrectionKernel correction_;
@@ -175,7 +175,7 @@ class AcousticStep1stHalf<Contact<RiemannSolverType, KernelCorrectionType, Param
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         CorrectionKernel correction_;

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_1st_half.hpp
@@ -65,7 +65,7 @@ AcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Par
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void AcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    InitializeKernel::initialize(size_t index_i, Real dt)
+    InitializeKernel::compute(size_t index_i, Real dt)
 {
     compression_[index_i] += 0.5 * dt * compression_rate_[index_i];
     rho_[index_i] = compression_[index_i] * eos_.getReferenceDensity(index_i);
@@ -88,7 +88,7 @@ AcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Par
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void AcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Vecd force_sum = Vecd::Zero();
     Real compression_dissipation(0);
@@ -121,7 +121,7 @@ AcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Par
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void AcousticStep1stHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    UpdateKernel::update(size_t index_i, Real dt)
+    UpdateKernel::compute(size_t index_i, Real dt)
 {
     vel_[index_i] += (force_prior_[index_i] + force_[index_i]) / mass_[index_i] * dt;
 }
@@ -155,7 +155,7 @@ AcousticStep1stHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType, Param
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void AcousticStep1stHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Vecd force_sum = Vecd::Zero();
     Real compression_dissipation(0);
@@ -216,7 +216,7 @@ AcousticStep1stHalf<Contact<RiemannSolverType, KernelCorrectionType, Parameters.
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void AcousticStep1stHalf<Contact<RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Vecd force_sum = Vecd::Zero();
     Real compression_dissipation(0);

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_2nd_half.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_2nd_half.h
@@ -66,7 +66,7 @@ class AcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionTyp
       public:
         template <class ExecutionPolicy, class EncloserType>
         InitializeKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void initialize(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         DataView<Vecd> vel_, dpos_;
@@ -77,7 +77,7 @@ class AcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionTyp
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         CorrectionKernel correction_;
@@ -91,7 +91,7 @@ class AcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionTyp
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         EosKernel eos_;
@@ -123,7 +123,7 @@ class AcousticStep2ndHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType,
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         CorrectionKernel correction_;
@@ -163,7 +163,7 @@ class AcousticStep2ndHalf<Contact<RiemannSolverType, KernelCorrectionType, Param
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         CorrectionKernel correction_;

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_2nd_half.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/acoustic_step_2nd_half.hpp
@@ -32,7 +32,7 @@ AcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Par
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void AcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    InitializeKernel::initialize(size_t index_i, Real dt)
+    InitializeKernel::compute(size_t index_i, Real dt)
 {
     dpos_[index_i] += vel_[index_i] * dt * 0.5;
 }
@@ -52,7 +52,7 @@ AcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Par
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void AcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Real divergence_sum(0);
     Vecd p_dissipation = Vecd::Zero();
@@ -82,7 +82,7 @@ AcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Par
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void AcousticStep2ndHalf<Inner<OneLevel, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    UpdateKernel::update(size_t index_i, Real dt)
+    UpdateKernel::compute(size_t index_i, Real dt)
 {
     compression_[index_i] += 0.5 * dt * compression_rate_[index_i];
     rho_[index_i] = compression_[index_i] * eos_.getReferenceDensity(index_i);
@@ -115,7 +115,7 @@ AcousticStep2ndHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType, Param
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void AcousticStep2ndHalf<Contact<Wall, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Real divergence_sum(0);
     Vecd p_dissipation = Vecd::Zero();
@@ -171,7 +171,7 @@ AcousticStep2ndHalf<Contact<RiemannSolverType, KernelCorrectionType, Parameters.
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void AcousticStep2ndHalf<Contact<RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Real divergence_sum(0);
     Vecd p_dissipation = Vecd::Zero();

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.h
@@ -53,7 +53,7 @@ class BufferIndicationCK : public BaseLocalDynamics<OrientedBoxByCell>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         int part_id_;
@@ -97,7 +97,7 @@ class BufferInflowInjectionCK : public BaseLocalDynamics<OrientedBoxByCell>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       private:
         int part_id_;
@@ -151,7 +151,7 @@ class BufferOutflowIndication : public BaseLocalDynamics<OrientedBoxByCell>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         OrientedBox *oriented_box_;
@@ -184,7 +184,7 @@ class OutflowParticleDeletion : public LocalDynamics
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(UnsignedInt index_i, Real dt = 0.0);
+        void compute(UnsignedInt index_i, Real dt = 0.0);
 
       protected:
         RemoveRealParticleKernel remove_real_particle_;
@@ -212,7 +212,7 @@ class PressureVelocityCondition : public BaseLocalDynamics<OrientedBoxByCell>,
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         OrientedBox *oriented_box_;
@@ -246,7 +246,7 @@ class SupplementaryCondition : public BaseLocalDynamics<OrientedBoxByCell>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         OrientedBox *oriented_box_;

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/bidirectional_boundary_ck.hpp
@@ -19,7 +19,7 @@ BufferIndicationCK::UpdateKernel::
       pos_(encloser.dv_pos_->DelegatedData(ex_policy)),
       buffer_indicator_(encloser.dv_buffer_indicator_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
-inline void BufferIndicationCK::UpdateKernel::update(size_t index_i, Real dt)
+inline void BufferIndicationCK::UpdateKernel::compute(size_t index_i, Real dt)
 {
     if (oriented_box_->checkContain(pos_[index_i]))
     {
@@ -64,7 +64,7 @@ BufferInflowInjectionCK<ConditionType>::
       upper_bound_fringe_(encloser.upper_bound_fringe_) {}
 //=================================================================================================//
 template <class ConditionType>
-void BufferInflowInjectionCK<ConditionType>::UpdateKernel::update(size_t index_i, Real dt)
+void BufferInflowInjectionCK<ConditionType>::UpdateKernel::compute(size_t index_i, Real dt)
 {
     if (!oriented_box_->checkInBounds(pos_[index_i]))
     {
@@ -97,7 +97,7 @@ inline bool BufferOutflowIndication::UpdateKernel::IsDeletable::operator()(size_
            oriented_box_->checkLowerBound(pos_[index_i]);
 }
 //=================================================================================================//
-inline void BufferOutflowIndication::UpdateKernel::update(size_t index_i, Real dt)
+inline void BufferOutflowIndication::UpdateKernel::compute(size_t index_i, Real dt)
 {
     if (!oriented_box_->checkInBounds(pos_[index_i]))
     {
@@ -114,7 +114,7 @@ OutflowParticleDeletion::UpdateKernel::
     : remove_real_particle_(ex_policy, encloser.remove_real_particle_method_),
       life_status_mask_(ex_policy, encloser.particle_group_manager_, encloser.life_status_) {}
 //=================================================================================================//
-inline void OutflowParticleDeletion::UpdateKernel::update(UnsignedInt index_i, Real dt)
+inline void OutflowParticleDeletion::UpdateKernel::compute(UnsignedInt index_i, Real dt)
 {
     if (life_status_mask_.check(index_i)) // to delete
     {
@@ -148,7 +148,7 @@ PressureVelocityCondition<KernelCorrectionType, ConditionType>::UpdateKernel::
 //=================================================================================================//
 template <class KernelCorrectionType, typename ConditionType>
 void PressureVelocityCondition<KernelCorrectionType, ConditionType>::
-    UpdateKernel::update(size_t index_i, Real dt)
+    UpdateKernel::compute(size_t index_i, Real dt)
 {
     if (oriented_box_->checkContain(pos_[index_i]))
     {
@@ -182,7 +182,7 @@ SupplementaryCondition<ConditionType>::UpdateKernel::UpdateKernel(
       pos_(encloser.dv_pos_->DelegatedDataView(ex_policy)) {}
 //=================================================================================================//
 template <typename ConditionType>
-void SupplementaryCondition<ConditionType>::UpdateKernel::update(size_t index_i, Real dt)
+void SupplementaryCondition<ConditionType>::UpdateKernel::compute(size_t index_i, Real dt)
 {
     if (oriented_box_->checkContain(pos_[index_i]))
     {

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/emitter_boundary_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/emitter_boundary_ck.h
@@ -53,7 +53,7 @@ class EmitterInflowConditionCK : public BaseLocalDynamics<OrientedBoxPartType>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         OrientedBox *oriented_box_;
@@ -83,7 +83,7 @@ class EmitterInflowInjectionCK : public BaseLocalDynamics<OrientedBoxPartType>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         OrientedBox *oriented_box_;
@@ -123,7 +123,7 @@ class WithinDisposerIndication : public BaseLocalDynamics<OrientedBoxByCell>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         OrientedBox *oriented_box_;

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/emitter_boundary_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/emitter_boundary_ck.hpp
@@ -31,7 +31,7 @@ EmitterInflowConditionCK<OrientedBoxPartType, ConditionFunction>::UpdateKernel::
 //=================================================================================================//
 template <class OrientedBoxPartType, class ConditionFunction>
 void EmitterInflowConditionCK<OrientedBoxPartType, ConditionFunction>::
-    UpdateKernel::update(size_t index_i, Real dt)
+    UpdateKernel::compute(size_t index_i, Real dt)
 {
     int aligned_axis = oriented_box_->ReferenceAxis();
     Transform &transform = oriented_box_->getTransform();
@@ -80,7 +80,7 @@ EmitterInflowInjectionCK<OrientedBoxPartType>::UpdateKernel::
       p_(encloser.dv_p_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <typename OrientedBoxPartType>
-void EmitterInflowInjectionCK<OrientedBoxPartType>::UpdateKernel::update(size_t index_i, Real dt)
+void EmitterInflowInjectionCK<OrientedBoxPartType>::UpdateKernel::compute(size_t index_i, Real dt)
 {
     if (oriented_box_->checkUpperBound(pos_[index_i]))
     {
@@ -100,7 +100,7 @@ WithinDisposerIndication::UpdateKernel::
       mask_(ex_policy, encloser.particle_group_manager_, encloser.life_status_),
       total_real_particles_(encloser.sv_total_real_particles_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
-inline void WithinDisposerIndication::UpdateKernel::update(size_t index_i, Real dt)
+inline void WithinDisposerIndication::UpdateKernel::compute(size_t index_i, Real dt)
 {
     if (oriented_box_->checkContain(pos_[index_i]) && index_i < *total_real_particles_)
     {

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/free_stream_boundary.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/free_stream_boundary.h
@@ -48,7 +48,7 @@ class FreeStreamCondition : public LocalDynamics
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         ConditionFunction free_stream_velocity_;

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/free_stream_boundary.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/boundary_condition/free_stream_boundary.hpp
@@ -31,7 +31,7 @@ FreeStreamCondition<ConditionFunction>::UpdateKernel::UpdateKernel(
       physical_time_(encloser.sv_physical_time_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <typename ConditionFunction>
-void FreeStreamCondition<ConditionFunction>::UpdateKernel::update(size_t index_i, Real dt)
+void FreeStreamCondition<ConditionFunction>::UpdateKernel::compute(size_t index_i, Real dt)
 {
     if (indicator_[index_i] == 1)
     {

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.h
@@ -73,7 +73,7 @@ class CompressionSummation<Inner<Parameters...>>
       public:
         template <class ExecutionPolicy, class Encloser>
         InteractKernel(const ExecutionPolicy &ex_policy, Encloser &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Vecd zero_;
@@ -98,7 +98,7 @@ class CompressionSummation<Contact<Parameters...>>
       public:
         template <class ExecutionPolicy, class Encloser>
         InteractKernel(const ExecutionPolicy &ex_policy, Encloser &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         DataView<Real> compression_sum_, contact_Vol_ref_;
@@ -162,7 +162,7 @@ class DensityRegularization : public BaseLocalDynamics<DynamicsIdentifier>
       public:
         template <class ExecutionPolicy, class Encloser>
         UpdateKernel(const ExecutionPolicy &ex_policy, Encloser &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         EosKernel eos_;

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/density_regularization.hpp
@@ -42,7 +42,7 @@ CompressionSummation<Inner<Parameters...>>::InteractKernel::InteractKernel(
 //=================================================================================================//
 template <typename... Parameters>
 void CompressionSummation<Inner<Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     compression_sum_[index_i] = this->W0(index_i, zero_) * Vol_ref_[index_i];
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -73,7 +73,7 @@ CompressionSummation<Contact<Parameters...>>::InteractKernel::InteractKernel(
 //=================================================================================================//
 template <typename... Parameters>
 void CompressionSummation<Contact<Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
     {
@@ -122,7 +122,7 @@ DensityRegularization<DynamicsIdentifier, FluidType, FlowType, ParticleScopes...
 //=================================================================================================//
 template <class DynamicsIdentifier, class FluidType, class FlowType, typename... ParticleScopes>
 void DensityRegularization<DynamicsIdentifier, FluidType, FlowType, ParticleScopes...>::
-    UpdateKernel::update(size_t index_i, Real dt)
+    UpdateKernel::compute(size_t index_i, Real dt)
 {
     if (this->particle_scope_(index_i))
     {

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/fluid_time_step_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/fluid_time_step_ck.h
@@ -142,7 +142,7 @@ class AdvectionStepSetup : public LocalDynamics
         template <class ExecutionPolicy>
         UpdateKernel(const ExecutionPolicy &ex_policy, AdvectionStepSetup &encloser);
 
-        void update(size_t index_i, Real dt = 0.0)
+        void compute(size_t index_i, Real dt = 0.0)
         {
             Vol_[index_i] = mass_[index_i] / rho_[index_i];
             dpos_[index_i] = Vecd::Zero();
@@ -170,7 +170,7 @@ class UpdateParticlePosition : public LocalDynamics
         template <class ExecutionPolicy>
         UpdateKernel(const ExecutionPolicy &ex_policy, UpdateParticlePosition &encloser);
 
-        void update(size_t index_i, Real dt = 0.0)
+        void compute(size_t index_i, Real dt = 0.0)
         {
             pos_[index_i] += dpos_[index_i];
         };

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.h
@@ -24,7 +24,7 @@ class TransportVelocityCorrectionCK : public BaseLocalDynamics<DynamicsIdentifie
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real squared_h_ref_, correction_scaling_; ///< typically coefficient * h_ref^2

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/transport_velocity_correction_ck.hpp
@@ -37,7 +37,7 @@ TransportVelocityCorrectionCK<DynamicsIdentifier, LimiterType, ParticleScopes...
 //=================================================================================================//
 template <class DynamicsIdentifier, class LimiterType, typename... ParticleScopes>
 void TransportVelocityCorrectionCK<DynamicsIdentifier, LimiterType, ParticleScopes...>::
-    UpdateKernel::update(size_t index_i, Real dt)
+    UpdateKernel::compute(size_t index_i, Real dt)
 {
     if (this->within_scope_(index_i))
     {

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.h
@@ -80,7 +80,7 @@ class ViscousForceCK<Inner<WithUpdate, ViscosityType, KernelCorrectionType, Para
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         InterParticleViscosity inter_particle_viscosity_;
@@ -110,7 +110,7 @@ class ViscousForceCK<Contact<Wall, ViscosityType, KernelCorrectionType, Paramete
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         OneSideViscosity one_side_viscosity_;

--- a/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_dynamics/viscous_force.hpp
@@ -42,7 +42,7 @@ ViscousForceCK<Inner<WithUpdate, ViscosityType, KernelCorrectionType, Parameters
 //=================================================================================================//
 template <typename ViscosityType, class KernelCorrectionType, typename... Parameters>
 void ViscousForceCK<Inner<WithUpdate, ViscosityType, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Vecd force = Vecd::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -83,7 +83,7 @@ ViscousForceCK<Contact<Wall, ViscosityType, KernelCorrectionType, Parameters...>
 //=================================================================================================//
 template <typename ViscosityType, class KernelCorrectionType, typename... Parameters>
 void ViscousForceCK<Contact<Wall, ViscosityType, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Vecd force = Vecd::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)

--- a/src/shared/shared_ck/particle_dynamics/fluid_structure_interaction/force_on_structure.h
+++ b/src/shared/shared_ck/particle_dynamics/fluid_structure_interaction/force_on_structure.h
@@ -93,7 +93,7 @@ class ViscousForceFromFluid<Contact<WithUpdate, ViscosityType, KernelCorrectionT
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         OneSideViscosity one_side_viscosity_;
@@ -145,7 +145,7 @@ class PressureForceFromFluid<Contact<WithUpdate, RiemannSolverType, KernelCorrec
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Vecd *acc_ave_, *n_;

--- a/src/shared/shared_ck/particle_dynamics/fluid_structure_interaction/force_on_structure.hpp
+++ b/src/shared/shared_ck/particle_dynamics/fluid_structure_interaction/force_on_structure.hpp
@@ -52,7 +52,7 @@ ViscousForceFromFluid<Contact<WithUpdate, ViscosityType, KernelCorrectionType, P
 //=================================================================================================//
 template <typename ViscosityType, class KernelCorrectionType, typename... Parameters>
 void ViscousForceFromFluid<Contact<WithUpdate, ViscosityType, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Vecd force = Vecd::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -100,7 +100,7 @@ PressureForceFromFluid<Contact<WithUpdate, RiemannSolverType, KernelCorrectionTy
 //=================================================================================================//
 template <class RiemannSolverType, class KernelCorrectionType, typename... Parameters>
 void PressureForceFromFluid<Contact<WithUpdate, RiemannSolverType, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Vecd force = Vecd::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/force_prior_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/force_prior_ck.h
@@ -52,7 +52,7 @@ class ForcePriorCK
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0)
+        void compute(size_t index_i, Real dt = 0.0)
         {
             force_prior_[index_i] += current_force_[index_i] - previous_force_[index_i];
             previous_force_[index_i] = current_force_[index_i];
@@ -76,7 +76,7 @@ class GravityForceCK : public LocalDynamics, public ForcePriorCK
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         GravityType gravity_;

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/force_prior_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/force_prior_ck.hpp
@@ -35,11 +35,11 @@ GravityForceCK<GravityType>::UpdateKernel::
       mass_(encloser.dv_mass_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <class GravityType>
-void GravityForceCK<GravityType>::UpdateKernel::update(size_t index_i, Real dt)
+void GravityForceCK<GravityType>::UpdateKernel::compute(size_t index_i, Real dt)
 {
     this->current_force_[index_i] =
         mass_[index_i] * gravity_.InducedAcceleration(pos_[index_i], *physical_time_);
-    ForcePriorCK::UpdateKernel::update(index_i, dt);
+    ForcePriorCK::UpdateKernel::compute(index_i, dt);
 }
 //=================================================================================================//
 } // namespace SPH

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/general_assignment.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/general_assignment.h
@@ -51,7 +51,7 @@ class VariableAssignment : public BaseLocalDynamics<DynamicsIdentifier>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(UnsignedInt index_i, Real dt = 0.0) { assign_(index_i); };
+        void compute(UnsignedInt index_i, Real dt = 0.0) { assign_(index_i); };
 
       protected:
         Assign assign_;

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/general_constraint_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/general_constraint_ck.h
@@ -55,7 +55,7 @@ class ConstantConstraintCK : public BaseLocalDynamics<DynamicsIdentifier>
             : variable_(encloser.dv_variable_->DelegatedData(ex_policy)),
               constrained_value_(encloser.constrained_value_){};
 
-        void update(size_t index_i, Real dt = 0.0)
+        void compute(size_t index_i, Real dt = 0.0)
         {
             variable_[index_i] = constrained_value_;
         };
@@ -94,7 +94,7 @@ class FixConstraintCK : public MotionConstraintCK<DynamicsIdentifier>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Vecd *pos_, *pos0_, *vel_;

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/general_constraint_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/general_constraint_ck.hpp
@@ -25,7 +25,7 @@ FixConstraintCK<DynamicsIdentifier>::UpdateKernel::UpdateKernel(
       vel_(encloser.dv_vel_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <class DynamicsIdentifier>
-void FixConstraintCK<DynamicsIdentifier>::UpdateKernel::update(size_t index_i, Real dt)
+void FixConstraintCK<DynamicsIdentifier>::UpdateKernel::compute(size_t index_i, Real dt)
 {
     pos_[index_i] = pos0_[index_i];
     vel_[index_i] = Vecd::Zero();

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.h
@@ -135,7 +135,7 @@ class LinearGradient<Inner<DataType, Parameters...>>
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
             : BaseDynamicsType::InteractKernel(ex_policy, encloser){};
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
     };
 };
 
@@ -158,7 +158,7 @@ class LinearGradient<Contact<DataType, Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real *contact_Vol_;
@@ -216,7 +216,7 @@ class Hessian<Inner<DataType, Parameters...>>
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
             : BaseDynamicsType::InteractKernel(ex_policy, encloser){};
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
     };
 };
 
@@ -236,7 +236,7 @@ class Hessian<Contact<DataType, Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real *contact_Vol_;
@@ -267,7 +267,7 @@ class SecondOrderGradient<Inner<DataType, Parameters...>>
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
             : BaseDynamicsType::InteractKernel(ex_policy, encloser){};
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
     };
 };
 
@@ -287,7 +287,7 @@ class SecondOrderGradient<Contact<DataType, Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real *contact_Vol_;

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/general_gradient.hpp
@@ -28,7 +28,7 @@ Gradient<Base, DataType, RelationType<Parameters...>>::InteractKernel::
       B_(encloser.dv_B_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <typename DataType, typename... Parameters>
-void LinearGradient<Inner<DataType, Parameters...>>::InteractKernel::interact(size_t index_i, Real dt)
+void LinearGradient<Inner<DataType, Parameters...>>::InteractKernel::compute(size_t index_i, Real dt)
 {
     Grad<DataType> summation = Grad<DataType>::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -60,7 +60,7 @@ LinearGradient<Contact<DataType, Parameters...>>::InteractKernel::
 //=================================================================================================//
 template <typename DataType, typename... Parameters>
 void LinearGradient<Contact<DataType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Grad<DataType> summation = Grad<DataType>::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -92,7 +92,7 @@ Hessian<Base, DataType, RelationType<Parameters...>>::InteractKernel::
 //=================================================================================================//
 template <typename DataType, typename... Parameters>
 void Hessian<Inner<DataType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Hess<DataType> summation = Hess<DataType>::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -126,7 +126,7 @@ Hessian<Contact<DataType, Parameters...>>::InteractKernel::
 //=================================================================================================//
 template <typename DataType, typename... Parameters>
 void Hessian<Contact<DataType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Hess<DataType> summation = Hess<DataType>::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -145,7 +145,7 @@ void Hessian<Contact<DataType, Parameters...>>::
 //=================================================================================================//
 template <typename DataType, typename... Parameters>
 void SecondOrderGradient<Inner<DataType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Grad<DataType> summation = Grad<DataType>::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -178,7 +178,7 @@ SecondOrderGradient<Contact<DataType, Parameters...>>::InteractKernel::
 //=================================================================================================//
 template <typename DataType, typename... Parameters>
 void SecondOrderGradient<Contact<DataType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Grad<DataType> summation = Grad<DataType>::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/geometric_dynamics.cpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/geometric_dynamics.cpp
@@ -16,7 +16,7 @@ NormalFromBodyShapeCK::NormalFromBodyShapeCK(SPHBody &sph_body)
       dv_phi_(particles_->registerStateVariable<Real>("SignedDistance")),
       dv_phi0_(particles_->registerStateVariableFrom<Real>("InitialSignedDistance", "SignedDistance")) {}
 //=============================================================================================//
-void NormalFromBodyShapeCK::UpdateKernel::update(size_t index_i, Real dt)
+void NormalFromBodyShapeCK::UpdateKernel::compute(size_t index_i, Real dt)
 {
     Vecd normal_direction = initial_shape_->findNormalDirection(pos_[index_i]);
     n_[index_i] = normal_direction;
@@ -40,7 +40,7 @@ NormalFromSubShapeAndOpCK::NormalFromSubShapeAndOpCK(SPHBody &sph_body, const st
     : NormalFromSubShapeAndOpCK(
           sph_body, DynamicCast<ComplexShape>(this, sph_body.getInitialShape()), shape_name) {}
 //=================================================================================================//
-void NormalFromSubShapeAndOpCK::UpdateKernel::update(size_t index_i, Real /*dt*/)
+void NormalFromSubShapeAndOpCK::UpdateKernel::compute(size_t index_i, Real /*dt*/)
 {
     Vecd normal_direction = switch_sign_ * shape_->findNormalDirection(pos_[index_i]);
     n_[index_i] = normal_direction;
@@ -57,7 +57,7 @@ SurfaceIndicationFromBodyShape::SurfaceIndicationFromBodyShape(SPHBody &sph_body
       dv_indicator_(particles_->registerStateVariable<int>("SurfaceIndicator")),
       dv_pos_(particles_->getVariableByName<Vecd>("Position")) {}
 //=============================================================================================//
-void SurfaceIndicationFromBodyShape::UpdateKernel::update(size_t index_i, Real dt)
+void SurfaceIndicationFromBodyShape::UpdateKernel::compute(size_t index_i, Real dt)
 {
     Real signed_distance = initial_shape_->findSignedDistance(pos_[index_i]);
     indicator_[index_i] = signed_distance > -spacing_ref_ ? 1 : 0;
@@ -67,7 +67,7 @@ RandomizeParticlePositionCK::RandomizeParticlePositionCK(SPHBody &sph_body, Real
     : LocalDynamics(sph_body), dv_pos_(particles_->getVariableByName<Vecd>("Position")),
       randomize_scale_(sph_body.getSPHAdaptation().MinimumSpacing() * randomize_factor) {}
 //=============================================================================================//
-void RandomizeParticlePositionCK::UpdateKernel::update(size_t index_i, Real dt)
+void RandomizeParticlePositionCK::UpdateKernel::compute(size_t index_i, Real dt)
 {
     for (int k = 0; k != Dimensions; ++k)
     {

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/geometric_dynamics.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/geometric_dynamics.h
@@ -61,7 +61,7 @@ class NormalFromBodyShapeCK : public LocalDynamics
         template <class ExecutionPolicy>
         UpdateKernel(const ExecutionPolicy &ex_policy,
                      NormalFromBodyShapeCK &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Shape *initial_shape_;
@@ -87,7 +87,7 @@ class NormalFromSubShapeAndOpCK : public LocalDynamics
       public:
         template <class ExecutionPolicy, class Encloser>
         UpdateKernel(const ExecutionPolicy &ex_policy, Encloser &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Shape *shape_;
@@ -114,7 +114,7 @@ class SurfaceIndicationFromBodyShape : public LocalDynamics
         template <class ExecutionPolicy>
         UpdateKernel(const ExecutionPolicy &ex_policy,
                      SurfaceIndicationFromBodyShape &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Shape *initial_shape_;
@@ -141,7 +141,7 @@ class RandomizeParticlePositionCK : public LocalDynamics
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Vecd *pos_;

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/geometric_dynamics.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/geometric_dynamics.h
@@ -44,7 +44,7 @@ class HostKernel
     {
         // not implemented for device policy due to virtual function call in initial_shape_,
         // which is not allowed in device code
-        static_assert(!std::is_base_of<execution::DeviceExecution<>, ExecutionPolicy>::value,
+        static_assert(!std::is_base_of<execution::SYCLDevicePolicy, ExecutionPolicy>::value,
                       "This compute kernel is not designed for execution on device!");
     }
 };

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.h
@@ -92,7 +92,7 @@ class DisplacementMatrixGradient<Inner<Parameters...>>
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
             : BaseDynamicsType::InteractKernel(ex_policy, encloser){};
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
     };
 };
 
@@ -114,7 +114,7 @@ class DisplacementMatrixGradient<Contact<Parameters...>>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
             : BaseDynamicsType::InteractKernel(ex_policy, encloser),
               contact_Vol_(encloser.dv_contact_Vol_->DelegatedData(ex_policy)){};
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real *contact_Vol_;
@@ -142,7 +142,7 @@ class HessianCorrectionMatrix<Inner<WithUpdate, Parameters...>>
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
             : BaseDynamicsType::InteractKernel(ex_policy, encloser){};
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
     };
 
     class UpdateKernel : public BaseDynamicsType::InteractKernel
@@ -151,7 +151,7 @@ class HessianCorrectionMatrix<Inner<WithUpdate, Parameters...>>
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
             : BaseDynamicsType::InteractKernel(ex_policy, encloser), alpha_(encloser.alpha_){};
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real alpha_;
@@ -180,7 +180,7 @@ class HessianCorrectionMatrix<Contact<Parameters...>>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
             : BaseDynamicsType::InteractKernel(ex_policy, encloser),
               contact_Vol_(encloser.dv_contact_Vol_->DelegatedData(ex_policy)){};
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real *contact_Vol_;

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/hessian_correction_ck.hpp
@@ -32,7 +32,7 @@ HessianCorrectionMatrix<Base, RelationType<Parameters...>>::InteractKernel::
 //=================================================================================================//
 template <typename... Parameters>
 void DisplacementMatrixGradient<Inner<Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     VecMatGrad grad_displacement_matrix = VecMatGrad::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -54,7 +54,7 @@ DisplacementMatrixGradient<Contact<Parameters...>>::
 //=================================================================================================//
 template <typename... Parameters>
 void DisplacementMatrixGradient<Contact<Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     VecMatGrad grad_displacement_matrix = VecMatGrad::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -71,7 +71,7 @@ void DisplacementMatrixGradient<Contact<Parameters...>>::
 //=================================================================================================//
 template <typename... Parameters>
 void HessianCorrectionMatrix<Inner<WithUpdate, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     MatTend summation = MatTend::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -92,7 +92,7 @@ void HessianCorrectionMatrix<Inner<WithUpdate, Parameters...>>::
 //=================================================================================================//
 template <typename... Parameters>
 void HessianCorrectionMatrix<Inner<WithUpdate, Parameters...>>::
-    UpdateKernel::update(size_t index_i, Real dt)
+    UpdateKernel::compute(size_t index_i, Real dt)
 {
     Real det_sqr = math::pow(this->M_[index_i].determinant(), Real(2));
     Real min_det_sqr = SMAX(alpha_ - det_sqr, Real(0));
@@ -110,7 +110,7 @@ HessianCorrectionMatrix<Contact<Parameters...>>::
 //=================================================================================================//
 template <typename... Parameters>
 void HessianCorrectionMatrix<Contact<Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     MatTend summation = MatTend::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.h
@@ -83,7 +83,7 @@ class Interpolation<Contact<DataType, Parameters...>> : public Interpolation<Con
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         DataType zero_value_;
@@ -118,7 +118,7 @@ class Interpolation<Contact<DataType, RestoringCorrection, Parameters...>> : pub
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         PredictVecd zero_prediction_;

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/interpolation_dynamics.hpp
@@ -35,7 +35,7 @@ Interpolation<Contact<DataType, Parameters...>>::InteractKernel::
       contact_data_(encloser.dv_contact_data_->DelegatedEntryView(ex_policy, encloser.entry_)) {}
 //=================================================================================================//
 template <typename DataType, typename... Parameters>
-void Interpolation<Contact<DataType, Parameters...>>::InteractKernel::interact(size_t index_i, Real dt)
+void Interpolation<Contact<DataType, Parameters...>>::InteractKernel::compute(size_t index_i, Real dt)
 {
     DataType interpolated_quantity(zero_value_);
     Real ttl_weight(0);
@@ -63,7 +63,7 @@ Interpolation<Contact<DataType, RestoringCorrection, Parameters...>>::InteractKe
 //=================================================================================================//
 template <typename DataType, typename... Parameters>
 void Interpolation<Contact<DataType, RestoringCorrection, Parameters...>>::InteractKernel::
-    interact(size_t index_i, Real dt)
+    compute(size_t index_i, Real dt)
 {
     PredictVecd prediction = zero_prediction_;
     RestoreMatd restoring_matrix = Eps * RestoreMatd::Identity();

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.h
@@ -74,7 +74,7 @@ class LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         DataView<Matd> B_;
@@ -86,7 +86,7 @@ class LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real alpha_;
@@ -114,7 +114,7 @@ class LinearCorrectionMatrix<Contact<Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         DataView<Matd> B_;
@@ -138,7 +138,7 @@ class LinearCorrectionMatrixScope : public BaseLocalDynamics<DynamicsIdentifier>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         DataView<Matd> B_;

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_correction_ck.hpp
@@ -36,7 +36,7 @@ LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>>::InteractKernel::
 //=================================================================================================//
 template <typename... Parameters>
 void LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     B_[index_i] = Matd::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -55,7 +55,7 @@ LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>>::UpdateKernel::
 //=================================================================================================//
 template <typename... Parameters>
 void LinearCorrectionMatrix<Inner<WithUpdate, Parameters...>>::
-    UpdateKernel::update(size_t index_i, Real dt)
+    UpdateKernel::compute(size_t index_i, Real dt)
 {
     Real determinant = B_[index_i].determinant();
     Real det_sqr = SMAX(alpha_ - determinant, Real(0));
@@ -79,7 +79,7 @@ LinearCorrectionMatrix<Contact<Parameters...>>::InteractKernel::
 //=================================================================================================//
 template <typename... Parameters>
 void LinearCorrectionMatrix<Contact<Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
     {
@@ -106,7 +106,7 @@ LinearCorrectionMatrixScope<DynamicsIdentifier, ParticleScope>::UpdateKernel::
 //=================================================================================================//
 template <class DynamicsIdentifier, class ParticleScope>
 void LinearCorrectionMatrixScope<DynamicsIdentifier, ParticleScope>::UpdateKernel::
-    update(size_t index_i, Real dt)
+    compute(size_t index_i, Real dt)
 {
     if (!within_scope_(index_i))
     {

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_gradient_integral.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_gradient_integral.h
@@ -66,7 +66,7 @@ class KernelGradientIntegral<Inner<KernelCorrectionType, Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         CorrectionKernel correction_;
@@ -95,7 +95,7 @@ class KernelGradientIntegral<Contact<Boundary, KernelCorrectionType, Parameters.
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         CorrectionKernel correction_;

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_gradient_integral.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/kernel_gradient_integral.hpp
@@ -35,7 +35,7 @@ KernelGradientIntegral<Inner<KernelCorrectionType, Parameters...>>::InteractKern
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
 void KernelGradientIntegral<Inner<KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Vecd inconsistency = Vecd::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -70,7 +70,7 @@ KernelGradientIntegral<Contact<Boundary, KernelCorrectionType, Parameters...>>::
 //=================================================================================================//
 template <class KernelCorrectionType, typename... Parameters>
 void KernelGradientIntegral<Contact<Boundary, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Vecd inconsistency = Vecd::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/surface_indication/surface_indication_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/surface_indication/surface_indication_ck.h
@@ -48,7 +48,7 @@ class FreeSurfaceIndicationCK<Base, RelationType<Parameters...>>
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
 
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         int *indicator_;
@@ -94,7 +94,7 @@ class FreeSurfaceIndicationCK<Inner<WithUpdate, Parameters...>>
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
 
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         int *previous_surface_indicator_;
@@ -114,7 +114,7 @@ class FreeSurfaceIndicationCK<Inner<WithUpdate, Parameters...>>
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
 
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         int *previous_surface_indicator_;
@@ -152,7 +152,7 @@ class FreeSurfaceIndicationCK<Contact<Parameters...>>
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
 
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real *contact_Vol_;

--- a/src/shared/shared_ck/particle_dynamics/general_dynamics/surface_indication/surface_indication_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/general_dynamics/surface_indication/surface_indication_ck.hpp
@@ -50,7 +50,7 @@ FreeSurfaceIndicationCK<Inner<WithUpdate, Parameters...>>::InteractKernel::
 //=================================================================================================//
 template <typename... Parameters>
 void FreeSurfaceIndicationCK<Inner<WithUpdate, Parameters...>>::InteractKernel::
-    interact(size_t index_i, Real dt)
+    compute(size_t index_i, Real dt)
 {
     Real pos_div = 0.0;
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -94,7 +94,7 @@ FreeSurfaceIndicationCK<Inner<WithUpdate, Parameters...>>::UpdateKernel::
 //=================================================================================================//
 template <typename... Parameters>
 void FreeSurfaceIndicationCK<Inner<WithUpdate, Parameters...>>::UpdateKernel::
-    update(size_t index_i, Real dt)
+    compute(size_t index_i, Real dt)
 {
     this->indicator_[index_i] = 1;
     if (this->pos_div_[index_i] > this->threshold_by_dimensions_ && !isVeryNearFreeSurface(index_i))
@@ -139,7 +139,7 @@ FreeSurfaceIndicationCK<Contact<Parameters...>>::InteractKernel::
 //=================================================================================================//
 template <typename... Parameters>
 void FreeSurfaceIndicationCK<Contact<Parameters...>>::InteractKernel::
-    interact(size_t index_i, Real dt)
+    compute(size_t index_i, Real dt)
 {
     Real pos_div = 0.0;
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)

--- a/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.h
@@ -148,8 +148,7 @@ class InteractionDynamicsCK<ExecutionPolicy, Base, InteractionType<Contact<Param
     using RangeIdentifier = typename LocalDynamicsType::RangeIdentifier;
     using InteractKernel = typename LocalDynamicsType::InteractKernel;
     using KernelImplementation = Implementation<ExecutionPolicy, LocalDynamicsType, InteractKernel>;
-    UniquePtrKeeper<KernelImplementation> contact_kernel_implementation_ptr_;
-    KernelImplementation *contact_kernel_implementation_;
+    KernelImplementation contact_kernel_implementation_;
 
   public:
     template <typename... Args>

--- a/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.hpp
@@ -103,7 +103,7 @@ void InteractionDynamicsCK<ExecutionPolicy, Base, InteractionType<Inner<Paramete
     InteractKernel *interact_kernel = kernel_implementation_.getComputingKernel();
     particle_for(LoopRangeCK<ExecutionPolicy, RangeIdentifier>(*this->identifier_),
                  [=](size_t i)
-                 { interact_kernel->interact(i, dt); });
+                 { interact_kernel->compute(i, dt); });
 
     this->logger_->debug(
         "InteractionDynamicsCK::runInteraction() for {} at {}",
@@ -130,7 +130,7 @@ void InteractionDynamicsCK<ExecutionPolicy, Base, InteractionType<Contact<Parame
     particle_for(LoopRangeCK<ExecutionPolicy, RangeIdentifier>(*this->identifier_),
                  [=](size_t i)
                  {
-                     interact_kernel->interact(i, dt);
+                     interact_kernel->compute(i, dt);
                  });
 
     this->logger_->debug(
@@ -210,7 +210,7 @@ void InteractionDynamicsCK<ExecutionPolicy, InteractionType<RelationType<WithUpd
     UpdateKernel *update_kernel = kernel_implementation_.getComputingKernel();
     particle_for(LoopRangeCK<ExecutionPolicy, RangeIdentifier>(*this->identifier_),
                  [=](size_t i)
-                 { update_kernel->update(i, dt); });
+                 { update_kernel->compute(i, dt); });
 
     this->logger_->debug(
         "InteractionDynamicsCK::runUpdateStep() for {} at {}",
@@ -265,7 +265,7 @@ void InteractionDynamicsCK<ExecutionPolicy, InteractionType<RelationType<OneLeve
     InitializeKernel *initialize_kernel = initialize_kernel_implementation_.getComputingKernel();
     particle_for(LoopRangeCK<ExecutionPolicy, RangeIdentifier>(*this->identifier_),
                  [=](size_t i)
-                 { initialize_kernel->initialize(i, dt); });
+                 { initialize_kernel->compute(i, dt); });
 
     this->logger_->debug(
         "InteractionDynamicsCK::runInitializationStep() for {} at {}",
@@ -281,7 +281,7 @@ void InteractionDynamicsCK<ExecutionPolicy, InteractionType<RelationType<OneLeve
     UpdateKernel *update_kernel = update_kernel_implementation_.getComputingKernel();
     particle_for(LoopRangeCK<ExecutionPolicy, RangeIdentifier>(*this->identifier_),
                  [=](size_t i)
-                 { update_kernel->update(i, dt); });
+                 { update_kernel->compute(i, dt); });
 
     this->logger_->debug(
         "InteractionDynamicsCK::runUpdateStep() for {} at {}",

--- a/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.hpp
+++ b/src/shared/shared_ck/particle_dynamics/interaction_algorithms_ck.hpp
@@ -100,10 +100,8 @@ template <class ExecutionPolicy, template <typename...> class InteractionType, t
 void InteractionDynamicsCK<ExecutionPolicy, Base, InteractionType<Inner<Parameters...>>>::
     runInteraction(Real dt)
 {
-    InteractKernel *interact_kernel = kernel_implementation_.getComputingKernel();
     particle_for(LoopRangeCK<ExecutionPolicy, RangeIdentifier>(*this->identifier_),
-                 [=](size_t i)
-                 { interact_kernel->compute(i, dt); });
+                 kernel_implementation_, dt);
 
     this->logger_->debug(
         "InteractionDynamicsCK::runInteraction() for {} at {}",
@@ -115,23 +113,18 @@ template <class ExecutionPolicy, template <typename...> class InteractionType, t
 template <typename... Args>
 InteractionDynamicsCK<ExecutionPolicy, Base, InteractionType<Contact<Parameters...>>>::
     InteractionDynamicsCK(Args &&...args)
-    : InteractionType<Contact<Parameters...>>(std::forward<Args>(args)...)
+    : InteractionType<Contact<Parameters...>>(std::forward<Args>(args)...),
+      contact_kernel_implementation_(*this)
 {
-    contact_kernel_implementation_ =
-        contact_kernel_implementation_ptr_.template createPtr<KernelImplementation>(*this);
-    this->registerComputingKernel(contact_kernel_implementation_);
+    this->registerComputingKernel(&contact_kernel_implementation_);
 }
 //=================================================================================================//
 template <class ExecutionPolicy, template <typename...> class InteractionType, typename... Parameters>
 void InteractionDynamicsCK<ExecutionPolicy, Base, InteractionType<Contact<Parameters...>>>::
     runInteraction(Real dt)
 {
-    InteractKernel *interact_kernel = contact_kernel_implementation_->getComputingKernel();
     particle_for(LoopRangeCK<ExecutionPolicy, RangeIdentifier>(*this->identifier_),
-                 [=](size_t i)
-                 {
-                     interact_kernel->compute(i, dt);
-                 });
+                 contact_kernel_implementation_, dt);
 
     this->logger_->debug(
         "InteractionDynamicsCK::runInteraction() for {} at {}",
@@ -207,10 +200,8 @@ template <class ExecutionPolicy, template <typename...> class InteractionType,
 void InteractionDynamicsCK<ExecutionPolicy, InteractionType<RelationType<WithUpdate, OtherParameters...>>>::
     runUpdateStep(Real dt)
 {
-    UpdateKernel *update_kernel = kernel_implementation_.getComputingKernel();
     particle_for(LoopRangeCK<ExecutionPolicy, RangeIdentifier>(*this->identifier_),
-                 [=](size_t i)
-                 { update_kernel->compute(i, dt); });
+                 kernel_implementation_, dt);
 
     this->logger_->debug(
         "InteractionDynamicsCK::runUpdateStep() for {} at {}",
@@ -262,10 +253,8 @@ template <class ExecutionPolicy, template <typename...> class InteractionType,
 void InteractionDynamicsCK<ExecutionPolicy, InteractionType<RelationType<OneLevel, OtherParameters...>>>::
     runInitializationStep(Real dt)
 {
-    InitializeKernel *initialize_kernel = initialize_kernel_implementation_.getComputingKernel();
     particle_for(LoopRangeCK<ExecutionPolicy, RangeIdentifier>(*this->identifier_),
-                 [=](size_t i)
-                 { initialize_kernel->compute(i, dt); });
+                 initialize_kernel_implementation_, dt);
 
     this->logger_->debug(
         "InteractionDynamicsCK::runInitializationStep() for {} at {}",
@@ -278,10 +267,8 @@ template <class ExecutionPolicy, template <typename...> class InteractionType,
 void InteractionDynamicsCK<ExecutionPolicy, InteractionType<RelationType<OneLevel, OtherParameters...>>>::
     runUpdateStep(Real dt)
 {
-    UpdateKernel *update_kernel = update_kernel_implementation_.getComputingKernel();
     particle_for(LoopRangeCK<ExecutionPolicy, RangeIdentifier>(*this->identifier_),
-                 [=](size_t i)
-                 { update_kernel->compute(i, dt); });
+                 update_kernel_implementation_, dt);
 
     this->logger_->debug(
         "InteractionDynamicsCK::runUpdateStep() for {} at {}",

--- a/src/shared/shared_ck/particle_dynamics/particle_iterators_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/particle_iterators_ck.h
@@ -66,23 +66,29 @@ void particle_for(const LoopRangeCK<ParallelPolicy, Identifier> &loop_range,
         ap);
 };
 
-template <typename Operation, class Identifier, class ReturnType, class UnaryFunc>
+template <typename Operation, class Identifier, class ReturnType, class KernelImplementationType>
 ReturnType particle_reduce(const LoopRangeCK<SequencedPolicy, Identifier> &loop_range,
-                           ReturnType temp, const UnaryFunc &unary_func)
+                           ReturnType temp, KernelImplementationType &implementation, Real dt)
 {
+    auto reduce_kernel = implementation.getComputingKernel();
     Operation operation;
     ReturnType temp0 = temp;
     for (size_t i = 0; i < loop_range.LoopBound(); ++i)
     {
-        temp0 = operation(temp0, loop_range.computeUnit(temp, operation, unary_func, i));
+        temp0 = operation(
+            temp0, loop_range.computeUnit(
+                       temp, operation,
+                       [=](size_t i)
+                       { return reduce_kernel->reduce(i, dt); }, i));
     }
     return temp0;
 }
 
-template <typename Operation, class Identifier, class ReturnType, class UnaryFunc>
+template <typename Operation, class Identifier, class ReturnType, class KernelImplementationType>
 ReturnType particle_reduce(const LoopRangeCK<ParallelPolicy, Identifier> &loop_range,
-                           ReturnType temp, const UnaryFunc &unary_func)
+                           ReturnType temp, KernelImplementationType &implementation, Real dt)
 {
+    auto reduce_kernel = implementation.getComputingKernel();
     Operation operation;
     return tbb::parallel_reduce(
         IndexRange(0, loop_range.LoopBound()), temp,
@@ -90,7 +96,10 @@ ReturnType particle_reduce(const LoopRangeCK<ParallelPolicy, Identifier> &loop_r
         {
 				for (size_t i = r.begin(); i != r.end(); ++i)
 				{
-					temp0 = operation(temp0, loop_range.computeUnit(temp, operation, unary_func, i));
+					temp0 = operation(temp0, loop_range.computeUnit(
+                        temp, operation,                         
+                        [=](size_t i)
+                       { return reduce_kernel->reduce(i, dt); }, i));
 				}
 				return temp0; },
         [&](const ReturnType &x, const ReturnType &y) -> ReturnType

--- a/src/shared/shared_ck/particle_dynamics/particle_iterators_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/particle_iterators_ck.h
@@ -107,5 +107,25 @@ ReturnType particle_reduce(const LoopRangeCK<ParallelPolicy, Identifier> &loop_r
             return operation(x, y);
         });
 };
+
+template <typename Operation, class ReturnType, class UnaryFunc>
+ReturnType particle_reduce(const ParallelPolicy &par, const IndexRange &particles_range,
+                           ReturnType temp, const UnaryFunc &unary_func)
+{
+    Operation operation;
+    return tbb::parallel_reduce(
+        particles_range, temp,
+        [&](const IndexRange &r, ReturnType temp0) -> ReturnType
+        {
+				for (size_t i = r.begin(); i != r.end(); ++i)
+				{
+					temp0 = operation(temp0, unary_func(i));
+				}
+				return temp0; },
+        [&](const ReturnType &x, const ReturnType &y) -> ReturnType
+        {
+            return operation(x, y);
+        });
+};
 } // namespace SPH
 #endif // PARTICLE_ITERATORS_CK_H

--- a/src/shared/shared_ck/particle_dynamics/particle_iterators_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/particle_iterators_ck.h
@@ -37,25 +37,30 @@ namespace SPH
 {
 using namespace execution;
 
-template <class Identifier, class UnaryFunc>
+template <class Identifier, class KernelImplementationType>
 void particle_for(const LoopRangeCK<SequencedPolicy, Identifier> &loop_range,
-                  const UnaryFunc &unary_func)
+                  KernelImplementationType &implementation, Real dt)
 {
+    auto kernel = implementation.getComputingKernel();
     for (size_t i = 0; i < loop_range.LoopBound(); ++i)
-        loop_range.computeUnit(unary_func, i);
+        loop_range.computeUnit([=](size_t i)
+                               { kernel->compute(i, dt); }, i);
 };
 
-template <class Identifier, class UnaryFunc>
+template <class Identifier, class KernelImplementationType>
 void particle_for(const LoopRangeCK<ParallelPolicy, Identifier> &loop_range,
-                  const UnaryFunc &unary_func)
+                  KernelImplementationType &implementation, Real dt)
 {
+    auto kernel = implementation.getComputingKernel();
     tbb::parallel_for(
         IndexRange(0, loop_range.LoopBound()),
         [&](const IndexRange &r)
         {
             for (size_t i = r.begin(); i < r.end(); ++i)
             {
-                loop_range.computeUnit(unary_func, i);
+                loop_range.computeUnit(
+                    [=](size_t i)
+                    { kernel->compute(i, dt); }, i);
             }
         },
         ap);

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_stepping_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/relaxation_stepping_ck.h
@@ -95,7 +95,7 @@ class PositionRelaxationCK : public BaseLocalDynamics<DynamicIdentifier>
               residual_(encloser.residual_->DelegatedData(ex_policy)),
               h_ratio_(ex_policy, encloser.adaptation_){};
 
-        void update(size_t index_i, Real dt_square)
+        void compute(size_t index_i, Real dt_square)
         {
             pos_[index_i] += residual_[index_i] * dt_square * 0.5 / h_ratio_(index_i);
         };
@@ -139,7 +139,7 @@ class UpdateSmoothingLengthRatio : public BaseLocalDynamics<DynamicIdentifier>
               local_spacing_(ex_policy, encloser.local_spacing_method_),
               reference_spacing_(encloser.reference_spacing_){};
 
-        void update(size_t index_i, Real dt = 0.0)
+        void compute(size_t index_i, Real dt = 0.0)
         {
             Real local_spacing = local_spacing_(pos_[index_i]);
             h_ratio_[index_i] = reference_spacing_ / local_spacing;

--- a/src/shared/shared_ck/particle_dynamics/relax_dynamics/surface_correction.h
+++ b/src/shared/shared_ck/particle_dynamics/relax_dynamics/surface_correction.h
@@ -50,7 +50,7 @@ class LevelsetBounding : public BaseLocalDynamics<BodyPartByCell>
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
 
-        void update(size_t index_i, Real dt = 0.0)
+        void compute(size_t index_i, Real dt = 0.0)
         {
             Real phi = signed_distance_(pos_[index_i]);
 
@@ -91,7 +91,7 @@ class LevelsetKernelGradientIntegral : public BaseLocalDynamics<DynamicIdentifie
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
 
-        void update(size_t index_i, Real dt = 0.0)
+        void compute(size_t index_i, Real dt = 0.0)
         {
             residual_[index_i] -= 2.0 * kernel_gradient_integral_(pos_[index_i], h_ratio_(index_i));
         };

--- a/src/shared/shared_ck/particle_dynamics/simple_algorithms_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/simple_algorithms_ck.h
@@ -60,10 +60,8 @@ class StateDynamics : public UpdateType, public BaseDynamics<void>
     {
         this->setUpdated(this->identifier_->getSPHBody());
         this->setupDynamics(dt);
-        UpdateKernel *update_kernel = kernel_implementation_.getComputingKernel();
         particle_for(LoopRangeCK<ExecutionPolicy, RangeIdentifier>(*this->identifier_),
-                     [=](size_t i)
-                     { update_kernel->compute(i, dt); });
+                     kernel_implementation_, dt);
 
         finish_dynamics_();
 

--- a/src/shared/shared_ck/particle_dynamics/simple_algorithms_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/simple_algorithms_ck.h
@@ -53,7 +53,7 @@ class StateDynamics : public UpdateType, public BaseDynamics<void>
     template <typename... Args>
     StateDynamics(Args &&...args)
         : UpdateType(std::forward<Args>(args)...),
-          BaseDynamics<void>(), kernel_implementation_(*this), finish_dynamics_(*this){};
+          BaseDynamics<void>(), kernel_implementation_(*this), finish_dynamics_(*this) {};
     virtual ~StateDynamics() {};
 
     virtual void exec(Real dt = 0.0) override
@@ -94,7 +94,7 @@ class ReduceDynamicsCK : public ReduceType,
     ReduceDynamicsCK(Args &&...args)
         : ReduceType(std::forward<Args>(args)...),
           BaseDynamics<OutputType>(), kernel_implementation_(*this),
-          reduced_value_(this->reference_), finish_dynamics_(*this){};
+          reduced_value_(this->reference_), finish_dynamics_(*this) {};
     virtual ~ReduceDynamicsCK() {};
     std::string QuantityName() { return this->quantity_name_; };
     ReduceReturnType ReducedValue() { return reduced_value_; };
@@ -102,12 +102,9 @@ class ReduceDynamicsCK : public ReduceType,
     virtual OutputType exec(Real dt = 0.0) override
     {
         this->setupDynamics(dt);
-        ReduceKernel *reduce_kernel = kernel_implementation_.getComputingKernel();
         reduced_value_ = particle_reduce<Operation>(
             LoopRangeCK<ExecutionPolicy, RangeIdentifier>(*this->identifier_),
-            this->reference_,
-            [=](size_t i)
-            { return reduce_kernel->reduce(i, dt); });
+            this->reference_, kernel_implementation_, dt);
 
         this->logger_->debug(
             "ReduceDynamicsCK::exec() for {} at {}",

--- a/src/shared/shared_ck/particle_dynamics/simple_algorithms_ck.h
+++ b/src/shared/shared_ck/particle_dynamics/simple_algorithms_ck.h
@@ -63,7 +63,7 @@ class StateDynamics : public UpdateType, public BaseDynamics<void>
         UpdateKernel *update_kernel = kernel_implementation_.getComputingKernel();
         particle_for(LoopRangeCK<ExecutionPolicy, RangeIdentifier>(*this->identifier_),
                      [=](size_t i)
-                     { update_kernel->update(i, dt); });
+                     { update_kernel->compute(i, dt); });
 
         finish_dynamics_();
 

--- a/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_factor.h
+++ b/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_factor.h
@@ -72,7 +72,7 @@ class RepulsionFactor<Contact<Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real *repulsion_factor_;

--- a/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_factor.hpp
+++ b/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_factor.hpp
@@ -39,7 +39,7 @@ RepulsionFactor<Contact<Parameters...>>::InteractKernel::
 //=================================================================================================//
 template <typename... Parameters>
 void RepulsionFactor<Contact<Parameters...>>::InteractKernel::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Real sigma(0);
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)

--- a/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_force.h
+++ b/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_force.h
@@ -75,7 +75,7 @@ class RepulsionForceCK<Contact<WithUpdate, Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real numerical_damping_;
@@ -110,7 +110,7 @@ class RepulsionForceCK<Contact<WithUpdate, Wall, Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real numerical_damping_;

--- a/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_force.hpp
+++ b/src/shared/shared_ck/particle_dynamics/solid_dynamics/contact_dynamics/repulsion_force.hpp
@@ -61,7 +61,7 @@ RepulsionForceCK<Contact<WithUpdate, Parameters...>>::InteractKernel::
 //=================================================================================================//
 template <typename... Parameters>
 void RepulsionForceCK<Contact<WithUpdate, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Vecd force = Vecd::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -105,7 +105,7 @@ RepulsionForceCK<Contact<WithUpdate, Wall, Parameters...>>::InteractKernel::
 //=================================================================================================//
 template <typename... Parameters>
 void RepulsionForceCK<Contact<WithUpdate, Wall, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Vecd force = Vecd::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)

--- a/src/shared/shared_ck/particle_dynamics/solid_dynamics/derived_solid_state.h
+++ b/src/shared/shared_ck/particle_dynamics/solid_dynamics/derived_solid_state.h
@@ -70,7 +70,7 @@ class UpdateDisplacementFromPosition : public DisplacementAndPosition
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
             : DisplacementAndPosition::UpdateKernel(ex_policy, encloser){};
-        void update(size_t index_i, Real dt = 0.0)
+        void compute(size_t index_i, Real dt = 0.0)
         {
             displacement_[index_i] = pos_[index_i] - pos0_[index_i];
         };
@@ -89,7 +89,7 @@ class UpdatePositionFromDisplacement : public DisplacementAndPosition
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
             : DisplacementAndPosition::UpdateKernel(ex_policy, encloser){};
-        void update(size_t index_i, Real dt = 0.0)
+        void compute(size_t index_i, Real dt = 0.0)
         {
             pos_[index_i] = pos0_[index_i] + displacement_[index_i];
         };

--- a/src/shared/shared_ck/particle_dynamics/solid_dynamics/solid_constraint.h
+++ b/src/shared/shared_ck/particle_dynamics/solid_dynamics/solid_constraint.h
@@ -53,7 +53,7 @@ class ConstraintBySimBodyCK : public BaseLocalDynamics<DynamicsIdentifier>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Vecd *pos_, *pos0_, *vel_;

--- a/src/shared/shared_ck/particle_dynamics/solid_dynamics/solid_constraint.hpp
+++ b/src/shared/shared_ck/particle_dynamics/solid_dynamics/solid_constraint.hpp
@@ -51,7 +51,7 @@ ConstraintBySimBodyCK<DynamicsIdentifier>::UpdateKernel::
       simbody_state_(encloser.sv_simbody_state_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
 template <class DynamicsIdentifier>
-void ConstraintBySimBodyCK<DynamicsIdentifier>::UpdateKernel::update(size_t index_i, Real dt)
+void ConstraintBySimBodyCK<DynamicsIdentifier>::UpdateKernel::compute(size_t index_i, Real dt)
 {
     Vec3d pos, vel, acc, n;
     simbody_state_->findStationLocationVelocityAndAccelerationInGround(

--- a/src/shared/shared_ck/particle_dynamics/solid_dynamics/structure_dynamics.h
+++ b/src/shared/shared_ck/particle_dynamics/solid_dynamics/structure_dynamics.h
@@ -98,7 +98,7 @@ class BaseStructureIntegration1stHalf : public StructureDynamicsVariables
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real *mass_;
@@ -132,7 +132,7 @@ class StructureIntegration1stHalf<Inner<OneLevel, MaterialType, KernelCorrection
       public:
         template <class ExecutionPolicy, class EncloserType>
         InitializeKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void initialize(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         ConstituteKernel constitute_;
@@ -149,7 +149,7 @@ class StructureIntegration1stHalf<Inner<OneLevel, MaterialType, KernelCorrection
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real *Vol0_;
@@ -186,7 +186,7 @@ class StructureIntegration1stHalfPK2<Inner<OneLevel, MaterialType, Parameters...
       public:
         template <class ExecutionPolicy, class EncloserType>
         InitializeKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void initialize(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         ConstituteKernel constitute_;
@@ -201,7 +201,7 @@ class StructureIntegration1stHalfPK2<Inner<OneLevel, MaterialType, Parameters...
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real *Vol0_;
@@ -233,7 +233,7 @@ class StructureIntegration2ndHalf<Inner<OneLevel, Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         InitializeKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void initialize(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Vecd *pos_, *vel_;
@@ -244,7 +244,7 @@ class StructureIntegration2ndHalf<Inner<OneLevel, Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Real *Vol0_;
@@ -257,7 +257,7 @@ class StructureIntegration2ndHalf<Inner<OneLevel, Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Matd *F_, *dF_dt_;
@@ -288,7 +288,7 @@ class StructureNumericalDamping<Inner<WithUpdate, MaterialType, Parameters...>>
       public:
         template <class ExecutionPolicy, class EncloserType>
         InteractKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void interact(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         ConstituteKernel constitute_;
@@ -317,7 +317,7 @@ class UpdateElasticNormalDirectionCK : public LocalDynamics
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Vecd *n_, *n0_;
@@ -341,7 +341,7 @@ class UpdateAnisotropicMeasure : public LocalDynamics
       public:
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser);
-        void update(size_t index_i, Real dt = 0.0);
+        void compute(size_t index_i, Real dt = 0.0);
 
       protected:
         Vecd *scaling_, *scaling0_;

--- a/src/shared/shared_ck/particle_dynamics/solid_dynamics/structure_dynamics.hpp
+++ b/src/shared/shared_ck/particle_dynamics/solid_dynamics/structure_dynamics.hpp
@@ -32,7 +32,7 @@ BaseStructureIntegration1stHalf::UpdateKernel::
       force_(encloser.dv_force_->DelegatedData(ex_policy)),
       force_prior_(encloser.dv_force_prior_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
-inline void BaseStructureIntegration1stHalf::UpdateKernel::update(size_t index_i, Real dt)
+inline void BaseStructureIntegration1stHalf::UpdateKernel::compute(size_t index_i, Real dt)
 {
     vel_[index_i] += (force_prior_[index_i] + force_[index_i]) / mass_[index_i] * dt;
 }
@@ -66,7 +66,7 @@ StructureIntegration1stHalf<Inner<OneLevel, MaterialType, KernelCorrectionType, 
 //=================================================================================================//
 template <class MaterialType, typename KernelCorrectionType, typename... Parameters>
 void StructureIntegration1stHalf<Inner<OneLevel, MaterialType, KernelCorrectionType, Parameters...>>::
-    InitializeKernel::initialize(size_t index_i, Real dt)
+    InitializeKernel::compute(size_t index_i, Real dt)
 {
     pos_[index_i] += vel_[index_i] * dt * 0.5;
     F_[index_i] += dF_dt_[index_i] * dt * 0.5;
@@ -101,7 +101,7 @@ StructureIntegration1stHalf<Inner<OneLevel, MaterialType, KernelCorrectionType, 
 //=================================================================================================//
 template <class MaterialType, typename KernelCorrectionType, typename... Parameters>
 void StructureIntegration1stHalf<Inner<OneLevel, MaterialType, KernelCorrectionType, Parameters...>>::
-    InteractKernel::interact(size_t index_i, Real dt)
+    InteractKernel::compute(size_t index_i, Real dt)
 {
     Vecd sum = Vecd::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -148,7 +148,7 @@ StructureIntegration1stHalfPK2<Inner<OneLevel, MaterialType, Parameters...>>::
 //=================================================================================================//
 template <class MaterialType, typename... Parameters>
 void StructureIntegration1stHalfPK2<Inner<OneLevel, MaterialType, Parameters...>>::
-    InitializeKernel::initialize(size_t index_i, Real dt)
+    InitializeKernel::compute(size_t index_i, Real dt)
 {
     pos_[index_i] += vel_[index_i] * dt * 0.5;
     F_[index_i] += dF_dt_[index_i] * dt * 0.5;
@@ -170,7 +170,7 @@ StructureIntegration1stHalfPK2<Inner<OneLevel, MaterialType, Parameters...>>::
 //=================================================================================================//
 template <class MaterialType, typename... Parameters>
 void StructureIntegration1stHalfPK2<Inner<OneLevel, MaterialType, Parameters...>>::InteractKernel::
-    interact(size_t index_i, Real dt)
+    compute(size_t index_i, Real dt)
 {
     Vecd sum = Vecd::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -197,7 +197,7 @@ StructureIntegration2ndHalf<Inner<OneLevel, Parameters...>>::InitializeKernel::
 //=================================================================================================//
 template <typename... Parameters>
 void StructureIntegration2ndHalf<Inner<OneLevel, Parameters...>>::InitializeKernel::
-    initialize(size_t index_i, Real dt)
+    compute(size_t index_i, Real dt)
 {
     pos_[index_i] += vel_[index_i] * dt * 0.5;
 }
@@ -214,7 +214,7 @@ StructureIntegration2ndHalf<Inner<OneLevel, Parameters...>>::InteractKernel::
 //=================================================================================================//
 template <typename... Parameters>
 void StructureIntegration2ndHalf<Inner<OneLevel, Parameters...>>::InteractKernel::
-    interact(size_t index_i, Real dt)
+    compute(size_t index_i, Real dt)
 {
     Matd sum = Matd::Zero();
     for (UnsignedInt n = this->FirstNeighbor(index_i); n != this->LastNeighbor(index_i); ++n)
@@ -235,7 +235,7 @@ StructureIntegration2ndHalf<Inner<OneLevel, Parameters...>>::UpdateKernel::
 //=================================================================================================//
 template <typename... Parameters>
 void StructureIntegration2ndHalf<Inner<OneLevel, Parameters...>>::UpdateKernel::
-    update(size_t index_i, Real dt)
+    compute(size_t index_i, Real dt)
 {
     F_[index_i] += dF_dt_[index_i] * dt * 0.5;
 }
@@ -268,7 +268,7 @@ StructureNumericalDamping<Inner<WithUpdate, MaterialType, Parameters...>>::
 //=================================================================================================//
 template <class MaterialType, typename... Parameters>
 void StructureNumericalDamping<Inner<WithUpdate, MaterialType, Parameters...>>::InteractKernel::
-    interact(size_t index_i, Real dt)
+    compute(size_t index_i, Real dt)
 {
     Vecd sum = Vecd::Zero();
     Real inv_W0 = 1.0 / this->W0(index_i, zero_);
@@ -300,7 +300,7 @@ UpdateElasticNormalDirectionCK::UpdateKernel::
       phi0_(encloser.dv_phi0_->DelegatedData(ex_policy)),
       F_(encloser.dv_F_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
-inline void UpdateElasticNormalDirectionCK::UpdateKernel::update(size_t index_i, Real dt)
+inline void UpdateElasticNormalDirectionCK::UpdateKernel::compute(size_t index_i, Real dt)
 {
     n_[index_i] = polarRotation(F_[index_i]) * n0_[index_i];
     // Nanson's relation is used to update the distance to surface
@@ -317,7 +317,7 @@ UpdateAnisotropicMeasure::UpdateKernel::
       orientation0_(encloser.dv_orientation0_->DelegatedData(ex_policy)),
       F_(encloser.dv_F_->DelegatedData(ex_policy)) {}
 //=================================================================================================//
-inline void UpdateAnisotropicMeasure::UpdateKernel::update(size_t index_i, Real dt)
+inline void UpdateAnisotropicMeasure::UpdateKernel::compute(size_t index_i, Real dt)
 {
     Matd rotation = Matd::Identity();
     Matd stretch = Matd::Identity();

--- a/src/src_sycl/shared/common/algorithm_primitive_sycl.cpp
+++ b/src/src_sycl/shared/common/algorithm_primitive_sycl.cpp
@@ -5,7 +5,7 @@
 namespace SPH
 {
 //=================================================================================================//
-void RadixSort::sort(const ParallelDevicePolicy &ex_policy, UnsignedInt size, UnsignedInt start_index)
+void RadixSort::sort(const SYCLDevicePolicy &ex_policy, UnsignedInt size, UnsignedInt start_index)
 {
     UnsignedInt *index_permutation = dv_index_permutation_->DelegatedData(ex_policy);
     UnsignedInt *begin = dv_sequence_->DelegatedData(ex_policy) + start_index;

--- a/src/src_sycl/shared/common/algorithm_primitive_sycl.h
+++ b/src/src_sycl/shared/common/algorithm_primitive_sycl.h
@@ -85,7 +85,7 @@ class RadixSort
                        DiscreteVariable<UnsignedInt> *dv_sequence,
                        DiscreteVariable<UnsignedInt> *dv_index_permutation)
         : dv_sequence_(dv_sequence), dv_index_permutation_(dv_index_permutation) {};
-    void sort(const ParallelDevicePolicy &ex_policy, UnsignedInt size, UnsignedInt start_index = 0);
+    void sort(const SYCLDevicePolicy &ex_policy, UnsignedInt size, UnsignedInt start_index = 0);
 
   protected:
     DiscreteVariable<UnsignedInt> *dv_sequence_;
@@ -94,7 +94,7 @@ class RadixSort
 };
 
 template <typename T, typename Op>
-T exclusive_scan(const ParallelDevicePolicy &par_policy, T *first, T *d_first, UnsignedInt d_size, Op op)
+T exclusive_scan(const SYCLDevicePolicy &par_policy, T *first, T *d_first, UnsignedInt d_size, Op op)
 {
 #if !SPHINXSYS_USE_ONEDPL
     execution_instance.getQueue()
@@ -122,7 +122,7 @@ T exclusive_scan(const ParallelDevicePolicy &par_policy, T *first, T *d_first, U
 }
 
 template <class UnaryFunc>
-void generic_for(const ParallelDevicePolicy &par_device,
+void generic_for(const SYCLDevicePolicy &sycl_device,
                  const IndexRange &index_range,
                  const UnaryFunc &unary_func)
 {

--- a/src/src_sycl/shared/common/sphinxsys_constant_sycl.hpp
+++ b/src/src_sycl/shared/common/sphinxsys_constant_sycl.hpp
@@ -8,7 +8,6 @@ namespace SPH
 {
 //=================================================================================================//
 template <typename DataType>
-template <class PolicyType>
 DataType *ConstantArray<DataType>::DelegatedOnDevice(const SYCLDevicePolicy &ex_policy)
 {
     if (!isDataDelegated())
@@ -20,7 +19,6 @@ DataType *ConstantArray<DataType>::DelegatedOnDevice(const SYCLDevicePolicy &ex_
 };
 //=================================================================================================//
 template <typename DataType>
-template <class PolicyType>
 DeviceOnlyConstantArray<DataType>::DeviceOnlyConstantArray(
     const SYCLDevicePolicy &ex_policy, ConstantArray<DataType> *host_constant)
     : Quantity(host_constant->Name()), device_only_data_(nullptr)
@@ -39,7 +37,6 @@ DeviceOnlyConstantArray<DataType>::~DeviceOnlyConstantArray()
 }
 //=================================================================================================//
 template <typename GeneratorType, typename ComputingKernelType>
-template <class PolicyType>
 ComputingKernelType *ComputingKernelArray<GeneratorType, ComputingKernelType>::DelegatedOnDevice(
     const SYCLDevicePolicy &ex_policy)
 {
@@ -52,7 +49,6 @@ ComputingKernelType *ComputingKernelArray<GeneratorType, ComputingKernelType>::D
 }
 //=================================================================================================//
 template <typename GeneratorType, typename ComputingKernelType>
-template <class PolicyType>
 DeviceOnlyComputingKernelArray<GeneratorType, ComputingKernelType>::DeviceOnlyComputingKernelArray(
     const SYCLDevicePolicy &ex_policy,
     ComputingKernelArray<GeneratorType, ComputingKernelType> *host_constant)

--- a/src/src_sycl/shared/common/sphinxsys_constant_sycl.hpp
+++ b/src/src_sycl/shared/common/sphinxsys_constant_sycl.hpp
@@ -9,12 +9,12 @@ namespace SPH
 //=================================================================================================//
 template <typename DataType>
 template <class PolicyType>
-DataType *ConstantArray<DataType>::DelegatedOnDevice(const DeviceExecution<PolicyType> &ex_policy)
+DataType *ConstantArray<DataType>::DelegatedOnDevice(const SYCLDevicePolicy &ex_policy)
 {
     if (!isDataDelegated())
     {
         device_only_constant_array_keeper_
-            .createPtr<DeviceOnlyConstantArray<DataType>>(DeviceExecution<PolicyType>{}, this);
+            .createPtr<DeviceOnlyConstantArray<DataType>>(SYCLDevicePolicy{}, this);
     }
     return delegated_;
 };
@@ -22,7 +22,7 @@ DataType *ConstantArray<DataType>::DelegatedOnDevice(const DeviceExecution<Polic
 template <typename DataType>
 template <class PolicyType>
 DeviceOnlyConstantArray<DataType>::DeviceOnlyConstantArray(
-    const DeviceExecution<PolicyType> &ex_policy, ConstantArray<DataType> *host_constant)
+    const SYCLDevicePolicy &ex_policy, ConstantArray<DataType> *host_constant)
     : Quantity(host_constant->Name()), device_only_data_(nullptr)
 {
     size_t data_size = host_constant->getSize();
@@ -41,12 +41,12 @@ DeviceOnlyConstantArray<DataType>::~DeviceOnlyConstantArray()
 template <typename GeneratorType, typename ComputingKernelType>
 template <class PolicyType>
 ComputingKernelType *ComputingKernelArray<GeneratorType, ComputingKernelType>::DelegatedOnDevice(
-    const DeviceExecution<PolicyType> &ex_policy)
+    const SYCLDevicePolicy &ex_policy)
 {
     if (!isDataDelegated())
     {
         device_only_kernel_array_keeper_.createPtr<DeviceOnlyComputingKernelArray<
-            GeneratorType, ComputingKernelType>>(DeviceExecution<PolicyType>{}, this);
+            GeneratorType, ComputingKernelType>>(SYCLDevicePolicy{}, this);
     }
     return delegated_;
 }
@@ -54,7 +54,7 @@ ComputingKernelType *ComputingKernelArray<GeneratorType, ComputingKernelType>::D
 template <typename GeneratorType, typename ComputingKernelType>
 template <class PolicyType>
 DeviceOnlyComputingKernelArray<GeneratorType, ComputingKernelType>::DeviceOnlyComputingKernelArray(
-    const DeviceExecution<PolicyType> &ex_policy,
+    const SYCLDevicePolicy &ex_policy,
     ComputingKernelArray<GeneratorType, ComputingKernelType> *host_constant)
     : Quantity(host_constant->Name()), device_only_data_(nullptr)
 {

--- a/src/src_sycl/shared/common/sphinxsys_variable_array_sycl.hpp
+++ b/src/src_sycl/shared/common/sphinxsys_variable_array_sycl.hpp
@@ -8,7 +8,6 @@ namespace SPH
 {
 //=================================================================================================//
 template <typename DataType>
-template <class PolicyType>
 MultiEntryView<DataType> *VariableArray<DataType>::DelegatedOnDevice()
 {
     if (!isVariableArrayViewDelegated())
@@ -20,7 +19,6 @@ MultiEntryView<DataType> *VariableArray<DataType>::DelegatedOnDevice()
 }
 //=================================================================================================//
 template <typename DataType>
-template <class PolicyType>
 DeviceOnlyVariableArray<DataType>::
     DeviceOnlyVariableArray(const SYCLDevicePolicy &ex_policy,
                             VariableArray<DataType> *host_variable_array)

--- a/src/src_sycl/shared/common/sphinxsys_variable_array_sycl.hpp
+++ b/src/src_sycl/shared/common/sphinxsys_variable_array_sycl.hpp
@@ -14,7 +14,7 @@ MultiEntryView<DataType> *VariableArray<DataType>::DelegatedOnDevice()
     if (!isVariableArrayViewDelegated())
     {
         device_only_variable_array_ = device_only_variable_array_keeper_.createPtr<
-            DeviceOnlyVariableArray<DataType>>(DeviceExecution<PolicyType>{}, this);
+            DeviceOnlyVariableArray<DataType>>(SYCLDevicePolicy{}, this);
     }
     return device_only_variable_array_->DeviceOnlyMultiEntryView();
 }
@@ -22,7 +22,7 @@ MultiEntryView<DataType> *VariableArray<DataType>::DelegatedOnDevice()
 template <typename DataType>
 template <class PolicyType>
 DeviceOnlyVariableArray<DataType>::
-    DeviceOnlyVariableArray(const DeviceExecution<PolicyType> &ex_policy,
+    DeviceOnlyVariableArray(const SYCLDevicePolicy &ex_policy,
                             VariableArray<DataType> *host_variable_array)
     : Quantity(host_variable_array->Name()), device_only_multi_entry_view_(nullptr)
 {

--- a/src/src_sycl/shared/mesh_dynamics/mesh_iterators_sycl.hpp
+++ b/src/src_sycl/shared/mesh_dynamics/mesh_iterators_sycl.hpp
@@ -8,7 +8,7 @@ namespace SPH
 {
 //=================================================================================================//
 template <typename FunctionOnData>
-void package_for(const ParallelDevicePolicy &par_device, UnsignedInt start_index,
+void package_for(const SYCLDevicePolicy &sycl_device, UnsignedInt start_index,
                  UnsignedInt end_index, const FunctionOnData &function)
 {
     UnsignedInt operations = end_index - start_index;

--- a/src/src_sycl/shared/particle_dynamics/configuration_dynamics/base_configuration_dynamics_sycl.h
+++ b/src/src_sycl/shared/particle_dynamics/configuration_dynamics/base_configuration_dynamics_sycl.h
@@ -36,13 +36,13 @@ namespace SPH
 
 class RadixSort;
 template <>
-struct SortMethod<ParallelDevicePolicy>
+struct SortMethod<SYCLDevicePolicy>
 {
     typedef RadixSort type;
 };
 
 template <>
-struct PlusUnsignedInt<ParallelDevicePolicy>
+struct PlusUnsignedInt<SYCLDevicePolicy>
 {
     typedef sycl::plus<UnsignedInt> type;
 };

--- a/src/src_sycl/shared/particle_dynamics/particle_iterators_sycl.h
+++ b/src/src_sycl/shared/particle_dynamics/particle_iterators_sycl.h
@@ -35,7 +35,7 @@
 namespace SPH
 {
 template <class UnaryFunc>
-void particle_for(const ParallelDevicePolicy &par_device,
+void particle_for(const SYCLDevicePolicy &sycl_device,
                   const IndexRange &particles_range,
                   const UnaryFunc &unary_func)
 {
@@ -50,21 +50,7 @@ void particle_for(const ParallelDevicePolicy &par_device,
 }
 
 template <class Identifier, class UnaryFunc>
-void particle_for(const LoopRangeCK<SequencedDevicePolicy, Identifier> &loop_range,
-                  const UnaryFunc &unary_func)
-{
-    auto &sycl_queue = execution_instance.getQueue();
-    const size_t loop_bound = loop_range.LoopBound();
-    sycl_queue.submit([&](sycl::handler &cgh)
-                      { cgh.single_task([=]()
-                                        {
-                                for (int i = 0; i != loop_bound; i++)
-                                    loop_range.computeUnit(unary_func, i); }); })
-        .wait_and_throw();
-}
-
-template <class Identifier, class UnaryFunc>
-void particle_for(const LoopRangeCK<ParallelDevicePolicy, Identifier> &loop_range,
+void particle_for(const LoopRangeCK<SYCLDevicePolicy, Identifier> &loop_range,
                   const UnaryFunc &unary_func)
 {
     auto &sycl_queue = execution_instance.getQueue();
@@ -78,7 +64,7 @@ void particle_for(const LoopRangeCK<ParallelDevicePolicy, Identifier> &loop_rang
 }
 
 template <typename Operation, class Identifier, class ReturnType, class UnaryFunc>
-ReturnType particle_reduce(const LoopRangeCK<ParallelDevicePolicy, Identifier> &loop_range,
+ReturnType particle_reduce(const LoopRangeCK<SYCLDevicePolicy, Identifier> &loop_range,
                            ReturnType temp, const UnaryFunc &unary_func)
 {
     auto &sycl_queue = execution_instance.getQueue();

--- a/src/src_sycl/shared/particle_dynamics/particle_iterators_sycl.h
+++ b/src/src_sycl/shared/particle_dynamics/particle_iterators_sycl.h
@@ -49,17 +49,20 @@ void particle_for(const SYCLDevicePolicy &sycl_device,
         .wait_and_throw();
 }
 
-template <class Identifier, class UnaryFunc>
+template <class Identifier, class KernelImplementationType>
 void particle_for(const LoopRangeCK<SYCLDevicePolicy, Identifier> &loop_range,
-                  const UnaryFunc &unary_func)
+                  KernelImplementationType &implementation, Real dt)
 {
+    auto kernel = implementation.getComputingKernel();
     auto &sycl_queue = execution_instance.getQueue();
     const size_t loop_bound = loop_range.LoopBound();
     sycl_queue.submit([&](sycl::handler &cgh)
                       { cgh.parallel_for(execution_instance.getUniformNdRange(loop_bound), [=](sycl::nd_item<1> index)
                                          {
                                  if(index.get_global_id(0) < loop_bound)
-                                     loop_range.computeUnit(unary_func, index.get_global_id(0)); }); })
+                                     loop_range.computeUnit(
+                                         [=](size_t i){ kernel->compute(i, dt); }, 
+                                        index.get_global_id(0)); }); })
         .wait_and_throw();
 }
 

--- a/src/src_sycl/shared/particle_dynamics/particle_iterators_sycl.h
+++ b/src/src_sycl/shared/particle_dynamics/particle_iterators_sycl.h
@@ -95,5 +95,31 @@ ReturnType particle_reduce(const LoopRangeCK<SYCLDevicePolicy, Identifier> &loop
     } // buffer_result goes out of scope, so the result (of temp) is updated
     return temp;
 }
+
+template <typename Operation, class ReturnType, class UnaryFunc>
+ReturnType particle_reduce(const SYCLDevicePolicy &sycl_device, const IndexRange &particles_range,
+                           ReturnType temp, const UnaryFunc &unary_func)
+{
+   auto &sycl_queue = execution_instance.getQueue();
+    const size_t loop_bound = particles_range.size();
+    ReturnType temp0 = temp;
+    {
+        sycl::buffer<ReturnType> buffer_result(&temp, 1);
+        sycl::buffer<ReturnType> buffer_reference(&temp0, 1);
+        sycl_queue.submit([&](sycl::handler &cgh)
+                          {
+                                Operation operation;
+                                sycl::accessor acc(buffer_reference, cgh, sycl::read_only);
+                                auto reduction_operator = sycl::reduction(buffer_result, cgh, operation);
+                                cgh.parallel_for(execution_instance.getUniformNdRange(loop_bound), reduction_operator,
+                                                 [=](sycl::nd_item<1> item, auto &reduction)
+                                                 {
+                                                     if (item.get_global_id() < loop_bound)
+                                                         reduction.combine(unary_func(item.get_global_id(0)));
+                                                 }); })
+            .wait_and_throw();
+    } // buffer_result goes out of scope, so the result (of temp) is updated
+    return temp;
+}
 } // namespace SPH
 #endif // PARTICLE_ITERATORS_SYCL_H

--- a/src/src_sycl/shared/particle_dynamics/particle_iterators_sycl.h
+++ b/src/src_sycl/shared/particle_dynamics/particle_iterators_sycl.h
@@ -66,10 +66,11 @@ void particle_for(const LoopRangeCK<SYCLDevicePolicy, Identifier> &loop_range,
         .wait_and_throw();
 }
 
-template <typename Operation, class Identifier, class ReturnType, class UnaryFunc>
+template <typename Operation, class Identifier, class ReturnType, class KernelImplementationType>
 ReturnType particle_reduce(const LoopRangeCK<SYCLDevicePolicy, Identifier> &loop_range,
-                           ReturnType temp, const UnaryFunc &unary_func)
+                           ReturnType temp, KernelImplementationType &implementation, Real dt)
 {
+    auto reduce_kernel = implementation.getComputingKernel();
     auto &sycl_queue = execution_instance.getQueue();
     const size_t loop_bound = loop_range.LoopBound();
     ReturnType temp0 = temp;
@@ -86,7 +87,9 @@ ReturnType particle_reduce(const LoopRangeCK<SYCLDevicePolicy, Identifier> &loop
                                                  {
                                                      if (item.get_global_id() < loop_bound)
                                                          reduction.combine(loop_range.computeUnit(
-                                                             acc[0], operation, unary_func, item.get_global_id(0)));
+                                                             acc[0], operation, 
+                                                             [=](size_t i){ return reduce_kernel->reduce(i, dt); }, 
+                                                             item.get_global_id(0)));
                                                  }); })
             .wait_and_throw();
     } // buffer_result goes out of scope, so the result (of temp) is updated

--- a/tests/tests_sycl/2d_examples/test_2d_flow_stream_around_fish_sycl/2d_flow_stream_around_fish.h
+++ b/tests/tests_sycl/2d_examples/test_2d_flow_stream_around_fish_sycl/2d_flow_stream_around_fish.h
@@ -214,7 +214,7 @@ class InitializeDisplacementCK : public LocalDynamics
             : pos_(encloser.dv_pos_->DelegatedData(ex_policy)),
               pos_temp_(encloser.dv_pos_temp_->DelegatedData(ex_policy)) {}
 
-        void update(size_t index_i, Real dt = 0.0) { pos_temp_[index_i] = pos_[index_i]; }
+        void compute(size_t index_i, Real dt = 0.0) { pos_temp_[index_i] = pos_[index_i]; }
 
       protected:
         Vecd *pos_, *pos_temp_;
@@ -243,7 +243,7 @@ class UpdateAverageVelocityAndAccelerationCK : public LocalDynamics
               vel_ave_(encloser.dv_vel_ave_->DelegatedData(ex_policy)),
               acc_ave_(encloser.dv_acc_ave_->DelegatedData(ex_policy)) {}
 
-        void update(size_t index_i, Real dt = 0.0)
+        void compute(size_t index_i, Real dt = 0.0)
         {
             Vecd updated_vel_ave = (pos_[index_i] - pos_temp_[index_i]) / (dt + Eps);
             acc_ave_[index_i] = (updated_vel_ave - vel_ave_[index_i]) / (dt + Eps);
@@ -266,7 +266,7 @@ class FishMaterialInitialization : public MaterialIdInitialization
           dv_material_id_(particles_->getVariableByName<int>("MaterialID")),
           dv_pos_(particles_->getVariableByName<Vecd>("Position")) {};
 
-    void update(size_t index_i, Real dt = 0.0)
+    void compute(size_t index_i, Real dt = 0.0)
     {
         Real x = pos_[index_i][0] - cx;
         Real y = pos_[index_i][1];
@@ -301,7 +301,7 @@ class FishMaterialInitialization : public MaterialIdInitialization
               bone_thickness_(bone_thickness),
               a1_(a1), a2_(a2), a3_(a3), a4_(a4), a5_(a5) {}
 
-        void update(size_t index_i, Real dt = 0.0)
+        void compute(size_t index_i, Real dt = 0.0)
         {
             Real x = pos_[index_i][0] - cx_;
             Real y = pos_[index_i][1];
@@ -367,7 +367,7 @@ class ImposingActiveStrain : public LocalDynamics
               active_strain_(encloser.dv_active_strain_->DelegatedData(ex_policy)),
               cx_(cx), cy_(cy), fish_length_(fish_length), bone_thickness_(bone_thickness) {}
 
-        void update(size_t index_i, Real dt = 0.0)
+        void compute(size_t index_i, Real dt = 0.0)
         {
             if (material_id_[index_i] == 0)
             {

--- a/tests/tests_sycl/2d_examples/test_2d_lid_driven_cavity_corrected_sycl/lid_driven_cavity_sycl.cpp
+++ b/tests/tests_sycl/2d_examples/test_2d_lid_driven_cavity_corrected_sycl/lid_driven_cavity_sycl.cpp
@@ -231,12 +231,12 @@ int main(int ac, char *av[])
     //----------------------------------------------------------------------
     SingleVariable<Real> *sv_physical_time = sph_system.getSystemVariableByName<Real>("PhysicalTime");
     wall_boundary_normal_direction.exec(); // run particle dynamics on CPU first
+    solid_initial_condition.exec(); // run particle dynamics on CPU first
     water_cell_linked_list.exec();
     wall_cell_linked_list.exec();
     water_block_update_complex_relation.exec();
     horizontal_observer_contact_relation.exec();
     vertical_observer_contact_relation.exec();
-    solid_initial_condition.exec();
     fluid_linear_correction_matrix.exec();
     //----------------------------------------------------------------------
     //	Setup for time-stepping control

--- a/tests/tests_sycl/3d_examples/test_3d_repose_angle_sycl/repose_angle_sycl.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_repose_angle_sycl/repose_angle_sycl.cpp
@@ -65,7 +65,7 @@ class SoilInitialConditionCK : public continuum_dynamics::ContinuumInitialCondit
         template <class ExecutionPolicy, class EncloserType>
         UpdateKernel(const ExecutionPolicy &ex_policy, EncloserType &encloser)
             : ContinuumInitialConditionCK::UpdateKernel(ex_policy, encloser){};
-        void update(UnsignedInt index_i, Real dt = 0.0)
+        void compute(UnsignedInt index_i, Real dt = 0.0)
         {
             /** initial stress */
             Real y = pos_[index_i][1];

--- a/tests/tests_sycl/3d_examples/test_3d_t_shape_pipe_sycl/test_3d_t_shape_pipe_sycl.cpp
+++ b/tests/tests_sycl/3d_examples/test_3d_t_shape_pipe_sycl/test_3d_t_shape_pipe_sycl.cpp
@@ -110,7 +110,7 @@ class ResetBufferCorrectionMatrixCK : public BaseLocalDynamics<OrientedBoxByCell
               pos_(encloser.dv_pos_->DelegatedData(ex_policy)),
               B_(encloser.dv_B_->DelegatedData(ex_policy)),
               radius_(encloser.radius_) {}
-        void update(size_t index_i, Real dt = 0.0)
+        void compute(size_t index_i, Real dt = 0.0)
         {
             if (oriented_box_->checkLowerBound(pos_[index_i], -radius_))
                 B_[index_i] = Matd::Identity();

--- a/tests/tests_sycl/unit_test_src/shared/particle_dynamics/configuration_dynamics/test_exclusive_scan_sycl/test_exclusive_scan.cpp
+++ b/tests/tests_sycl/unit_test_src/shared/particle_dynamics/configuration_dynamics/test_exclusive_scan_sycl/test_exclusive_scan.cpp
@@ -22,7 +22,7 @@ TEST(exclusive_scan, test_sycl)
     UnsignedInt *device_list_data = allocateDeviceOnly<UnsignedInt>(list_size);
     UnsignedInt *device_result = allocateDeviceOnly<UnsignedInt>(list_size);
     copyToDevice(list_data, device_list_data, list_size);
-    UnsignedInt sycl_sum = exclusive_scan(ParallelDevicePolicy{}, device_list_data, device_result, list_size, PlusUnsignedInt<ParallelDevicePolicy>::type());
+    UnsignedInt sycl_sum = exclusive_scan(SYCLDevicePolicy{}, device_list_data, device_result, list_size, PlusUnsignedInt<SYCLDevicePolicy>::type());
     copyFromDevice(sycl_result.data(), device_result, list_size);
 
     freeDeviceData(device_list_data);

--- a/tests/tests_sycl/unit_test_src/shared/particle_dynamics/test_particle_reduce_sycl/test_particle_reduce.cpp
+++ b/tests/tests_sycl/unit_test_src/shared/particle_dynamics/test_particle_reduce_sycl/test_particle_reduce.cpp
@@ -55,10 +55,10 @@ TEST(particle_reduce, test_sycl)
             return SimTK::SpatialVec(a, force_ck[i]);
         });
 
-    SimTKVec3 *torque_sycl = dv_torque.DelegatedData(ParallelDevicePolicy{});
-    SimTKVec3 *force_sycl = dv_force.DelegatedData(ParallelDevicePolicy{});
+    SimTKVec3 *torque_sycl = dv_torque.DelegatedData(SYCLDevicePolicy{});
+    SimTKVec3 *force_sycl = dv_force.DelegatedData(SYCLDevicePolicy{});
     SimTK::SpatialVec sum_sycl = particle_reduce<ReduceSum<SimTK::SpatialVec>>(
-        LoopRangeCK<ParallelDevicePolicy, SPHBody>(&sv_total_particles),
+        LoopRangeCK<SYCLDevicePolicy, SPHBody>(&sv_total_particles),
         ReduceReference<ReduceSum<SimTK::SpatialVec>>::value,
         [=](size_t i)
         {

--- a/tests/tests_sycl/unit_test_src/shared/particle_dynamics/test_particle_reduce_sycl/test_particle_reduce.cpp
+++ b/tests/tests_sycl/unit_test_src/shared/particle_dynamics/test_particle_reduce_sycl/test_particle_reduce.cpp
@@ -24,13 +24,14 @@ TEST(particle_reduce, test_sycl)
                               rand_uniform(-1.0, 1.0));
     }
 
-    SimTK::SpatialVec sum = particle_reduce(SequencedPolicy{}, IndexRange(0, torques.size()),
-                                            ZeroData<SimTK::SpatialVec>::value, ReduceSum<SimTK::SpatialVec>(),
-                                            [&](size_t i)
-                                            {
-                                                SimTKVec3 a = SimTK::cross(torques[i], forces[i]);
-                                                return SimTK::SpatialVec(a, forces[i]);
-                                            });
+    SimTK::SpatialVec sum = particle_reduce(
+        SequencedPolicy{}, IndexRange(0, torques.size()),
+        ZeroData<SimTK::SpatialVec>::value, ReduceSum<SimTK::SpatialVec>(),
+        [&](size_t i)
+        {
+            SimTKVec3 a = SimTK::cross(torques[i], forces[i]);
+            return SimTK::SpatialVec(a, forces[i]);
+        });
 
     DiscreteVariable<SimTKVec3> dv_torque("Torque", torques.size());
     DiscreteVariable<SimTKVec3> dv_force("Force", forces.size());
@@ -47,7 +48,7 @@ TEST(particle_reduce, test_sycl)
     SimTKVec3 *torque_ck = dv_torque.DelegatedData(ParallelPolicy{});
     SimTKVec3 *force_ck = dv_force.DelegatedData(ParallelPolicy{});
     SimTK::SpatialVec sum_ck = particle_reduce<ReduceSum<SimTK::SpatialVec>>(
-        LoopRangeCK<ParallelPolicy, SPHBody>(&sv_total_particles),
+        ParallelPolicy{}, IndexRange(0, dv_torque.getSize()),
         ReduceReference<ReduceSum<SimTK::SpatialVec>>::value,
         [=](size_t i)
         {
@@ -58,7 +59,7 @@ TEST(particle_reduce, test_sycl)
     SimTKVec3 *torque_sycl = dv_torque.DelegatedData(SYCLDevicePolicy{});
     SimTKVec3 *force_sycl = dv_force.DelegatedData(SYCLDevicePolicy{});
     SimTK::SpatialVec sum_sycl = particle_reduce<ReduceSum<SimTK::SpatialVec>>(
-        LoopRangeCK<SYCLDevicePolicy, SPHBody>(&sv_total_particles),
+        SYCLDevicePolicy{}, IndexRange(0, dv_torque.getSize()),
         ReduceReference<ReduceSum<SimTK::SpatialVec>>::value,
         [=](size_t i)
         {


### PR DESCRIPTION
This pull request refactors the device execution policy system to use a new `SYCLDevicePolicy` class in place of the previous `DeviceExecution<PolicyType>` template and its associated typedefs. Additionally, it standardizes function parameter naming for execution policies and renames certain methods for clarity. The changes improve code clarity and maintainability, especially for SYCL-based device execution.

**Device execution policy refactor:**

* Introduced the `SYCLDevicePolicy` class to replace the `DeviceExecution<PolicyType>` template and removed related typedefs such as `ParallelDevicePolicy` and `SequencedDevicePolicy`. All device execution code now uses `SYCLDevicePolicy` directly. (`src/shared/particle_dynamics/execution/execution_policy.h`)
* Updated all function signatures and class methods that previously accepted `DeviceExecution<PolicyType>` or device policy typedefs to instead use `SYCLDevicePolicy`. This includes constructors, delegated data accessors, and kernel management functions. [[1]](diffhunk://#diff-626afb5c87620384b2b0db239c529ef4925994c70f74191dee1a9d01a4a38da6L86-R92) [[2]](diffhunk://#diff-626afb5c87620384b2b0db239c529ef4925994c70f74191dee1a9d01a4a38da6L111-R111) [[3]](diffhunk://#diff-626afb5c87620384b2b0db239c529ef4925994c70f74191dee1a9d01a4a38da6L143-R143) [[4]](diffhunk://#diff-626afb5c87620384b2b0db239c529ef4925994c70f74191dee1a9d01a4a38da6L168-R166) [[5]](diffhunk://#diff-f13847e73cef33d9c9f381e692f69aa72993c8e5b77709c1a1fc098cfcbbc587L156-R156) [[6]](diffhunk://#diff-f13847e73cef33d9c9f381e692f69aa72993c8e5b77709c1a1fc098cfcbbc587L286-R285) [[7]](diffhunk://#diff-2ee8328598207abab08b86f9b674c26d4164672ba9716f8a46bc26526837882bL63-R63) [[8]](diffhunk://#diff-2ee8328598207abab08b86f9b674c26d4164672ba9716f8a46bc26526837882bL103-R104) [[9]](diffhunk://#diff-0bdf796ceaaa19ca30779d4ba8f087ca8f65620603abd7e61cfdffc7d597aa9cL76-R90)

**Standardization of function parameter names:**

* Replaced parameter names like `par_host` and `par_device` with the more generic `ex_policy` or `sycl_device` in all parallel and device execution functions for consistency. [[1]](diffhunk://#diff-7ecb06cce8571e4ae18ef35d875d66016ed3aad4be6b46a5dff962e07d5a6ddfL290-R290) [[2]](diffhunk://#diff-a7de0f90381a90e37e4a4d792300b6819c68a68b7487b6aca488dccc1d81864eL70-R70) [[3]](diffhunk://#diff-a7de0f90381a90e37e4a4d792300b6819c68a68b7487b6aca488dccc1d81864eL85-R85) [[4]](diffhunk://#diff-a7de0f90381a90e37e4a4d792300b6819c68a68b7487b6aca488dccc1d81864eL97-R97) [[5]](diffhunk://#diff-33ae062ca63edfec2462b6d477b1fdaa8ced55c070fd0e435706ba767bb0cab9L69-R69) [[6]](diffhunk://#diff-33ae062ca63edfec2462b6d477b1fdaa8ced55c070fd0e435706ba767bb0cab9L96-R96) [[7]](diffhunk://#diff-33ae062ca63edfec2462b6d477b1fdaa8ced55c070fd0e435706ba767bb0cab9L128-R128) [[8]](diffhunk://#diff-33ae062ca63edfec2462b6d477b1fdaa8ced55c070fd0e435706ba767bb0cab9L158-R158) [[9]](diffhunk://#diff-33ae062ca63edfec2462b6d477b1fdaa8ced55c070fd0e435706ba767bb0cab9L199-R199) [[10]](diffhunk://#diff-33ae062ca63edfec2462b6d477b1fdaa8ced55c070fd0e435706ba767bb0cab9L233-R233) [[11]](diffhunk://#diff-33ae062ca63edfec2462b6d477b1fdaa8ced55c070fd0e435706ba767bb0cab9L275-R275) [[12]](diffhunk://#diff-f13847e73cef33d9c9f381e692f69aa72993c8e5b77709c1a1fc098cfcbbc587L343-R341) [[13]](diffhunk://#diff-f13847e73cef33d9c9f381e692f69aa72993c8e5b77709c1a1fc098cfcbbc587L353-R355)

**Method renaming for clarity:**

* Renamed methods such as `update` to `compute` in functor classes for better semantic clarity, and updated all call sites accordingly. [[1]](diffhunk://#diff-eaf9069406bcd48c0345ea766059e1432f324105a0d5008c5c3d5f71709ac2cdL73-R73) [[2]](diffhunk://#diff-8e17328079f4b1f3e610c9b0a00d9b5a09c94de941b27773c276ed0174ee420dL102-R102) [[3]](diffhunk://#diff-8e17328079f4b1f3e610c9b0a00d9b5a09c94de941b27773c276ed0174ee420dL117-R117) [[4]](diffhunk://#diff-f4f68b4df9c533c9a9db9c72fddaf4e18d3c66cdc910712890293a23972a52c7L50-R50)

These changes collectively modernize and clarify the execution policy interface, especially for SYCL-based device execution, and improve overall code readability and maintainability.