### PR TITLE
identify variable to write and particle attributes to write due to sp…

### DIFF
--- a/src/for_3D_build/io_system/io_vtk_mesh_3d.hpp
+++ b/src/for_3D_build/io_system/io_vtk_mesh_3d.hpp
@@ -9,7 +9,7 @@ namespace SPH
 template <typename OutStreamType>
 void BodyStatesRecordingToTriangleMeshVtp::writeCellsToVtk(OutStreamType &output_stream, BaseParticles &particles)
 {
-    DiscreteVariables &variables_to_write = particles.VariablesToWrite();
+    DiscreteVariables &variables_to_write = particles.ParticleAttributesToWrite();
 
     // write scalars
     constexpr int type_index_Real = DataTypeIndex<Real>::value;

--- a/src/shared/io_system/io_plt.cpp
+++ b/src/shared/io_system/io_plt.cpp
@@ -103,7 +103,7 @@ void BodyStatesRecordingToPlt::writeWithFileName(const std::string &sequence)
     for (SPHBody *body : bodies_)
     {
         BaseParticles &particles = body->getBaseParticles();
-        DiscreteVariables &variables_to_write = particles.VariablesToWrite();
+        DiscreteVariables &variables_to_write = particles.ParticleAttributesToWrite();
         if (body->checkNewlyUpdated())
         {
             if (state_recording_)

--- a/src/shared/io_system/io_vtk.cpp
+++ b/src/shared/io_system/io_vtk.cpp
@@ -72,7 +72,7 @@ void BodyStatesRecordingToVtp::writeWithFileName(const std::string &sequence)
 void BodyStatesRecordingToVtp::addParticlesToVtkPolyData(vtkPolyData *polydata, BaseParticles &particles)
 {
     size_t total_real_particles = particles.TotalRealParticles();
-    DiscreteVariables &variables_to_write = particles.VariablesToWrite();
+    DiscreteVariables &variables_to_write = particles.ParticleAttributesToWrite();
 
     // Write sorted particle IDs
     vtkNew<vtkIntArray> sorted_id_array;

--- a/src/shared/io_system/io_vtk.hpp
+++ b/src/shared/io_system/io_vtk.hpp
@@ -13,7 +13,7 @@ template <typename OutStreamType>
 void BodyStatesRecordingToVtp::writeParticlesToVtk(OutStreamType &output_stream, BaseParticles &particles)
 {
     size_t total_real_particles = particles.TotalRealParticles();
-    DiscreteVariables &variables_to_write = particles.VariablesToWrite();
+    DiscreteVariables &variables_to_write = particles.ParticleAttributesToWrite();
 
     // write sorted particles ID
     output_stream

--- a/src/shared/particles/base_particles.cpp
+++ b/src/shared/particles/base_particles.cpp
@@ -61,6 +61,7 @@ void BaseParticles::initializeBasicDiscreteVariables()
 {
     addEvolvingVariable<Vecd>("Position");
     addEvolvingVariable<Real>("VolumetricMeasure");
+    addDiscreteVariableToList<Vecd>(variables_to_write_, "Position");
     original_id_ = registerDiscreteVariableData<UnsignedInt>("OriginalID", particles_bound_, AssignIndex());
     addEvolvingVariable<UnsignedInt>("OriginalID");
     addVariableToWrite<UnsignedInt>("OriginalID");

--- a/src/shared/particles/base_particles.h
+++ b/src/shared/particles/base_particles.h
@@ -157,6 +157,7 @@ class BaseParticles
   public:
     DiscreteVariables &VariablesToWrite() { return variables_to_write_; };
     DiscreteVariables &EvolvingVariables() { return evolving_variables_; };
+    DiscreteVariables &ParticleAttributesToWrite() { return particle_attributes_to_write_; };
     StdVec<std::string> &ParticleGroupsToWrite() { return particle_groups_to_write_; };
     void addParticleGroupToWrite(const std::string &name);
     template <typename DataType, typename... Args>
@@ -187,7 +188,8 @@ class BaseParticles
     XmlParser &reload_xml_parser_;
     DiscreteVariables all_discrete_variables_;
     SingleVariables all_singular_variables_;
-    DiscreteVariables variables_to_write_;
+    DiscreteVariables variables_to_write_; // position is included
+    DiscreteVariables particle_attributes_to_write_; // position is excluded
     StdVec<std::string> particle_groups_to_write_;
 
   protected:

--- a/src/shared/particles/base_particles.hpp
+++ b/src/shared/particles/base_particles.hpp
@@ -157,6 +157,7 @@ template <typename DataType, typename... Args>
 void BaseParticles::addVariableToWrite(Args &&...args)
 {
     addDiscreteVariableToList<DataType>(variables_to_write_, std::forward<Args>(args)...);
+    addDiscreteVariableToList<DataType>(particle_attributes_to_write_, std::forward<Args>(args)...);
 }
 //===============================================================================
 template <typename DataType>

--- a/src/shared/shared_ck/io_system/io_base_ck.hpp
+++ b/src/shared/shared_ck/io_system/io_base_ck.hpp
@@ -16,7 +16,6 @@ void BodyStatesRecordingToVtpCK<ExecutionPolicy>::prepareToWrite()
         if (bodies_[i]->checkNewlyUpdated())
         {
             BaseParticles &base_particles = bodies_[i]->getBaseParticles();
-            base_particles.dvParticlePosition()->prepareForOutput(ExecutionPolicy{});
             prepare_variable_to_write_(base_particles.VariablesToWrite(), ExecutionPolicy{});
         }
     }

--- a/src/shared/shared_ck/io_system/io_vtk_mesh_ck.h
+++ b/src/shared/shared_ck/io_system/io_vtk_mesh_ck.h
@@ -52,7 +52,6 @@ class BodyStatesRecordingToTriangleMeshVtpCK : public BodyStatesRecordingToTrian
                 if (bodies_[i]->checkNewlyUpdated())
                 {
                     BaseParticles &base_particles = bodies_[i]->getBaseParticles();
-                    base_particles.dvParticlePosition()->prepareForOutput(ExecutionPolicy{});
                     prepare_variable_to_write_(base_particles.VariablesToWrite(), ExecutionPolicy{});
                 }
             }


### PR DESCRIPTION
This pull request refactors how particle attributes are selected for output in various I/O modules. The main change is the introduction of a new method, `ParticleAttributesToWrite()`, which provides a list of particle attributes excluding the position variable, distinguishing it from the existing `VariablesToWrite()`. This update is propagated across several I/O routines to ensure that only the intended attributes are written. Additionally, the initialization and management of these variable lists in `BaseParticles` have been updated for clarity and correctness.

**I/O System Refactoring:**

* Updated all relevant I/O routines (`io_vtk_mesh_3d.hpp`, `io_plt.cpp`, `io_vtk.cpp`, `io_vtk.hpp`) to use `ParticleAttributesToWrite()` instead of `VariablesToWrite()`, ensuring position is excluded from attribute output. [[1]](diffhunk://#diff-856e271db334c492dd529e6502c4fd25a47d46ebdde5ab605f65d24bd1963071L12-R12) [[2]](diffhunk://#diff-156abdf87c92071d8f4fc853da3bb24c4645ba597ac9b676ea4b1aa6891da47bL106-R106) [[3]](diffhunk://#diff-6da3014fc40dce401cc0e1e3a069e441075e32c4a67a99ea0a4a00fdd406fd69L75-R75) [[4]](diffhunk://#diff-c334bc402a48c3a48a5a3436c5e17a9113b4979b1b8b7d806a044cd4398ec474L16-R16)

**BaseParticles Class Enhancements:**

* Added a new method `ParticleAttributesToWrite()` to `BaseParticles`, and introduced a new member variable `particle_attributes_to_write_` to separately track particle attributes (excluding position) to write. [[1]](diffhunk://#diff-429fe4c2d7d343634cb6b8f381e45b91cecbd79fa65b86c343c0b0318c70606eR160) [[2]](diffhunk://#diff-429fe4c2d7d343634cb6b8f381e45b91cecbd79fa65b86c343c0b0318c70606eL190-R192)
* Modified `addVariableToWrite` to add variables to both `variables_to_write_` and `particle_attributes_to_write_`, ensuring consistent tracking.
* In `initializeBasicDiscreteVariables`, explicitly adds "Position" to `variables_to_write_` to clarify its inclusion.

**Code Cleanup:**

* Removed redundant calls to prepare the particle position for output in checkpointing routines, relying on the new variable selection logic. [[1]](diffhunk://#diff-e2526b55b1a6ecbb4ca057c1c115682728579ac09798a1245124ee22ff5d2c99L19) [[2]](diffhunk://#diff-750dc9dd5b776fb024abded1689e7b886b40a0ca118d1d0e8037ea1bca46bffaL55)